### PR TITLE
Remove IdentifyPath from MetadataBackend interface

### DIFF
--- a/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
@@ -27,11 +27,9 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/renameio/v2"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/cache"
-	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/pkg/xattr"
 	"github.com/rogpeppe/go-internal/lockedfile"
 	"github.com/shamaton/msgpack/v2"
@@ -60,36 +58,6 @@ func NewMessagePackBackend(rootPath string, o cache.Config) MessagePackBackend {
 
 // Name returns the name of the backend
 func (MessagePackBackend) Name() string { return "messagepack" }
-
-// IdentifyPath returns the id and mtime of a file
-func (b MessagePackBackend) IdentifyPath(_ context.Context, path string) (string, string, time.Time, error) {
-	metaPath := filepath.Join(path + ".mpk")
-	source, err := os.Open(metaPath)
-	// // No cached entry found. Read from storage and store in cache
-	if err != nil {
-		return "", "", time.Time{}, err
-	}
-	msgBytes, err := io.ReadAll(source)
-	if err != nil || len(msgBytes) == 0 {
-		return "", "", time.Time{}, err
-
-	}
-	attribs := map[string][]byte{}
-	err = msgpack.Unmarshal(msgBytes, &attribs)
-	if err != nil {
-		return "", "", time.Time{}, err
-	}
-
-	spaceID := attribs[prefixes.IDAttr]
-	id := attribs[prefixes.IDAttr]
-
-	mtimeAttr := attribs[prefixes.MTimeAttr]
-	mtime, err := time.Parse(time.RFC3339Nano, string(mtimeAttr))
-	if err != nil {
-		return "", "", time.Time{}, err
-	}
-	return string(spaceID), string(id), mtime, nil
-}
 
 // All reads all extended attributes for a node
 func (b MessagePackBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -47,7 +46,6 @@ type MetadataNode interface {
 // Backend defines the interface for file attribute backends
 type Backend interface {
 	Name() string
-	IdentifyPath(ctx context.Context, path string) (string, string, time.Time, error)
 
 	All(ctx context.Context, n MetadataNode) (map[string][]byte, error)
 	AllWithLockedSource(ctx context.Context, n MetadataNode, source io.Reader) (map[string][]byte, error)
@@ -73,11 +71,6 @@ type NullBackend struct{}
 
 // Name returns the name of the backend
 func (NullBackend) Name() string { return "null" }
-
-// IdentifyPath returns the ids and mtime of a file
-func (NullBackend) IdentifyPath(ctx context.Context, path string) (string, string, time.Time, error) {
-	return "", "", time.Time{}, errUnconfiguredError
-}
 
 // All reads all extended attributes for a node
 func (NullBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {

--- a/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/opencloud-eu/reva/v2/pkg/storage/cache"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
@@ -50,16 +49,6 @@ func NewXattrsBackend(rootPath string, o cache.Config) XattrsBackend {
 
 // Name returns the name of the backend
 func (XattrsBackend) Name() string { return "xattrs" }
-
-// IdentifyPath returns the space id, node id and mtime of a file
-func (b XattrsBackend) IdentifyPath(_ context.Context, path string) (string, string, time.Time, error) {
-	spaceID, _ := xattr.Get(path, prefixes.SpaceIDAttr)
-	id, _ := xattr.Get(path, prefixes.IDAttr)
-
-	mtimeAttr, _ := xattr.Get(path, prefixes.MTimeAttr)
-	mtime, _ := time.Parse(time.RFC3339Nano, string(mtimeAttr))
-	return string(spaceID), string(id), mtime, nil
-}
 
 // Get an extended attribute value for the given key
 // No file locking is involved here as reading a single xattr is


### PR DESCRIPTION
It is specific to posixfs only. Instead lookup file and spaceid directly via xattrs.