### PR TITLE
Add a hybrid metadatabackend

### DIFF
--- a/pkg/storage/fs/posix/options/options.go
+++ b/pkg/storage/fs/posix/options/options.go
@@ -54,6 +54,11 @@ func New(m map[string]interface{}) (*Options, error) {
 		return nil, err
 	}
 
+	// default to hybrid metadatabackend for posixfs
+	if _, ok := m["metadata_backend"]; !ok {
+		m["metadata_backend"] = "hybrid"
+	}
+
 	do, err := decomposedoptions.New(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -1,0 +1,440 @@
+package metadata
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/renameio/v2"
+	"github.com/pkg/errors"
+	"github.com/pkg/xattr"
+	"github.com/rogpeppe/go-internal/lockedfile"
+	"github.com/shamaton/msgpack/v2"
+
+	"github.com/opencloud-eu/reva/v2/pkg/storage/cache"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/filelocks"
+)
+
+var _grantsOffloadedAttr = prefixes.OcPrefix + "grants_offloaded"
+
+type MetadataPathFunc func(MetadataNode) string
+
+// HybridBackend stores the file attributes in extended attributes
+type HybridBackend struct {
+	offloadLimit     int
+	metaCache        cache.FileMetadataCache
+	metadataPathFunc MetadataPathFunc
+}
+
+// NewMessageBackend returns a new HybridBackend instance
+func NewHybridBackend(offloadLimit int, metadataPathFunc MetadataPathFunc, o cache.Config) HybridBackend {
+	return HybridBackend{
+		offloadLimit:     offloadLimit,
+		metaCache:        cache.GetFileMetadataCache(o),
+		metadataPathFunc: metadataPathFunc,
+	}
+}
+
+// Name returns the name of the backend
+func (HybridBackend) Name() string { return "hybrid" }
+
+// IdentifyPath returns the space id, node id and mtime of a file
+func (b HybridBackend) IdentifyPath(_ context.Context, path string) (string, string, time.Time, error) {
+	spaceID, _ := xattr.Get(path, prefixes.SpaceIDAttr)
+	id, _ := xattr.Get(path, prefixes.IDAttr)
+
+	mtimeAttr, _ := xattr.Get(path, prefixes.MTimeAttr)
+	mtime, _ := time.Parse(time.RFC3339Nano, string(mtimeAttr))
+	return string(spaceID), string(id), mtime, nil
+}
+
+// Get an extended attribute value for the given key
+// No file locking is involved here as reading a single xattr is
+// considered to be atomic.
+func (b HybridBackend) Get(ctx context.Context, n MetadataNode, key string) ([]byte, error) {
+	attribs := map[string][]byte{}
+	err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
+	if err == nil && len(attribs[key]) > 0 {
+		return attribs[key], err
+	}
+
+	if isGrantAttribute(key) {
+		// check if grants are offloaded
+		offloaded, err := xattr.Get(n.InternalPath(), _grantsOffloadedAttr)
+		if err == nil && string(offloaded) == "1" {
+			msgpackAttribs := map[string][]byte{}
+			msgBytes, err := os.ReadFile(b.MetadataPath(n))
+			if err != nil {
+				return nil, err
+			}
+			err = msgpack.Unmarshal(msgBytes, &msgpackAttribs)
+			if err != nil {
+				return nil, err
+			}
+			return msgpackAttribs[key], nil
+		}
+	}
+	return xattr.Get(n.InternalPath(), key)
+}
+
+// GetInt64 reads a string as int64 from the xattrs
+func (b HybridBackend) GetInt64(ctx context.Context, n MetadataNode, key string) (int64, error) {
+	attr, err := b.Get(ctx, n, key)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseInt(string(attr), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// List retrieves a list of names of extended attributes associated with the
+// given path in the file system.
+func (b HybridBackend) List(ctx context.Context, n MetadataNode) (attribs []string, err error) {
+	return b.list(ctx, n, true)
+}
+
+func (b HybridBackend) list(ctx context.Context, n MetadataNode, acquireLock bool) (attribs []string, err error) {
+	filePath := n.InternalPath()
+	attrs, err := xattr.List(filePath)
+	if err == nil {
+		return attrs, nil
+	}
+
+	// listing xattrs failed, try again, either with lock or without
+	if acquireLock {
+		f, err := lockedfile.OpenFile(filePath+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return nil, err
+		}
+		defer cleanupLockfile(ctx, f)
+
+	}
+	return xattr.List(filePath)
+}
+
+// All reads all extended attributes for a node, protected by a
+// shared file lock
+func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
+	return b.getAll(ctx, n, false, false, true)
+}
+
+func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipCache, skipOffloaded, acquireLock bool) (map[string][]byte, error) {
+	attribs := map[string][]byte{}
+
+	if !skipCache {
+		err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
+		if err == nil {
+			return attribs, err
+		}
+	}
+
+	attrNames, err := b.list(ctx, n, acquireLock)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(attrNames) == 0 {
+		return attribs, nil
+	}
+
+	var (
+		xerrs = 0
+		xerr  error
+	)
+	// error handling: Count if there are errors while reading all attribs.
+	// if there were any, return an error.
+	attribs = make(map[string][]byte, len(attrNames))
+	path := n.InternalPath()
+	for _, name := range attrNames {
+		var val []byte
+		if val, xerr = xattr.Get(path, name); xerr != nil && !IsAttrUnset(xerr) {
+			xerrs++
+		} else {
+			attribs[name] = val
+		}
+	}
+
+	if xerrs > 0 {
+		return nil, errors.Wrap(xerr, "Failed to read all xattrs")
+	}
+
+	// merge the attributes from the offload file
+	offloaded, err := xattr.Get(path, _grantsOffloadedAttr)
+	if skipOffloaded == false && err == nil && string(offloaded) == "1" {
+		msgpackAttribs := map[string][]byte{}
+		msgBytes, err := os.ReadFile(b.MetadataPath(n))
+		if err != nil {
+			return nil, err
+		}
+		err = msgpack.Unmarshal(msgBytes, &msgpackAttribs)
+		if err != nil {
+			return nil, err
+		}
+		for key, val := range msgpackAttribs {
+			attribs[key] = val
+		}
+	}
+
+	err = b.metaCache.PushToCache(b.cacheKey(n), attribs)
+	if err != nil {
+		return nil, err
+	}
+
+	return attribs, nil
+}
+
+// Set sets one attribute for the given path
+func (b HybridBackend) Set(ctx context.Context, n MetadataNode, key string, val []byte) (err error) {
+	return b.SetMultiple(ctx, n, map[string][]byte{key: val}, true)
+}
+
+// SetMultiple sets a set of attribute for the given path
+func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) (err error) {
+	path := n.InternalPath()
+	if acquireLock {
+		err := os.MkdirAll(filepath.Dir(path), 0600)
+		if err != nil {
+			return err
+		}
+		lockedFile, err := lockedfile.OpenFile(b.LockfilePath(n), os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer cleanupLockfile(ctx, lockedFile)
+	}
+
+	offloaded, err := xattr.Get(path, _grantsOffloadedAttr)
+	if err == nil && string(offloaded) == "1" {
+		// already offloaded -> write to messagepack
+		metaPath := b.MetadataPath(n)
+		var msgBytes []byte
+		msgBytes, err = os.ReadFile(metaPath)
+
+		attribs := map[string][]byte{}
+		switch {
+		case err != nil:
+			if !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
+		default:
+			err = msgpack.Unmarshal(msgBytes, &attribs)
+			if err != nil {
+				return err
+			}
+		}
+
+		// prepare metadata
+		for key, val := range attribs {
+			attribs[key] = val
+		}
+		var d []byte
+		d, err = msgpack.Marshal(attribs)
+		if err != nil {
+			return err
+		}
+
+		// overwrite file atomically
+		err = renameio.WriteFile(metaPath, d, 0600)
+		if err != nil {
+			return err
+		}
+	} else {
+		xerrs := 0
+		var xerr error
+		// error handling: Count if there are errors while setting the attribs.
+		// if there were any, return an error.
+		for key, val := range attribs {
+			if xerr = xattr.Set(path, key, val); xerr != nil {
+				// log
+				xerrs++
+			}
+		}
+		if xerrs > 0 {
+			return errors.Wrap(xerr, "Failed to set all xattrs")
+		}
+	}
+
+	attribs, err = b.getAll(ctx, n, true, false, false)
+	if err != nil {
+		return err
+	}
+	err = b.metaCache.PushToCache(b.cacheKey(n), attribs)
+	if err != nil {
+		return err
+	}
+
+	// offload if the grant size exceeds the limit
+	grantSize := 0
+	for key := range attribs {
+		if isGrantAttribute(key) {
+			grantSize += len(attribs[key]) + len(key)
+		}
+	}
+	if grantSize > b.offloadLimit && string(offloaded) != "1" {
+		return b.offloadMetadata(ctx, n)
+	}
+
+	return nil
+}
+
+func (b HybridBackend) offloadMetadata(ctx context.Context, n MetadataNode) error {
+	path := n.InternalPath()
+	msgpackAttribs := map[string][]byte{}
+	xerrs := 0
+	var xerr error
+
+	// collect attributes to move
+	existingAttribs, err := b.getAll(ctx, n, true, true, false)
+	if err != nil {
+		return err
+	}
+	for key, val := range existingAttribs {
+		if isGrantAttribute(key) {
+			msgpackAttribs[key] = val
+			xerr = xattr.Remove(path, key)
+			if err != nil {
+				xerrs++
+			}
+		}
+	}
+
+	var d []byte
+	d, err = msgpack.Marshal(msgpackAttribs)
+	if err != nil {
+		return err
+	}
+	err = renameio.WriteFile(b.MetadataPath(n), d, 0600)
+	if err != nil {
+		return err
+	}
+
+	// set the grants offloaded attribute
+	err = xattr.Set(path, _grantsOffloadedAttr, []byte("1"))
+	if err != nil {
+		return err
+	}
+	// remove grants from xattrs
+	for key, val := range existingAttribs {
+		if isGrantAttribute(key) {
+			msgpackAttribs[key] = val
+			xerr = xattr.Remove(path, key)
+			if err != nil {
+				xerrs++
+			}
+		}
+	}
+	if xerrs > 0 {
+		return errors.Wrap(xerr, "Failed to remove xattrs while offloading")
+	}
+
+	return nil
+}
+
+// Remove an extended attribute key
+func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error {
+	path := n.InternalPath()
+	if acquireLock {
+		lockedFile, err := lockedfile.OpenFile(path+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer cleanupLockfile(ctx, lockedFile)
+	}
+
+	err := xattr.Remove(path, key)
+	if err != nil {
+		return err
+	}
+	attribs, err := b.getAll(ctx, n, true, false, false)
+	if err != nil {
+		return err
+	}
+	return b.metaCache.PushToCache(b.cacheKey(n), attribs)
+}
+
+// IsMetaFile returns whether the given path represents a meta file
+func (HybridBackend) IsMetaFile(path string) bool { return strings.HasSuffix(path, ".meta.lock") }
+
+// Purge purges the data of a given path
+func (b HybridBackend) Purge(ctx context.Context, n MetadataNode) error {
+	path := n.InternalPath()
+	_, err := os.Stat(path)
+	if err == nil {
+		attribs, err := b.getAll(ctx, n, true, false, true)
+		if err != nil {
+			return err
+		}
+
+		for attr := range attribs {
+			if strings.HasPrefix(attr, prefixes.OcPrefix) {
+				err := xattr.Remove(path, attr)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return b.metaCache.RemoveMetadata(b.cacheKey(n))
+}
+
+// Rename moves the data for a given path to a new path
+func (b HybridBackend) Rename(oldNode, newNode MetadataNode) error {
+	data := map[string][]byte{}
+	err := b.metaCache.PullFromCache(b.cacheKey(oldNode), &data)
+	if err == nil {
+		err = b.metaCache.PushToCache(b.cacheKey(newNode), data)
+		if err != nil {
+			return err
+		}
+	}
+	return b.metaCache.RemoveMetadata(b.cacheKey(oldNode))
+}
+
+// MetadataPath returns the path of the file holding the metadata for the given path
+func (b HybridBackend) MetadataPath(n MetadataNode) string { return b.metadataPathFunc(n) }
+
+// LockfilePath returns the path of the lock file
+func (HybridBackend) LockfilePath(n MetadataNode) string { return n.InternalPath() + ".mlock" }
+
+// Lock locks the metadata for the given path
+func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
+	metaLockPath := b.LockfilePath(n)
+	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		err := mlock.Close()
+		if err != nil {
+			return err
+		}
+		return os.Remove(metaLockPath)
+	}, nil
+}
+
+// AllWithLockedSource reads all extended attributes from the given reader.
+// The path argument is used for storing the data in the cache
+func (b HybridBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {
+	return b.All(ctx, n)
+}
+
+func (b HybridBackend) cacheKey(n MetadataNode) string {
+	// rootPath is guaranteed to have no trailing slash
+	// the cache key shouldn't begin with a slash as some stores drop it which can cause
+	// confusion
+	return n.GetSpaceID() + "/" + n.GetID()
+}
+
+func isGrantAttribute(key string) bool {
+	return strings.HasPrefix(key, prefixes.GrantPrefix)
+}

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -80,7 +80,7 @@ func (b HybridBackend) Get(ctx context.Context, n MetadataNode, key string) ([]b
 			if val, ok := msgpackAttribs[key]; ok {
 				return val, nil
 			} else {
-				return nil, xattr.ENOATTR // attribute not found
+				return nil, &xattr.Error{Op: "HybridBackend.Get", Path: n.InternalPath(), Err: xattr.ENOATTR} // attribute not found
 			}
 		}
 	}

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -96,12 +96,6 @@ func (b HybridBackend) GetInt64(ctx context.Context, n MetadataNode, key string)
 	return v, nil
 }
 
-// List retrieves a list of names of extended attributes associated with the
-// given path in the file system.
-func (b HybridBackend) List(ctx context.Context, n MetadataNode) (attribs []string, err error) {
-	return b.list(ctx, n, true)
-}
-
 func (b HybridBackend) list(ctx context.Context, n MetadataNode, acquireLock bool) (attribs []string, err error) {
 	filePath := n.InternalPath()
 	attrs, err := xattr.List(filePath)

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -397,7 +397,7 @@ func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, a
 				}
 			}
 			if _, ok := mpkAttribs[key]; !ok {
-				return xattr.ENOATTR // attribute not found
+				return &xattr.Error{Op: "HybridBackend.Remove", Path: n.InternalPath(), Err: xattr.ENOATTR} // attribute not found
 			}
 
 			// 2. remove attribute

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -421,7 +421,14 @@ func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, a
 				return err
 			}
 		}
+	} else {
+		// remove from xattrs
+		err := xattr.Remove(path, key)
+		if err != nil {
+			return err
+		}
 	}
+
 	attribs, err := b.getAll(ctx, n, true, false, false)
 	if err != nil {
 		return err

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -240,4 +240,55 @@ var _ = Describe("HybridBackend", func() {
 			})
 		})
 	})
+
+	Describe("Remove", func() {
+		It("removes non-offloaded metadata", func() {
+			err := backend.Set(context.Background(), n, nonOffloadingKey, nonOffloadingData)
+			Expect(err).ToNot(HaveOccurred())
+			readData, err := backend.Get(context.Background(), n, nonOffloadingKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(nonOffloadingData))
+
+			err = backend.Remove(context.Background(), n, nonOffloadingKey, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = backend.Get(context.Background(), n, nonOffloadingKey)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("removes offloaded metadata", func() {
+			err := backend.Set(context.Background(), n, keyBig, dataBig)
+			Expect(err).ToNot(HaveOccurred())
+			readData, err := backend.Get(context.Background(), n, keyBig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(dataBig))
+
+			err = backend.Remove(context.Background(), n, keyBig, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = backend.Get(context.Background(), n, keyBig)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("removes non-offloaded metadata in the offloading case", func() {
+			err := backend.SetMultiple(context.Background(), n, map[string][]byte{
+				keySmall:         dataSmall,
+				keyBig:           dataBig,
+				nonOffloadingKey: nonOffloadingData,
+			}, false)
+			Expect(err).ToNot(HaveOccurred())
+			readData, err := backend.Get(context.Background(), n, keyBig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(dataBig))
+			readData, err = backend.Get(context.Background(), n, nonOffloadingKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(nonOffloadingData))
+
+			err = backend.Remove(context.Background(), n, nonOffloadingKey, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = backend.Get(context.Background(), n, nonOffloadingKey)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -206,6 +206,12 @@ var _ = Describe("HybridBackend", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
+			It("returns ENOATTR if the requested non-offloading attribute does not exist", func() {
+				_, err := backend.Get(context.Background(), n, "user.oc.idonotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(err.(*xattr.Error).Err).To(Equal(xattr.ENOATTR))
+			})
+
 			It("reads the grants", func() {
 				readData, err := backend.Get(context.Background(), n, keySmall)
 				Expect(err).ToNot(HaveOccurred())
@@ -221,6 +227,12 @@ var _ = Describe("HybridBackend", func() {
 					nonOffloadingKey: nonOffloadingData,
 				}, false)
 				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("returns ENOATTR if the requested offloading attribute does not exist", func() {
+				_, err := backend.Get(context.Background(), n, "user.oc.md.idonotexist")
+				Expect(err).To(HaveOccurred())
+				Expect(err.(*xattr.Error).Err).To(Equal(xattr.ENOATTR))
 			})
 
 			It("reads offloaded metadata", func() {

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -1,0 +1,203 @@
+package metadata_test
+
+import (
+	"context"
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/cache"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
+	"github.com/pkg/xattr"
+	"github.com/shamaton/msgpack/v2"
+)
+
+var _ = Describe("HybridBackend", func() {
+	var (
+		tmpdir string
+		n      testNode
+
+		backend metadata.Backend
+
+		keySmall   = prefixes.GrantUserAcePrefix + "1"
+		dataSmall  = []byte("1")
+		keySmall2  = prefixes.GrantUserAcePrefix + "2"
+		dataSmall2 = []byte("2")
+		keyBig     = prefixes.GrantUserAcePrefix + "100"
+		dataBig    = []byte("fooooooothosearetoomanybytes")
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpdir, err = os.MkdirTemp(os.TempDir(), "HybridBackendTest-")
+		Expect(err).ToNot(HaveOccurred())
+
+		offloadLimit := len(prefixes.GrantUserAcePrefix) + 2
+		backend = metadata.NewHybridBackend(offloadLimit,
+			func(n metadata.MetadataNode) string {
+				return n.InternalPath() + ".mpk"
+			},
+			cache.Config{
+				Database: tmpdir,
+			})
+	})
+
+	JustBeforeEach(func() {
+		n = testNode{
+			spaceID: "123",
+			id:      "456",
+			path:    path.Join(tmpdir, "file"),
+		}
+		_, err := os.Create(n.InternalPath())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if tmpdir != "" {
+			os.RemoveAll(tmpdir)
+		}
+	})
+
+	Describe("Set", func() {
+		It("sets an attribute", func() {
+			data := []byte(`bar\`)
+			err := backend.Set(context.Background(), n, "user.foo", data)
+			Expect(err).ToNot(HaveOccurred())
+
+			readData, err := backend.Get(context.Background(), n, "user.foo")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(data))
+		})
+
+		It("doesn't offload grants if size is not exceeded", func() {
+			err := backend.Set(context.Background(), n, keySmall, dataSmall)
+			Expect(err).ToNot(HaveOccurred())
+
+			readData, err := xattr.Get(n.InternalPath(), keySmall)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(readData).To(Equal(dataSmall))
+
+			messagepackPath := backend.MetadataPath(n)
+			_, err = os.Stat(messagepackPath)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("offloads grants if size is exceeded", func() {
+			err := backend.Set(context.Background(), n, keyBig, dataBig)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("not adding the grant to the xattrs")
+			_, err = xattr.Get(n.InternalPath(), keyBig)
+			Expect(err).To(HaveOccurred())
+
+			By("adding the grant to the messagepack file")
+			messagepackPath := backend.MetadataPath(n)
+			_, err = os.Stat(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			msgBytes, err := os.ReadFile(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			attribs := map[string][]byte{}
+			err = msgpack.Unmarshal(msgBytes, &attribs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attribs[keyBig]).To(Equal(dataBig))
+		})
+
+		It("offloads when the written attribute is small but the total exceeds the size", func() {
+			err := backend.Set(context.Background(), n, keySmall, dataSmall)
+			Expect(err).ToNot(HaveOccurred())
+			err = backend.Set(context.Background(), n, keySmall2, dataSmall2)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("not adding the grant to the xattrs")
+			_, err = xattr.Get(n.InternalPath(), keySmall)
+			Expect(err).To(HaveOccurred())
+			_, err = xattr.Get(n.InternalPath(), keySmall2)
+			Expect(err).To(HaveOccurred())
+
+			By("adding the grant to the messagepack file")
+			messagepackPath := backend.MetadataPath(n)
+			_, err = os.Stat(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			msgBytes, err := os.ReadFile(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			attribs := map[string][]byte{}
+			err = msgpack.Unmarshal(msgBytes, &attribs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attribs[keySmall]).To(Equal(dataSmall))
+			Expect(attribs[keySmall2]).To(Equal(dataSmall2))
+		})
+
+		It("offloads existing grants when offloading", func() {
+			// The first grant will not trigger offloading
+			err := backend.Set(context.Background(), n, keySmall, dataSmall)
+			Expect(err).ToNot(HaveOccurred())
+			messagepackPath := backend.MetadataPath(n)
+			_, err = os.Stat(messagepackPath)
+			Expect(err).To(HaveOccurred())
+
+			By("triggering offloading")
+			err = backend.Set(context.Background(), n, keyBig, dataBig)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Removing all grants from the xattrs")
+			_, err = xattr.Get(n.InternalPath(), keySmall)
+			Expect(err).To(HaveOccurred())
+			_, err = xattr.Get(n.InternalPath(), keyBig)
+			Expect(err).To(HaveOccurred())
+
+			By("adding all grants to the messagepack file")
+			_, err = os.Stat(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			msgBytes, err := os.ReadFile(messagepackPath)
+			Expect(err).ToNot(HaveOccurred())
+
+			attribs := map[string][]byte{}
+			err = msgpack.Unmarshal(msgBytes, &attribs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(attribs[keySmall]).To(Equal(dataSmall))
+			Expect(attribs[keyBig]).To(Equal(dataBig))
+		})
+	})
+
+	Describe("Get", func() {
+		Context("with unoffloaded grants", func() {
+			JustBeforeEach(func() {
+				err := backend.Set(context.Background(), n, keySmall, dataSmall)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("reads the grants", func() {
+				readData, err := backend.Get(context.Background(), n, keySmall)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(readData).To(Equal(dataSmall))
+			})
+		})
+
+		Context("with offloaded grants", func() {
+			JustBeforeEach(func() {
+				err := backend.SetMultiple(context.Background(), n, map[string][]byte{
+					keySmall: dataSmall,
+					keyBig:   dataBig,
+				}, false)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("reads the grants", func() {
+				readData, err := backend.Get(context.Background(), n, keySmall)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(readData).To(Equal(dataSmall))
+
+				readData, err = backend.Get(context.Background(), n, keyBig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(readData).To(Equal(dataBig))
+			})
+		})
+	})
+})


### PR DESCRIPTION
The new backend persists id, spaceid and mtime in xattrs while keeping additional attributes in a messagepack file. This prevents running out of space in the xattrs of node while still keeping the identity information close to the files/dirs themselves.

Note: requires a small change in opencloud: https://github.com/opencloud-eu/opencloud/tree/hybrid-metadata-backend

Fixes opencloud-eu/opencloud#222