### PR TITLE
Fix integration tests after recent refactoring

### DIFF
--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -61,6 +61,7 @@ func createFS(provider string, revads map[string]*Revad) (storage.FS, error) {
 	case "decomposed":
 		conf["root"] = revads["storage"].StorageRoot
 		conf["permissionssvc"] = revads["permissions"].GrpcAddress
+		conf["filemetadatacache"] = map[string]string{"cache_store": "noop"}
 		f = decomposed.New
 	case "nextcloud":
 		conf["endpoint"] = "http://localhost:8080/apps/sciencemesh/"


### PR DESCRIPTION
Force the use of the "noop" cache. The default "memory" is shared between the testcases and causes failures, after the metadata cache's key changed from paths.