### PR TITLE
Use the correct folder for trash on decomposed fs

### DIFF
--- a/pkg/storage/pkg/decomposedfs/recycle.go
+++ b/pkg/storage/pkg/decomposedfs/recycle.go
@@ -475,6 +475,5 @@ func (tb *DecomposedfsTrashbin) EmptyRecycle(ctx context.Context, ref *provider.
 }
 
 func (tb *DecomposedfsTrashbin) getRecycleRoot(spaceID string) string {
-	rootNode := node.NewBaseNode(spaceID, spaceID, tb.fs.lu)
-	return filepath.Join(rootNode.InternalPath(), "trash")
+	return filepath.Join(tb.fs.o.Root, "spaces", lookup.Pathify(spaceID, 1, 2), "trash")
 }


### PR DESCRIPTION
The trash is in '/spaces/no/de-id/trash' not /spaces/no/de-id/nodes/no/de-id/trash'

Fixes the unit tests once more.