### PR TITLE
always propagate size diff on trash restore

### DIFF
--- a/pkg/storage/pkg/decomposedfs/trashbin/trashbin.go
+++ b/pkg/storage/pkg/decomposedfs/trashbin/trashbin.go
@@ -23,13 +23,14 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/opencloud-eu/reva/v2/pkg/storage"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 )
 
 type Trashbin interface {
 	Setup(storage.FS) error
 
 	ListRecycle(ctx context.Context, spaceID, key, relativePath string) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, spaceID, key, relativePath string, restoreRef *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, spaceID, key, relativePath string, restoreRef *provider.Reference) (*node.Node, error)
 	PurgeRecycleItem(ctx context.Context, spaceID, key, relativePath string) error
 	EmptyRecycle(ctx context.Context, spaceID string) error
 }

--- a/pkg/storage/pkg/decomposedfs/tree/tree.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree.go
@@ -524,7 +524,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 }
 
 // RestoreRecycleItemFunc returns a node and a function to restore it from the trash.
-func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPath string, targetNode *node.Node) (*node.Node, *node.Node, func() error, error) {
+func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPath string, targetNode *node.Node) (*node.Node, *node.Node, func() (*node.Node, error), error) {
 	_, span := tracer.Start(ctx, "RestoreRecycleItemFunc")
 	defer span.End()
 	logger := appctx.GetLogger(ctx)
@@ -555,9 +555,9 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		return nil, nil, nil, err
 	}
 
-	fn := func() error {
+	fn := func() (*node.Node, error) {
 		if targetNode.Exists {
-			return errtypes.AlreadyExists("origin already exists")
+			return nil, errtypes.AlreadyExists("origin already exists")
 		}
 
 		parts := strings.SplitN(recycleNode.ID, node.TrashIDDelimiter, 2)
@@ -567,18 +567,18 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		// add the entry for the parent dir
 		err = os.Symlink("../../../../../"+lookup.Pathify(originalId, 4, 2), filepath.Join(targetNode.ParentPath(), targetNode.Name))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// attempt to rename only if we're not in a subfolder
 		if recycleNode.ID != restoreNode.ID {
 			err = os.Rename(recycleNode.InternalPath(), restoreNode.InternalPath())
 			if err != nil {
-				return err
+				return nil, err
 			}
 			err = t.lookup.MetadataBackend().Rename(recycleNode, restoreNode)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
@@ -590,7 +590,7 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		attrs.SetString(prefixes.ParentidAttr, targetNode.ParentID)
 
 		if err = t.lookup.MetadataBackend().SetMultiple(ctx, restoreNode, map[string][]byte(attrs), true); err != nil {
-			return errors.Wrap(err, "Decomposedfs: could not update recycle node")
+			return nil, errors.Wrap(err, "Decomposedfs: could not update recycle node")
 		}
 
 		// delete item link in trash
@@ -598,7 +598,7 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		if trashPath != "" && trashPath != "/" {
 			resolvedTrashRoot, err := filepath.EvalSymlinks(trashItem)
 			if err != nil {
-				return errors.Wrap(err, "Decomposedfs: could not resolve trash root")
+				return nil, errors.Wrap(err, "Decomposedfs: could not resolve trash root")
 			}
 			deletePath = filepath.Join(resolvedTrashRoot, trashPath)
 			if err = os.Remove(deletePath); err != nil {
@@ -610,17 +610,8 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 			}
 		}
 
-		var sizeDiff int64
-		if recycleNode.IsDir(ctx) {
-			treeSize, err := recycleNode.GetTreeSize(ctx)
-			if err != nil {
-				return err
-			}
-			sizeDiff = int64(treeSize)
-		} else {
-			sizeDiff = recycleNode.Blobsize
-		}
-		return t.Propagate(ctx, targetNode, sizeDiff)
+		// the recycle node has an id with the trish timestamp, but the propagation is only interested in the parent id
+		return recycleNode, nil
 	}
 	return recycleNode, parent, fn, nil
 }

--- a/pkg/storage/pkg/decomposedfs/tree/tree.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree.go
@@ -609,9 +609,10 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 				logger.Error().Err(err).Str("trashItem", trashItem).Str("deletePath", deletePath).Str("trashPath", trashPath).Msg("error recursively deleting trash item")
 			}
 		}
-
+		rn := node.New(restoreNode.SpaceID, restoreNode.ID, targetNode.ParentID, targetNode.Name, recycleNode.Blobsize, recycleNode.BlobID, recycleNode.Type(ctx), recycleNode.Owner(), t.lookup)
+		rn.Exists = true
 		// the recycle node has an id with the trish timestamp, but the propagation is only interested in the parent id
-		return recycleNode, nil
+		return rn, nil
 	}
 	return recycleNode, parent, fn, nil
 }

--- a/pkg/storage/pkg/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree_test.go
@@ -181,8 +181,13 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, err = restoreFunc()
+					restoredNode, err := restoreFunc()
 					Expect(err).ToNot(HaveOccurred())
+					Expect(restoredNode).ToNot(BeNil())
+					Expect(restoredNode.Exists).To(BeTrue())
+					Expect(restoredNode.SpaceID).To(Equal(n.SpaceID))
+					Expect(restoredNode.ID).To(Equal(n.ID))
+					Expect(restoredNode.ParentID).To(Equal(n.ParentID))
 
 					originalNode, err := env.Lookup.NodeFromResource(env.Ctx, &provider.Reference{
 						ResourceId: env.SpaceRootRes,
@@ -203,8 +208,13 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", dest)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, err = restoreFunc()
+					restoredNode, err := restoreFunc()
 					Expect(err).ToNot(HaveOccurred())
+					Expect(restoredNode).ToNot(BeNil())
+					Expect(restoredNode.Exists).To(BeTrue())
+					Expect(restoredNode.SpaceID).To(Equal(dest.SpaceID))
+					Expect(restoredNode.ID).To(Equal(n.ID))
+					Expect(restoredNode.ParentID).To(Equal(dest.ParentID))
 
 					newNode, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 					Expect(err).ToNot(HaveOccurred())
@@ -220,8 +230,13 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, err = restoreFunc()
+					restoredNode, err := restoreFunc()
 					Expect(err).ToNot(HaveOccurred())
+					Expect(restoredNode).ToNot(BeNil())
+					Expect(restoredNode.Exists).To(BeTrue())
+					Expect(restoredNode.SpaceID).To(Equal(n.SpaceID))
+					Expect(restoredNode.ID).To(Equal(n.ID))
+					Expect(restoredNode.ParentID).To(Equal(n.ParentID))
 
 					_, err = os.Stat(trashPath)
 					Expect(err).To(HaveOccurred())

--- a/pkg/storage/pkg/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree_test.go
@@ -181,7 +181,8 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(restoreFunc()).To(Succeed())
+					_, err = restoreFunc()
+					Expect(err).ToNot(HaveOccurred())
 
 					originalNode, err := env.Lookup.NodeFromResource(env.Ctx, &provider.Reference{
 						ResourceId: env.SpaceRootRes,
@@ -202,7 +203,8 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", dest)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(restoreFunc()).To(Succeed())
+					_, err = restoreFunc()
+					Expect(err).ToNot(HaveOccurred())
 
 					newNode, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 					Expect(err).ToNot(HaveOccurred())
@@ -218,7 +220,8 @@ var _ = Describe("Tree", func() {
 					_, _, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.SpaceRoot.ID, n.ID, "", nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					Expect(restoreFunc()).To(Succeed())
+					_, err = restoreFunc()
+					Expect(err).ToNot(HaveOccurred())
 
 					_, err = os.Stat(trashPath)
 					Expect(err).To(HaveOccurred())


### PR DESCRIPTION
fixes the etag propagation for trash items
part of https://github.com/opencloud-eu/opencloud/issues/281
```
❯ make test-acceptance-api \
   TEST_SERVER_URL=https://opencloud-server:9200 \
   BEHAT_FEATURE=tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature
[...]
The following tests were skipped because they are tagged @skip:
runsh: Total 8 scenarios (8 passed, 0 failed)
runsh: There were no unexpected failures.
runsh: There were no unexpected success.
```

and `make test` passes.

@aduffeck returning the recycleNode smells. but the propagation will call Parent() on it anyway. however ... I'm not 100% sure the parint will always be the target destination parent and not the old trash parent. I'll try if I can add that to the tests ... affter lunch
