### PR TITLE
feat: clear edition fallback

### DIFF
--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -75,10 +75,6 @@ func (c *Config) Init() {
 		c.ProductVersion = "10.0.11"
 	}
 
-	if c.Edition == "" {
-		c.Edition = "community"
-	}
-
 	if c.NameValidation.InvalidChars == nil {
 		c.NameValidation.InvalidChars = []string{"\f", "\r", "\n", "\\"}
 	}

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -70,7 +70,7 @@ func (h *Handler) Init(c *config.Config) {
 		h.c.Capabilities.Core.Status.VersionString = "10.0.11" // TODO make build determined
 	}
 	if h.c.Capabilities.Core.Status.Edition == "" {
-		h.c.Capabilities.Core.Status.Edition = "community" // TODO make build determined
+		h.c.Capabilities.Core.Status.Edition = "" // TODO make build determined
 	}
 	if h.c.Capabilities.Core.Status.ProductName == "" {
 		h.c.Capabilities.Core.Status.ProductName = "reva" // TODO make build determined
@@ -220,7 +220,7 @@ func (h *Handler) Init(c *config.Config) {
 			Minor:          0,
 			Micro:          11,
 			String:         "10.0.11",
-			Edition:        "community",
+			Edition:        "",
 			Product:        "reva",
 			ProductVersion: "",
 		}


### PR DESCRIPTION
Clears the `edition` fallback on "community" in the capabilities. We want to have this as empty string without any fallback.