### PR TITLE
New "jsoncs3" backend for app token storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/BurntSushi/toml v1.4.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/alexedwards/argon2id v1.0.0
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/beevik/etree v1.5.0
@@ -71,6 +72,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/sercand/kuberesolver/v5 v5.1.1
+	github.com/sethvargo/go-diceware v0.5.0
 	github.com/sethvargo/go-password v0.3.1
 	github.com/shamaton/msgpack/v2 v2.2.3
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alexedwards/argon2id v1.0.0 h1:wJzDx66hqWX7siL/SRUmgz3F8YMrd/nfX/xHHcQQP0w=
+github.com/alexedwards/argon2id v1.0.0/go.mod h1:tYKkqIjzXvZdzPvADMWOEZ+l6+BD6CtBXMj5fnJppiw=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -756,6 +758,8 @@ github.com/sercand/kuberesolver/v5 v5.1.1/go.mod h1:Fs1KbKhVRnB2aDWN12NjKCB+RgYM
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0/go.mod h1:Ad7IjTpvzZO8Fl0vh9AzQ+j/jYZfyp2diGwI8m5q+ns=
+github.com/sethvargo/go-diceware v0.5.0 h1:exrQ7GpaBo00GqRVM1N8ChXSsi3oS7tjQiIehsD+yR0=
+github.com/sethvargo/go-diceware v0.5.0/go.mod h1:Lg1SyPS7yQO6BBgTN5r4f2MUDkqGfLWsOjHPY0kA8iw=
 github.com/sethvargo/go-password v0.3.1 h1:WqrLTjo7X6AcVYfC6R7GtSyuUQR9hGyAj/f1PYQZCJU=
 github.com/sethvargo/go-password v0.3.1/go.mod h1:rXofC1zT54N7R8K/h1WDUdkf9BOx5OptoxrMBcrXzvs=
 github.com/shamaton/msgpack/v2 v2.2.3 h1:uDOHmxQySlvlUYfQwdjxyybAOzjlQsD1Vjy+4jmO9NM=

--- a/pkg/appauth/manager/jsoncs3/jsoncs3.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3.go
@@ -1,0 +1,491 @@
+package jsoncs3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alexedwards/argon2id"
+	apppb "github.com/cs3org/go-cs3apis/cs3/auth/applications/v1beta1"
+	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/opencloud-eu/reva/v2/pkg/appauth"
+	"github.com/opencloud-eu/reva/v2/pkg/appauth/manager/registry"
+	"github.com/opencloud-eu/reva/v2/pkg/appctx"
+	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata"
+	"github.com/opencloud-eu/reva/v2/pkg/utils"
+	"github.com/pkg/errors"
+	"github.com/sethvargo/go-diceware/diceware"
+	"github.com/sethvargo/go-password/password"
+	"go.opentelemetry.io/otel/codes"
+)
+
+type PasswordGenerator interface {
+	GeneratePassword() (string, error)
+}
+
+func init() {
+	registry.Register("jsoncs3", New)
+}
+
+type manager struct {
+	sync.RWMutex // for lazy initialization
+	mds          metadata.Storage
+	generator    PasswordGenerator
+	initialized  bool
+}
+
+type config struct {
+	ProviderAddr      string         `mapstructure:"provider_addr"`
+	ServiceUserID     string         `mapstructure:"service_user_id"`
+	ServiceUserIdp    string         `mapstructure:"service_user_idp"`
+	MachineAuthAPIKey string         `mapstructure:"machine_auth_apikey"`
+	Generator         string         `mapstructure:"password_generator"`
+	GeneratorConfig   map[string]any `mapstructure:"generator_config"`
+}
+
+type updaterFunc func(map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error)
+
+const tracerName = "jsoncs3"
+
+func New(m map[string]any) (appauth.Manager, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error creating a new manager")
+		return nil, err
+	}
+
+	if c.ProviderAddr == "" {
+		return nil, fmt.Errorf("appauth jsoncs3 manager: provider_addr not set")
+	}
+
+	if c.ServiceUserID == "" {
+		return nil, fmt.Errorf("appauth jsoncs3 manager: service_user_id not set")
+	}
+
+	if c.ServiceUserIdp == "" {
+		return nil, fmt.Errorf("appauth jsoncs3 manager: service_user_idp not set")
+	}
+
+	if c.MachineAuthAPIKey == "" {
+		return nil, fmt.Errorf("appauth jsoncs3 manager: machine_auth_apikey not set")
+	}
+
+	if c.Generator == "" {
+		c.Generator = "diceware"
+	}
+
+	var pwgen PasswordGenerator
+	var err error
+	switch c.Generator {
+	case "diceware":
+		pwgen, err = NewDicewareGenerator(c.GeneratorConfig)
+	case "random":
+		pwgen, err = NewRandGenerator(c.GeneratorConfig)
+	default:
+		return nil, fmt.Errorf("appauth jsoncs3 manager: unknown generator: %s", c.Generator)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("appauth jsoncs3 manager: failed initialize password generator: %w", err)
+	}
+
+	cs3, err := metadata.NewCS3Storage(c.ProviderAddr, c.ProviderAddr, c.ServiceUserID, c.ServiceUserIdp, c.MachineAuthAPIKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewWithOptions(cs3, pwgen)
+}
+
+func NewWithOptions(mds metadata.Storage, generator PasswordGenerator) (*manager, error) {
+	return &manager{
+		mds:       mds,
+		generator: generator,
+	}, nil
+}
+
+// GenerateAppPassword creates a password with specified scope to be used by
+// third-party applications.
+func (m *manager) GenerateAppPassword(ctx context.Context, scope map[string]*authpb.Scope, label string, expiration *typespb.Timestamp) (*apppb.AppPassword, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GenerateAppPassword")
+	defer span.End()
+	if err := m.initialize(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	token, err := m.generator.GeneratePassword()
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating new token")
+	}
+
+	tokenHashed, err := argon2id.CreateHash(token, argon2id.DefaultParams)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating new token")
+	}
+
+	var userID *userpb.UserId
+	if user, ok := ctxpkg.ContextGetUser(ctx); ok {
+		userID = user.GetId()
+	} else {
+		return nil, errtypes.BadRequest("no user in context")
+	}
+
+	cTime := &typespb.Timestamp{Seconds: uint64(time.Now().Unix())}
+
+	// For persisting we use the hashed password, since we don't
+	// want to store it in cleartext
+	appPass := &apppb.AppPassword{
+		Password:   tokenHashed,
+		TokenScope: scope,
+		Label:      label,
+		Expiration: expiration,
+		Ctime:      cTime,
+		Utime:      cTime,
+		User:       userID,
+	}
+
+	id := uuid.New().String()
+
+	err = m.updateWithRetry(ctx, 5, true, userID, func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+		a[id] = appPass
+		return a, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Here we need to resplace the hash with the cleartext password again since
+	// the requestor needs to know the cleartext value.
+	appPass.Password = token
+
+	return appPass, nil
+}
+
+// ListAppPasswords lists the application passwords created by a user.
+func (m *manager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error) {
+	log := appctx.GetLogger(ctx)
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "ListAppPasswords")
+	defer span.End()
+	if err := m.initialize(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	var userID *userpb.UserId
+	if user, ok := ctxpkg.ContextGetUser(ctx); ok {
+		userID = user.GetId()
+	} else {
+		return nil, errtypes.BadRequest("no user in context")
+	}
+	_, userAppPasswords, err := m.getUserAppPasswords(ctx, userID)
+	if err != nil {
+		log.Error().Err(err).Msg("getUserAppPasswords failed")
+		return nil, err
+	}
+
+	userAppPasswordSlice := make([]*apppb.AppPassword, 0, len(userAppPasswords))
+
+	for _, p := range userAppPasswords {
+		userAppPasswordSlice = append(userAppPasswordSlice, p)
+	}
+
+	return userAppPasswordSlice, nil
+}
+
+// InvalidateAppPassword invalidates a generated password.
+func (m *manager) InvalidateAppPassword(ctx context.Context, secret string) error {
+	log := appctx.GetLogger(ctx)
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "InvalidateAppPassword")
+	defer span.End()
+	if err := m.initialize(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	var userID *userpb.UserId
+	if user, ok := ctxpkg.ContextGetUser(ctx); ok {
+		userID = user.GetId()
+	} else {
+		return errtypes.BadRequest("no user in context")
+	}
+
+	updater := func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+		for key, pw := range a {
+			ok, err := argon2id.ComparePasswordAndHash(secret, pw.Password)
+			switch {
+			case err != nil:
+				log.Debug().Err(err).Msg("Error comparing password and hash")
+			case ok:
+				delete(a, key)
+				return a, nil
+			}
+		}
+		return a, errtypes.NotFound("password not found")
+	}
+
+	err := m.updateWithRetry(ctx, 5, false, userID, updater)
+	if err != nil {
+		log.Error().Err(err).Msg("getUserAppPasswords failed")
+		return errtypes.NotFound("password not found")
+	}
+	return nil
+}
+
+// GetAppPassword retrieves the password information by the combination of username and password.
+func (m *manager) GetAppPassword(ctx context.Context, user *userpb.UserId, secret string) (*apppb.AppPassword, error) {
+	log := appctx.GetLogger(ctx)
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetAppPassword")
+	defer span.End()
+	if err := m.initialize(ctx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	errUpdateSkipped := errors.New("update skipped")
+
+	var matchedPw *apppb.AppPassword
+	updater := func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+		matchedPw = nil
+		for id, pw := range a {
+			ok, err := argon2id.ComparePasswordAndHash(secret, pw.Password)
+			switch {
+			case err != nil:
+				log.Debug().Err(err).Msg("Error comparing password and hash")
+			case ok:
+				// password found
+				if pw.Expiration != nil && pw.Expiration.Seconds != 0 && uint64(time.Now().Unix()) > pw.Expiration.Seconds {
+					log.Debug().Str("AppPasswordId", id).Msg("password expired")
+					return nil, errtypes.NotFound("password not found")
+				}
+
+				matchedPw = pw
+				// password not expired
+				// Updating the Utime will cause an Upload for every single GetAppPassword request. We are limiting this to one
+				// update per 5 minutes otherwise this backend will become unusable.
+				if time.Since(utils.TSToTime(pw.Utime)) > 5*time.Minute {
+					a[id].Utime = utils.TSNow()
+					return a, nil
+				}
+				return a, errUpdateSkipped
+			}
+		}
+		return nil, errtypes.NotFound("password not found")
+	}
+
+	err := m.updateWithRetry(ctx, 5, false, user, updater)
+	switch {
+	case err == nil:
+		fallthrough
+	case errors.Is(err, errUpdateSkipped):
+		return matchedPw, nil
+	}
+
+	return nil, errtypes.NotFound("password not found")
+}
+
+func (m *manager) initialize(ctx context.Context) error {
+	_, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "initialize")
+	defer span.End()
+	if m.initialized {
+		span.SetStatus(codes.Ok, "already initialized")
+		return nil
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if m.initialized { // check if initialization happened while grabbing the lock
+		span.SetStatus(codes.Ok, "initialized while grabbing lock")
+		return nil
+	}
+
+	ctx = context.Background()
+	err := m.mds.Init(ctx, "jsoncs3-appauth-data")
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	m.initialized = true
+	return nil
+}
+
+func (m *manager) updateWithRetry(ctx context.Context, retries int, createIfNotFound bool, userid *userpb.UserId, updater updaterFunc) error {
+	_, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "initialize")
+	defer span.End()
+
+	retry := true
+	var (
+		etag             string
+		userAppPasswords map[string]*apppb.AppPassword
+		err              error
+	)
+
+	// retry for the specified number of times, then error out
+	for i := 0; i < retries && retry; i++ {
+		etag, userAppPasswords, err = m.getUserAppPasswords(ctx, userid)
+		switch err.(type) {
+		case nil:
+			// empty
+		case errtypes.NotFound:
+			if createIfNotFound {
+				userAppPasswords = map[string]*apppb.AppPassword{}
+			} else {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "downloading app tokens failed")
+				return err
+			}
+		default:
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "downloading app tokens failed")
+			return err
+		}
+
+		userAppPasswords, err = updater(userAppPasswords)
+		if err != nil {
+			return err
+		}
+
+		err = m.updateUserAppPassword(ctx, userid, userAppPasswords, etag)
+		switch err.(type) {
+		case nil:
+			retry = false
+		case errtypes.PreconditionFailed:
+			retry = true
+		default:
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	}
+	if retry {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "updating app tokens failed")
+		return err
+	}
+	return nil
+}
+
+func (m *manager) updateUserAppPassword(ctx context.Context, userid *userpb.UserId, appPasswords map[string]*apppb.AppPassword, ifMatchEtag string) error {
+	log := appctx.GetLogger(ctx)
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "getUserAppPasswords")
+	jsonPath := userAppTokenJSONPath(userid)
+
+	pwBytes, err := json.Marshal(appPasswords)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	ur := metadata.UploadRequest{
+		Path:        jsonPath,
+		Content:     pwBytes,
+		IfMatchEtag: ifMatchEtag,
+	}
+
+	// If there is no etag, make sure to only upload if the file wasn't craeted yet
+	if ifMatchEtag == "" {
+		ur.IfNoneMatch = []string{"*"}
+	}
+	_, err = m.mds.Upload(ctx, ur)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		log.Debug().Err(err).Msg("persisting provider cache failed")
+		return err
+	}
+	return nil
+}
+
+func (m *manager) getUserAppPasswords(ctx context.Context, userid *userpb.UserId) (string, map[string]*apppb.AppPassword, error) {
+	log := appctx.GetLogger(ctx)
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "getUserAppPasswords")
+	jsonPath := userAppTokenJSONPath(userid)
+	dlreq := metadata.DownloadRequest{
+		Path: jsonPath,
+	}
+
+	var userAppPasswords = map[string]*apppb.AppPassword{}
+	dlres, err := m.mds.Download(ctx, dlreq)
+	switch err.(type) {
+	case nil:
+		err = json.Unmarshal(dlres.Content, &userAppPasswords)
+		if err != nil {
+			log.Error().Err(err).Msg("unmarshaling app tokens failed")
+			return "", nil, err
+		}
+	case errtypes.NotFound:
+		return "", nil, errtypes.NotFound("password not found")
+	default:
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "downloading app tokens failed")
+		return "", nil, err
+	}
+	return dlres.Etag, userAppPasswords, nil
+}
+
+func userAppTokenJSONPath(userID *userpb.UserId) string {
+	return userID.GetOpaqueId() + ".json"
+}
+
+type randomPassword struct {
+	Strength int `mapstructure:"token_strength"`
+}
+
+func NewRandGenerator(config map[string]any) (*randomPassword, error) {
+	r := &randomPassword{}
+	if err := mapstructure.Decode(config, r); err != nil {
+		err = errors.Wrap(err, "error configuring password generator")
+		return nil, err
+	}
+	if r.Strength <= 0 {
+		r.Strength = 11
+	}
+	return r, nil
+}
+
+func (r randomPassword) GeneratePassword() (string, error) {
+	token, err := password.Generate(r.Strength, r.Strength/2, 0, false, false)
+	if err != nil {
+		return "", errors.Wrap(err, "error creating new token")
+	}
+	return token, nil
+}
+
+type dicewarePassword struct {
+	NumWords int `mapstructure:"number_of_words"`
+}
+
+func NewDicewareGenerator(config map[string]any) (*dicewarePassword, error) {
+	d := &dicewarePassword{}
+	if err := mapstructure.Decode(config, d); err != nil {
+		err = errors.Wrap(err, "error creating a new manager")
+		return nil, err
+	}
+	if d.NumWords <= 0 {
+		d.NumWords = 6
+	}
+	return d, nil
+}
+
+func (d dicewarePassword) GeneratePassword() (string, error) {
+	token, err := diceware.Generate(d.NumWords)
+	if err != nil {
+		return "", errors.Wrap(err, "error creating new token")
+	}
+	return strings.Join(token, " "), nil
+}

--- a/pkg/appauth/manager/jsoncs3/jsoncs3.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3.go
@@ -190,6 +190,9 @@ func (m *manager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, e
 	}
 	_, userAppPasswords, err := m.getUserAppPasswords(ctx, userID)
 	if err != nil {
+		if _, ok := err.(errtypes.NotFound); ok {
+			return []*apppb.AppPassword{}, nil
+		}
 		log.Error().Err(err).Msg("getUserAppPasswords failed")
 		return nil, err
 	}

--- a/pkg/appauth/manager/jsoncs3/jsoncs3_suite_test.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3_suite_test.go
@@ -1,0 +1,13 @@
+package jsoncs3_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestJsoncs3(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Jsoncs3 Suite")
+}

--- a/pkg/appauth/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3_test.go
@@ -1,0 +1,346 @@
+package jsoncs3_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/alexedwards/argon2id"
+	apppb "github.com/cs3org/go-cs3apis/cs3/auth/applications/v1beta1"
+	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/appauth"
+	"github.com/opencloud-eu/reva/v2/pkg/appauth/manager/jsoncs3"
+	"github.com/opencloud-eu/reva/v2/pkg/auth/scope"
+	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata"
+	mdMock "github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata/mocks"
+	"github.com/opencloud-eu/reva/v2/pkg/utils"
+)
+
+const (
+	testUsername = "Testuser"
+	testUserID   = "test-user-id"
+	testUserIDP  = "test-user-idp"
+)
+
+var _ = Describe("Jsoncs3", func() {
+	Describe("New", func() {
+		var (
+			config = map[string]any{
+				"provider_addr":       "eu.opencloud.api.storage-system",
+				"service_user_id":     "service-user-id",
+				"service_user_idp":    "service-user-idp",
+				"machine_auth_apikey": "machineauthpw",
+			}
+		)
+		It("Works with a valid config", func() {
+			m, err := jsoncs3.New(config)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).ToNot(BeNil())
+		})
+		It("Fails with an incomplete config", func() {
+			m, err := jsoncs3.New(map[string]any{})
+			Expect(err).To(HaveOccurred())
+			Expect(m).To(BeNil())
+		})
+	})
+	Describe("When configured", func() {
+		var (
+			ctx     context.Context
+			manager appauth.Manager
+			md      *mdMock.Storage
+			scopes  map[string]*authpb.Scope
+			err     error
+		)
+
+		BeforeEach(func() {
+			var gen jsoncs3.PasswordGenerator
+			gen, err = jsoncs3.NewDicewareGenerator(map[string]any{
+				"number_of_words": 3,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			md = mdMock.NewStorage(GinkgoT())
+			md.EXPECT().Init(mock.Anything, "jsoncs3-appauth-data").Return(nil).Once()
+			manager, err = jsoncs3.NewWithOptions(md, gen)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(manager).ToNot(BeNil())
+
+			scopes, err = scope.AddOwnerScope(map[string]*authpb.Scope{})
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx = ctxpkg.ContextSetUser(
+				context.Background(),
+				&user.User{
+					Username: testUsername,
+					Id: &user.UserId{
+						OpaqueId: testUserID,
+						Idp:      testUserIDP,
+					},
+				})
+		})
+		Describe("Initialization", func() {
+			It("is only done once on the first request", func() {
+				md.EXPECT().Download(mock.Anything, mock.Anything).Return(nil, errtypes.NotFound("unit test"))
+				md.EXPECT().Upload(mock.Anything, mock.Anything).Return(nil, nil)
+				_, err = manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				// subsequent calls don't re-initialize the storage
+				_, err = manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Describe("GenerateAppPassword", func() {
+			When("The user does not have any app passwords", func() {
+				BeforeEach(func() {
+					md.EXPECT().Download(mock.Anything, mock.Anything).Return(nil, errtypes.NotFound("unit test")).Once()
+				})
+				It("adds a new password and returns a valid response", func() {
+					md.On("Upload",
+						mock.Anything,
+						mock.MatchedBy(func(req metadata.UploadRequest) bool {
+							return req.Path == testUserID+".json"
+						}),
+					).Return(nil, nil)
+					apppw, err := manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(apppw.Password).ToNot(BeEmpty())
+					Expect(len(strings.Split(apppw.Password, " "))).To(Equal(3))
+				})
+			})
+			When("The user already has app passwords", func() {
+				var (
+					existingAppPw = map[string]*apppb.AppPassword{
+						"existing-id": {
+							Password: "hash",
+						},
+					}
+					content []byte
+				)
+				var uploadedPw map[string]*apppb.AppPassword
+				BeforeEach(func() {
+					uploadedPw = map[string]*apppb.AppPassword{}
+					content, err = json.Marshal(existingAppPw)
+					Expect(err).ToNot(HaveOccurred())
+					dlRes := metadata.DownloadResponse{
+						Content: content,
+						Etag:    "1",
+					}
+					md.EXPECT().Download(mock.Anything, mock.Anything).Return(&dlRes, nil).Once()
+				})
+				It("adds a new app password and returns a valid response", func() {
+					md.EXPECT().Upload(
+						mock.Anything,
+						mock.MatchedBy(func(req metadata.UploadRequest) bool {
+							if req.Path != testUserID+".json" {
+								return false
+							}
+							err := json.Unmarshal(req.Content, &uploadedPw)
+							return err == nil
+						}),
+					).Return(nil, nil).Once()
+					apppw, err := manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(uploadedPw)).To(Equal(2))
+					_, ok := uploadedPw["existing-id"]
+					Expect(ok).To(BeTrue())
+					Expect(apppw.Password).ToNot(BeEmpty())
+					Expect(len(strings.Split(apppw.Password, " "))).To(Equal(3))
+				})
+				It("retries when the etag on the app password changed", func() {
+					dlRes := metadata.DownloadResponse{
+						Content: content,
+						Etag:    "2",
+					}
+					md.EXPECT().Download(mock.Anything, mock.Anything).Return(&dlRes, nil).Once()
+					md.EXPECT().Upload(
+						mock.Anything,
+						mock.MatchedBy(func(req metadata.UploadRequest) bool {
+							if req.Path != testUserID+".json" {
+								return false
+							}
+							if req.IfMatchEtag != "1" {
+								return false
+							}
+							err := json.Unmarshal(req.Content, &uploadedPw)
+							return err == nil
+						}),
+					).Return(nil, errtypes.PreconditionFailed("etag mismatch")).Once()
+					md.EXPECT().Upload(
+						mock.Anything,
+						mock.MatchedBy(func(req metadata.UploadRequest) bool {
+							if req.Path != testUserID+".json" {
+								return false
+							}
+							if req.IfMatchEtag != "2" {
+								return false
+							}
+							err := json.Unmarshal(req.Content, &uploadedPw)
+							return err == nil
+						}),
+					).Return(nil, nil).Once()
+					apppw, err := manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(uploadedPw)).To(Equal(2))
+					_, ok := uploadedPw["existing-id"]
+					Expect(ok).To(BeTrue())
+					Expect(apppw.Password).ToNot(BeEmpty())
+					Expect(len(strings.Split(apppw.Password, " "))).To(Equal(3))
+				})
+				It("retries 5 times at maximum when the etag changes", func() {
+					dlRes := metadata.DownloadResponse{
+						Content: content,
+						Etag:    "1",
+					}
+					md.EXPECT().Download(mock.Anything, mock.Anything).Return(&dlRes, nil).Times(4)
+					md.EXPECT().Upload(
+						mock.Anything,
+						mock.MatchedBy(func(req metadata.UploadRequest) bool {
+							if req.Path != testUserID+".json" {
+								return false
+							}
+							if req.IfMatchEtag != "1" {
+								return false
+							}
+							err := json.Unmarshal(req.Content, &uploadedPw)
+							return err == nil
+						}),
+					).Return(nil, errtypes.PreconditionFailed("etag mismatch")).Times(5)
+					apppw, err := manager.GenerateAppPassword(ctx, scopes, "testing", nil)
+					Expect(err).To(HaveOccurred())
+					Expect(len(uploadedPw)).To(Equal(2))
+					_, ok := uploadedPw["existing-id"]
+					Expect(ok).To(BeTrue())
+					Expect(apppw).To(BeNil())
+				})
+			})
+		})
+		Describe("GetAppPassword", func() {
+			var (
+				existingAppPw = map[string]*apppb.AppPassword{}
+				uploadedPw    = map[string]*apppb.AppPassword{}
+				content       []byte
+				dlRes         *metadata.DownloadResponse
+			)
+			BeforeEach(func() {
+				hash, err := argon2id.CreateHash("password", argon2id.DefaultParams)
+				Expect(err).ToNot(HaveOccurred())
+				existingAppPw["existing-id"] = &apppb.AppPassword{
+					Password: hash,
+					Utime:    utils.TSNow(),
+				}
+
+				content, err = json.Marshal(existingAppPw)
+				Expect(err).ToNot(HaveOccurred())
+				dlRes = &metadata.DownloadResponse{
+					Content: content,
+				}
+
+				md.EXPECT().Download(mock.Anything, mock.Anything).Return(dlRes, nil)
+			})
+			It("Succeeds when the password matches", func() {
+				_, err = manager.GetAppPassword(ctx, &user.UserId{OpaqueId: "userid"}, "password")
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("Succeeds fails when the password does not match", func() {
+				_, err = manager.GetAppPassword(ctx, &user.UserId{OpaqueId: "userid"}, "wrong password")
+				Expect(err).Should(MatchError(errtypes.NotFound("password not found")))
+			})
+			It("Only uploads when the last utime update was more that 5 minute ago", func() {
+				utime := time.Now().Add(-6 * time.Minute)
+				existingAppPw["existing-id"].Utime = utils.TimeToTS(utime)
+				content, err = json.Marshal(existingAppPw)
+				dlRes.Content = content
+				md.EXPECT().Upload(
+					mock.Anything,
+					mock.MatchedBy(func(req metadata.UploadRequest) bool {
+						err := json.Unmarshal(req.Content, &uploadedPw)
+						return err == nil
+					}),
+				).Return(nil, nil)
+				pw, err := manager.GetAppPassword(ctx, &user.UserId{OpaqueId: "userid"}, "password")
+				updatedUTime := utils.TSToTime(pw.Utime)
+				Expect(updatedUTime.Sub(utime)).To(BeNumerically(">", 5*time.Minute))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+		Describe("ListAppPasswords", func() {
+			var existingAppPw = map[string]*apppb.AppPassword{
+				"existing-id": {
+					Password: "hash",
+				},
+			}
+			BeforeEach(func() {
+				content, err := json.Marshal(existingAppPw)
+				Expect(err).ToNot(HaveOccurred())
+				dlRes := metadata.DownloadResponse{
+					Content: content,
+				}
+
+				md.EXPECT().Download(mock.Anything, mock.Anything).Return(&dlRes, nil)
+			})
+			It("Returns the user's apppassword", func() {
+				res, err := manager.ListAppPasswords(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(res)).To(Equal(1))
+
+			})
+		})
+		Describe("InvalidateAppPassword", func() {
+			var appPasswords = map[string]*apppb.AppPassword{}
+			BeforeEach(func() {
+				hash1, err := argon2id.CreateHash("password1", argon2id.DefaultParams)
+				Expect(err).ToNot(HaveOccurred())
+				hash2, err := argon2id.CreateHash("password2", argon2id.DefaultParams)
+				Expect(err).ToNot(HaveOccurred())
+				appPasswords["id1"] = &apppb.AppPassword{
+					Password: hash1,
+				}
+				appPasswords["id2"] = &apppb.AppPassword{
+					Password: hash2,
+				}
+				content, err := json.Marshal(appPasswords)
+				Expect(err).ToNot(HaveOccurred())
+				dlRes := metadata.DownloadResponse{
+					Content: content,
+				}
+				md.EXPECT().Download(mock.Anything, mock.Anything).Return(&dlRes, nil)
+			})
+
+			It("Returns an error when the password does not match any password in the store", func() {
+				err := manager.InvalidateAppPassword(ctx, "test")
+				Expect(err).To(MatchError(errtypes.NotFound("password not found")))
+			})
+			It("Removes the requested password from the store", func() {
+				var uploadedPw map[string]*apppb.AppPassword
+				md.EXPECT().Upload(
+					mock.Anything,
+					mock.MatchedBy(func(req metadata.UploadRequest) bool {
+						if req.Path != testUserID+".json" {
+							return false
+						}
+						err := json.Unmarshal(req.Content, &uploadedPw)
+						return err == nil
+					}),
+				).Return(nil, nil)
+				err := manager.InvalidateAppPassword(ctx, "password2")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(uploadedPw)).To(Equal(1))
+
+				_, ok := uploadedPw["id1"]
+				Expect(ok).To(BeTrue())
+
+				_, ok = uploadedPw["id2"]
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/appauth/manager/loader/loader.go
+++ b/pkg/appauth/manager/loader/loader.go
@@ -21,5 +21,6 @@ package loader
 import (
 	// Load core application auth manager drivers.
 	_ "github.com/opencloud-eu/reva/v2/pkg/appauth/manager/json"
+	_ "github.com/opencloud-eu/reva/v2/pkg/appauth/manager/jsoncs3"
 	// Add your own here
 )


### PR DESCRIPTION
This backend stores the apptoken in a JSON file per user using the metabackend. By default passwords are generated using the "diceware" algorithm (based on https://xkcd.com/936/). It can be switched to generate "normal" random password. Passwords are hashed using the argon2id algorithm.
Note: There is no form of caching for now. I.e. the json file is loaded upon every single authentication request so there is lot of room for improvement here. To limit the amount of write operations the Utime (time of last usage of the password) is however only updated with a granularity of 5 minutes.

https://github.com/opencloud-eu/opencloud/issues/207