### PR TITLE
fix(appauth/jsoncs3) Avoid returing password hashes on API

### DIFF
--- a/pkg/appauth/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Jsoncs3", func() {
 						return err == nil
 					}),
 				).Return(nil, nil)
-				err := manager.InvalidateAppPassword(ctx, hash2)
+				err := manager.InvalidateAppPassword(ctx, "id2")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(uploadedPw)).To(Equal(1))
 


### PR DESCRIPTION
Up to now ListAppPasswords returned the hashed passwords in the 'password` property of the response. We don't want to expose password hashes. Instead, as a workaround for allowing to delete app tokes, we now return the token's unique id now in the 'password' property.

Fixes: https://github.com/opencloud-eu/opencloud/issues/490