### PR TITLE
🎉 Release 2.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.29.1](https://github.com/opencloud-eu/reva/releases/tag/v2.29.1) - 2025-03-26
+
+### ❤️ Thanks to all contributors! ❤️
+
+@amrita-shrestha
+
+
+
 ## [2.29.0](https://github.com/opencloud-eu/reva/releases/tag/v2.29.0) - 2025-03-26
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@amrita-shrestha
+@aduffeck, @amrita-shrestha
 
+### 🐛 Bug Fixes
 
+- Always try to get the blob id/size from the metadata [[#141](https://github.com/opencloud-eu/reva/pull/141)]
 
 ## [2.29.0](https://github.com/opencloud-eu/reva/releases/tag/v2.29.0) - 2025-03-26
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.29.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.29.1](https://github.com/opencloud-eu/reva/releases/tag/v2.29.1) - 2025-03-26

### 🐛 Bug Fixes

- Always try to get the blob id/size from the metadata [[#141](https://github.com/opencloud-eu/reva/pull/141)]