### PR TITLE
Cache internal path and disabled flag

### DIFF
--- a/pkg/storage/fs/posix/trashbin/trashbin.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin.go
@@ -168,10 +168,6 @@ func (tb *Trashbin) MoveToTrash(ctx context.Context, n *node.Node, path string) 
 	if err = tb.lu.IDCache.DeleteByPath(ctx, path); err != nil {
 		return err
 	}
-	err = tb.lu.MetadataBackend().Purge(ctx, n)
-	if err != nil {
-		return err
-	}
 
 	itemTrashPath := filepath.Join(trashPath, "files", key+".trashitem")
 	return os.Rename(path, itemTrashPath)

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -215,6 +215,7 @@ type Node struct {
 	SpaceRoot *Node
 
 	xattrsCache map[string][]byte
+	disabled    *bool
 	nodeType    *provider.ResourceType
 }
 
@@ -1002,10 +1003,17 @@ func (n *Node) HasPropagation(ctx context.Context) (propagation bool) {
 // only used to check if a space is disabled
 // FIXME confusing with the trash logic
 func (n *Node) IsDisabled(ctx context.Context) bool {
-	if _, err := n.GetDTime(ctx); err == nil {
-		return true
+	if n.disabled != nil {
+		return *n.disabled
 	}
-	return false
+	if _, err := n.GetDTime(ctx); err == nil {
+		v := true
+		n.disabled = &v
+	} else {
+		v := false
+		n.disabled = &v
+	}
+	return *n.disabled
 }
 
 // GetTreeSize reads the treesize from the extended attributes

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -178,8 +178,9 @@ type BaseNode struct {
 	SpaceID string
 	ID      string
 
-	lu           PathLookup
-	internalPath string
+	lu             PathLookup
+	internalPathID string
+	internalPath   string
 }
 
 func NewBaseNode(spaceID, nodeID string, lu PathLookup) *BaseNode {
@@ -195,11 +196,12 @@ func (n *BaseNode) GetID() string      { return n.ID }
 
 // InternalPath returns the internal path of the Node
 func (n *BaseNode) InternalPath() string {
-	if len(n.internalPath) > 0 {
+	if len(n.internalPath) > 0 && n.ID == n.internalPathID {
 		return n.internalPath
 	}
 
 	n.internalPath = n.lu.InternalPath(n.SpaceID, n.ID)
+	n.internalPathID = n.ID
 	return n.internalPath
 }
 

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -178,7 +178,8 @@ type BaseNode struct {
 	SpaceID string
 	ID      string
 
-	lu PathLookup
+	lu           PathLookup
+	internalPath string
 }
 
 func NewBaseNode(spaceID, nodeID string, lu PathLookup) *BaseNode {
@@ -194,7 +195,12 @@ func (n *BaseNode) GetID() string      { return n.ID }
 
 // InternalPath returns the internal path of the Node
 func (n *BaseNode) InternalPath() string {
-	return n.lu.InternalPath(n.SpaceID, n.ID)
+	if len(n.internalPath) > 0 {
+		return n.internalPath
+	}
+
+	n.internalPath = n.lu.InternalPath(n.SpaceID, n.ID)
+	return n.internalPath
 }
 
 // Node represents a node in the tree and provides methods to get a Parent or Child instance


### PR DESCRIPTION
Cache internal path and the disabled flag on node object, sparing lots of requests to the ID cache (nats by default).

Caching the internal path also prevents nodes from changing their identity mid-flight, e.g. when assimilation alters the cache in the background.

Speeds up directory listings with posix fs by a factor of 2-3 on my machine.