### PR TITLE
Periodically log stats about inotify resources usage on the system

### DIFF
--- a/pkg/storage/fs/posix/options/options.go
+++ b/pkg/storage/fs/posix/options/options.go
@@ -44,6 +44,9 @@ type Options struct {
 	WatchType               string `mapstructure:"watch_type"`
 	WatchPath               string `mapstructure:"watch_path"`
 	WatchFolderKafkaBrokers string `mapstructure:"watch_folder_kafka_brokers"`
+
+	// InotifyWatcher specific options
+	InotifyStatsFrequency time.Duration `mapstructure:"inotify_stats_frequency"`
 }
 
 // New returns a new Options instance for the given configuration
@@ -52,9 +55,11 @@ func New(m map[string]interface{}) (*Options, error) {
 	if _, ok := m["metadata_backend"]; !ok {
 		m["metadata_backend"] = "hybrid"
 	}
-	// debounced scan delay
 	if _, ok := m["scan_debounce_delay"]; !ok {
 		m["scan_debounce_delay"] = 10 * time.Millisecond
+	}
+	if _, ok := m["inotify_stats_frequency"]; !ok {
+		m["inotify_stats_frequency"] = 5 * time.Minute
 	}
 
 	o := &Options{}

--- a/pkg/storage/fs/posix/tree/inotifywatcher.go
+++ b/pkg/storage/fs/posix/tree/inotifywatcher.go
@@ -22,24 +22,40 @@ package tree
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/options"
 	"github.com/pablodz/inotifywaitgo/inotifywaitgo"
 	"github.com/rs/zerolog"
 )
 
 type InotifyWatcher struct {
-	tree *Tree
-	log  *zerolog.Logger
+	tree    *Tree
+	options *options.Options
+	log     *zerolog.Logger
 }
 
-func NewInotifyWatcher(tree *Tree, log *zerolog.Logger) (*InotifyWatcher, error) {
+func NewInotifyWatcher(tree *Tree, o *options.Options, log *zerolog.Logger) (*InotifyWatcher, error) {
 	return &InotifyWatcher{
-		tree: tree,
-		log:  log,
+		tree:    tree,
+		options: o,
+		log:     log,
 	}, nil
 }
 
 func (iw *InotifyWatcher) Watch(path string) {
+	if iw.options.InotifyStatsFrequency > 0 {
+		go func() {
+			for {
+				iw.printStats()
+				time.Sleep(iw.options.InotifyStatsFrequency)
+			}
+		}()
+	}
 	events := make(chan inotifywaitgo.FileEvent)
 	errors := make(chan error)
 
@@ -103,4 +119,120 @@ func (iw *InotifyWatcher) Watch(path string) {
 			}
 		}
 	}
+}
+
+// InotifyUsage holds the number of inotify watches and instances.
+type InotifyUsage struct {
+	Watches      int
+	Instances    int
+	MaxWatches   int
+	MaxInstances int
+}
+
+func countInotifyFDs(pid string) (int, int, error) {
+	fds, err := os.ReadDir(filepath.Join("/proc", pid, "fd"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil // Process may have exited, treat as 0.
+		}
+		return 0, 0, fmt.Errorf("failed to read /proc/%s/fd: %w", pid, err)
+	}
+
+	watches := 0
+	instances := 0
+	for _, fd := range fds {
+		if !fd.IsDir() {
+			if fd.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+
+			link, err := os.Readlink(filepath.Join("/proc", pid, "fd", fd.Name()))
+			if err != nil || (link != "inotify" && link != "anon_inode:inotify") {
+				continue
+			}
+
+			instances++
+			fdinfoPath := filepath.Join("/proc", pid, "fdinfo", fd.Name())
+			content, err := os.ReadFile(fdinfoPath)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to read %s: %w", fdinfoPath, err)
+			}
+
+			lines := strings.SplitSeq(string(content), "\n")
+			for line := range lines {
+				if strings.HasPrefix(line, "inotify") {
+					watches++
+				}
+			}
+		}
+	}
+	return watches, instances, nil
+}
+
+func GetInotifyUsageFromProc() (InotifyUsage, error) {
+	usage := InotifyUsage{}
+	var err error
+
+	usage.MaxWatches, err = readProcFile("sys/fs/inotify/max_user_watches")
+	if err != nil {
+		return usage, fmt.Errorf("failed to read max_user_watches: %w", err)
+	}
+	usage.MaxInstances, err = readProcFile("sys/fs/inotify/max_user_instances")
+	if err != nil {
+		return usage, fmt.Errorf("failed to read max_user_instances: %w", err)
+	}
+
+	dirs, err := os.ReadDir("/proc")
+	if err != nil {
+		return usage, fmt.Errorf("failed to read /proc: %w", err)
+	}
+
+	totalWatches := 0
+	totalInstances := 0
+	for _, dir := range dirs {
+		if dir.IsDir() {
+			pid := dir.Name()
+			if _, err := strconv.Atoi(pid); err == nil {
+				watches, instances, err := countInotifyFDs(pid)
+				if err != nil {
+					continue
+				}
+				totalWatches += watches
+				totalInstances += instances
+			}
+		}
+	}
+
+	usage.Watches = totalWatches
+	usage.Instances = totalInstances
+	return usage, nil
+}
+
+func readProcFile(filename string) (int, error) {
+	filePath := filepath.Join("/proc", filename)
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return 0, err
+	}
+	i, err := strconv.Atoi(strings.TrimSpace(string(content)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse max_user_watches: %w", err)
+	}
+	return i, nil
+}
+
+func (iw *InotifyWatcher) printStats() {
+	t := time.Now()
+	usage, err := GetInotifyUsageFromProc()
+	if err != nil {
+		iw.log.Error().Err(err).Msg("failed to get inotify usage")
+		return
+	}
+	d := time.Since(t)
+
+	iw.log.Info().
+		Str("watches", fmt.Sprintf("%d/%d (%.2f%%)", usage.Watches, usage.MaxWatches, float64(usage.Watches)/float64(usage.MaxWatches)*100)).
+		Str("instances", fmt.Sprintf("%d/%d (%.2f%%)", usage.Instances, usage.MaxInstances, float64(usage.Instances)/float64(usage.MaxInstances)*100)).
+		Str("duration", d.String()).
+		Msg("Inotify usage stats")
 }

--- a/pkg/storage/fs/posix/tree/inotifywatcher_default.go
+++ b/pkg/storage/fs/posix/tree/inotifywatcher_default.go
@@ -7,6 +7,7 @@ package tree
 
 import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/options"
 	"github.com/rs/zerolog"
 )
 
@@ -17,6 +18,6 @@ type NullWatcher struct{}
 func (*NullWatcher) Watch(path string) {}
 
 // NewInotifyWatcher returns a new inotify watcher
-func NewInotifyWatcher(tree *Tree, log *zerolog.Logger) (*NullWatcher, error) {
+func NewInotifyWatcher(_ *Tree, _ *options.Options, _ *zerolog.Logger) (*NullWatcher, error) {
 	return nil, errtypes.NotSupported("inotify watcher is not supported on this platform")
 }

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -129,7 +129,7 @@ func New(lu node.PathLookup, bs node.Blobstore, um usermapper.Mapper, trashbin *
 				return nil, err
 			}
 		default:
-			t.watcher, err = NewInotifyWatcher(t, log)
+			t.watcher, err = NewInotifyWatcher(t, o, log)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Example log:

```
2025-04-02T09:56:16+02:00 INF Inotify usage stats duration=126.907156ms instances="87/128 (67.97%)" line=/home/andre/src/opencloud/reva/pkg/storage/fs/posix/tree/inotifywatcher.go:237 pkg=rgrpc service=storage-users watches="27727/504714 (5.49%)"
2025-04-02T10:01:16+02:00 INF Inotify usage stats duration=82.352794ms instances="88/128 (68.75%)" line=/home/andre/src/opencloud/reva/pkg/storage/fs/posix/tree/inotifywatcher.go:237 pkg=rgrpc service=storage-users watches="27746/504714 (5.50%)"
```