### PR TITLE
flush cache by age

### DIFF
--- a/.woodpecker/purge-cache.yaml
+++ b/.woodpecker/purge-cache.yaml
@@ -18,6 +18,6 @@ steps:
         from_secret: cache_s3_server
       flush: true
       flush_age: 1
-      flush_path: cache/opencloud-eu/reva/
+      flush_path: dev/opencloud-eu/reva/
       secret_key:
         from_secret: cache_s3_secret_key

--- a/.woodpecker/purge-cache.yaml
+++ b/.woodpecker/purge-cache.yaml
@@ -1,6 +1,4 @@
 ---
-depends_on: [test, test-integration, api-integration-test-on-decomposed, api-integration-test-on-decomposedS3, api-integration-test-on-posixfs]
-
 variables:
   - &s3_cache_image 'plugins/s3-cache:1'
 

--- a/.woodpecker/purge-cache.yaml
+++ b/.woodpecker/purge-cache.yaml
@@ -2,7 +2,7 @@
 depends_on: [test, test-integration, api-integration-test-on-decomposed, api-integration-test-on-decomposedS3, api-integration-test-on-posixfs]
 
 variables:
-  - &minio_image 'minio/mc:RELEASE.2021-10-07T04-19-58Z'
+  - &s3_cache_image 'plugins/s3-cache:1'
 
 when:
   - event: [ push , manual ]
@@ -12,17 +12,14 @@ when:
 skip_clone: true
 steps:
   purge:
-    image: *minio_image
-    environment:
-      AWS_ACCESS_KEY_ID:
+    image: *s3_cache_image
+    settings:
+      access_key:
         from_secret: cache_s3_access_key
-      AWS_SECRET_ACCESS_KEY:
-        from_secret: cache_s3_secret_key
-      S3_BUCKET:
-        from_secret: cache_s3_bucket
-      S3_ENDPOINT:
+      endpoint:
         from_secret: cache_s3_server
-    commands:
-      - mc alias set s3 $S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
-      - mc rm --recursive --force s3/$S3_BUCKET/${CI_REPO}/$CI_COMMIT_SHA-$CI_PIPELINE_NUMBER-revad
-      - mc ls --recursive s3/$S3_BUCKET/opencloud-eu/reva
+      flush: true
+      flush_age: 1
+      flush_path: cache/opencloud-eu/reva/
+      secret_key:
+        from_secret: cache_s3_secret_key


### PR DESCRIPTION
Instead of deleting only the cache of the current run, flush the cache by age (1day).
That way we will not delete the cache of the current run immediately, but on the other hand we will delete the cache of old runs that failed or were canceled for some reason.