### PR TITLE
🎉 Release 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.30.1](https://github.com/opencloud-eu/reva/releases/tag/v2.30.1) - 2025-04-05
+
+### ❤️ Thanks to all contributors! ❤️
+
+@individual-it
+
+
+
 ## [2.30.0](https://github.com/opencloud-eu/reva/releases/tag/v2.30.0) - 2025-04-04
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## [2.30.1](https://github.com/opencloud-eu/reva/releases/tag/v2.30.1) - 2025-04-05
+## [2.30.1](https://github.com/opencloud-eu/reva/releases/tag/v2.30.1) - 2025-04-07
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@individual-it
+@aduffeck, @individual-it
 
+### 🐛 Bug Fixes
 
+- Do not send "delete" sses when items are moved [[#165](https://github.com/opencloud-eu/reva/pull/165)]
 
 ## [2.30.0](https://github.com/opencloud-eu/reva/releases/tag/v2.30.0) - 2025-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## [2.30.1](https://github.com/opencloud-eu/reva/releases/tag/v2.30.1) - 2025-04-07
+## [2.31.0](https://github.com/opencloud-eu/reva/releases/tag/v2.31.0) - 2025-04-07
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@aduffeck, @individual-it
+@JammingBen, @aduffeck, @individual-it
+
+### ✨ Features
+
+- revert: remove "edition" property [[#167](https://github.com/opencloud-eu/reva/pull/167)]
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix stale file metadata cache entries [[#166](https://github.com/opencloud-eu/reva/pull/166)]
 - Do not send "delete" sses when items are moved [[#165](https://github.com/opencloud-eu/reva/pull/165)]
 
 ## [2.30.0](https://github.com/opencloud-eu/reva/releases/tag/v2.30.0) - 2025-04-04


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.31.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.31.0](https://github.com/opencloud-eu/reva/releases/tag/v2.31.0) - 2025-04-07

### ✨ Features

- revert: remove "edition" property [[#167](https://github.com/opencloud-eu/reva/pull/167)]

### 🐛 Bug Fixes

- Fix stale file metadata cache entries [[#166](https://github.com/opencloud-eu/reva/pull/166)]
- Do not send "delete" sses when items are moved [[#165](https://github.com/opencloud-eu/reva/pull/165)]