### PR TITLE
revert: remove "edition" property

### DIFF
--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	FavoriteStorageDrivers      map[string]map[string]interface{} `mapstructure:"favorite_storage_drivers"`
 	Version                     string                            `mapstructure:"version"`
 	VersionString               string                            `mapstructure:"version_string"`
+	Edition                     string                            `mapstructure:"edition"`
 	Product                     string                            `mapstructure:"product"`
 	ProductName                 string                            `mapstructure:"product_name"`
 	ProductVersion              string                            `mapstructure:"product_version"`

--- a/internal/http/services/owncloud/ocdav/status.go
+++ b/internal/http/services/owncloud/ocdav/status.go
@@ -34,6 +34,7 @@ func (s *svc) doStatus(w http.ResponseWriter, r *http.Request) {
 		NeedsDBUpgrade: false,
 		Version:        s.c.Version,
 		VersionString:  s.c.VersionString,
+		Edition:        s.c.Edition,
 		ProductName:    s.c.ProductName,
 		ProductVersion: s.c.ProductVersion,
 		Product:        s.c.Product,

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -69,6 +69,9 @@ func (h *Handler) Init(c *config.Config) {
 	if h.c.Capabilities.Core.Status.VersionString == "" {
 		h.c.Capabilities.Core.Status.VersionString = "10.0.11" // TODO make build determined
 	}
+	if h.c.Capabilities.Core.Status.Edition == "" {
+		h.c.Capabilities.Core.Status.Edition = "" // TODO make build determined
+	}
 	if h.c.Capabilities.Core.Status.ProductName == "" {
 		h.c.Capabilities.Core.Status.ProductName = "reva" // TODO make build determined
 	}
@@ -217,6 +220,7 @@ func (h *Handler) Init(c *config.Config) {
 			Minor:          0,
 			Micro:          11,
 			String:         "10.0.11",
+			Edition:        "",
 			Product:        "reva",
 			ProductVersion: "",
 		}

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -297,6 +297,13 @@ func VersionString(val string) Option {
 	}
 }
 
+// Edition provides a function to set the Edition config option.
+func Edition(val string) Option {
+	return func(o *Options) {
+		o.config.Edition = val
+	}
+}
+
 // Product provides a function to set the Product config option.
 func Product(val string) Option {
 	return func(o *Options) {

--- a/pkg/owncloud/ocs/capabilities.go
+++ b/pkg/owncloud/ocs/capabilities.go
@@ -142,6 +142,7 @@ type Status struct {
 	NeedsDBUpgrade ocsBool `json:"needsDbUpgrade" xml:"needsDbUpgrade"`
 	Version        string  `json:"version" xml:"version"`
 	VersionString  string  `json:"versionstring" xml:"versionstring"`
+	Edition        string  `json:"edition" xml:"edition"`
 	ProductName    string  `json:"productname" xml:"productname"`
 	Product        string  `json:"product" xml:"product"`
 	ProductVersion string  `json:"productversion" xml:"productversion"`
@@ -308,6 +309,7 @@ type Version struct {
 	Minor          int    `json:"minor" xml:"minor"`
 	Micro          int    `json:"micro" xml:"micro"` // = patch level
 	String         string `json:"string" xml:"string"`
+	Edition        string `json:"edition" xml:"edition"`
 	Product        string `json:"product" xml:"product"`
 	ProductVersion string `json:"productversion" xml:"productversion"`
 }


### PR DESCRIPTION
Reverts commit b3b452e73475397762a929fa0d487cf35386fc23 after speaking with @tbsbdr since we want to keep the functionality to manually set a version string.