### PR TITLE
Fix wrong blobsize attributes due to premature assimilation

### DIFF
--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -292,6 +292,10 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	revisionNode := node.New(session.SpaceID(), session.NodeID(), "", "", session.Size(), session.ID(),
 		provider.ResourceType_RESOURCE_TYPE_FILE, session.SpaceOwner(), session.store.lu)
 
+	// lock the node before writing the blob
+	unlock, err := session.store.lu.MetadataBackend().Lock(revisionNode)
+	defer func() { _ = unlock() }()
+
 	// upload the data to the blobstore
 	_, subspan := tracer.Start(ctx, "WriteBlob")
 	err = session.store.tp.WriteBlob(revisionNode, session.binPath())


### PR DESCRIPTION
This prevents the assimilation to read the file while it's still being written, which could lead to wrong blobsize attributes being set.

Fixes #162