### PR TITLE
Abort when the space root has already been created. port #199 to stable

### DIFF
--- a/pkg/storage/pkg/decomposedfs/spaces.go
+++ b/pkg/storage/pkg/decomposedfs/spaces.go
@@ -129,7 +129,11 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	}
 
 	// 770 permissions for the space
-	if err := os.MkdirAll(rootPath, 0770); err != nil {
+	if err := os.Mkdir(rootPath, 0770); err != nil {
+		if os.IsExist(err) {
+			// Someone has created the space in the meantime. Abort.
+			return nil, errtypes.AlreadyExists(spaceID)
+		}
 		return nil, errors.Wrap(err, fmt.Sprintf("Decomposedfs: error creating space %s", rootPath))
 	}
 


### PR DESCRIPTION
Fixes a race condition where multiple threads could read the non-existent node and start creating the space in parallel.

Fixes opencloud-eu/opencloud#757