### PR TITLE
🎉 Release 2.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.29.3](https://github.com/opencloud-eu/reva/releases/tag/v2.29.3) - 2025-05-02
+
+### ❤️ Thanks to all contributors! ❤️
+
+@ScharfViktor
+
+### 🐛 Bug Fixes
+
+- Abort when the space root has already been created. port #199 to stable [[#202](https://github.com/opencloud-eu/reva/pull/202)]
+
 ## [2.29.2](https://github.com/opencloud-eu/reva/releases/tag/v2.29.2) - 2025-04-16
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.29.3` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.29` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.29.3](https://github.com/opencloud-eu/reva/releases/tag/v2.29.3) - 2025-05-02

### 🐛 Bug Fixes

- Abort when the space root has already been created. port #199 to stable [[#202](https://github.com/opencloud-eu/reva/pull/202)]