### PR TITLE
add ConsumerOptions

### DIFF
--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -1,0 +1,12 @@
+package events
+
+import (
+	"time"
+)
+
+// ConsumeOptions contains all the options which can be provided when consuming events
+type ConsumeOptions struct {
+	Group   string
+	AutoAck bool
+	AckWait time.Duration
+}


### PR DESCRIPTION
We aded `ConsumeWithOptions` and `ConsumeAllWithOptions` in a backward compatible way to the `pkg/events` package. They allow configuring the Consumer with a custom AckWait time.