### PR TITLE
Fix handling of webdav write locks

### DIFF
--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -63,7 +63,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	req := &provider.DeleteRequest{
 		Ref:    ref,
-		LockId: requestLockToken(r),
+		LockId: requestLock(r),
 	}
 
 	// FIXME the lock token is part of the application level protocol, it should be part of the DeleteRequest message not the opaque

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -297,7 +297,7 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 	mReq := &provider.MoveRequest{
 		Source:      src,
 		Destination: dst,
-		LockId:      requestLockToken(r),
+		LockId:      requestLock(r),
 	}
 	mRes, err := client.Move(ctx, mReq)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -133,14 +133,14 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 	rreq := &provider.UnsetArbitraryMetadataRequest{
 		Ref:                   ref,
 		ArbitraryMetadataKeys: []string{""},
-		LockId:                requestLockToken(r),
+		LockId:                requestLock(r),
 	}
 	sreq := &provider.SetArbitraryMetadataRequest{
 		Ref: ref,
 		ArbitraryMetadata: &provider.ArbitraryMetadata{
 			Metadata: map[string]string{},
 		},
-		LockId: requestLockToken(r),
+		LockId: requestLock(r),
 	}
 
 	acceptedProps := []xml.Name{}

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -276,7 +276,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	uReq := &provider.InitiateFileUploadRequest{
 		Ref:    ref,
 		Opaque: opaque,
-		LockId: requestLockToken(r),
+		LockId: requestLock(r),
 	}
 	if ifMatch := r.Header.Get(net.HeaderIfMatch); ifMatch != "" {
 		uReq.Options = &provider.InitiateFileUploadRequest_IfMatch{IfMatch: ifMatch}


### PR DESCRIPTION
We were wrongly using the "Lock-Token" header when validating a write lock during write operations. The Lock-Token is only returned during LOCK and provided during UNLOCK calls however.
Gaining access to a write-locked resource is instead done by providing the lock in the "If" header.

Fixes opencloud-eu/opencloud#933

/cc @butonic @dragonchaser 