### PR TITLE
utils: Rework GetUser() helper

### DIFF
--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -485,7 +485,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context, filters []*collaboration.F
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to list shares")
 		}
-		u, err := utils.GetUser(forUser, gwc)
+		u, err := utils.GetUser(ctx, forUser, gwc)
 		if err != nil {
 			return nil, errtypes.BadRequest("user not found")
 		}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -843,7 +843,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 		if err != nil {
 			return nil, err
 		}
-		u, err := utils.GetUser(forUser, client)
+		u, err := utils.GetUser(ctx, forUser, client)
 		if err != nil {
 			return nil, errtypes.BadRequest("user not found")
 		}

--- a/pkg/share/manager/owncloudsql/conversions.go
+++ b/pkg/share/manager/owncloudsql/conversions.go
@@ -61,7 +61,7 @@ type DBShare struct {
 type UserConverter interface {
 	UserNameToUserID(ctx context.Context, username string) (*userpb.UserId, error)
 	UserIDToUserName(ctx context.Context, userid *userpb.UserId) (string, error)
-	GetUser(userid *userpb.UserId) (*userpb.User, error)
+	GetUser(ctx context.Context, userid *userpb.UserId) (*userpb.User, error)
 }
 
 // GatewayUserConverter converts usernames and ids using the gateway
@@ -140,12 +140,12 @@ func (c *GatewayUserConverter) UserNameToUserID(ctx context.Context, username st
 }
 
 // GetUser gets the user
-func (c *GatewayUserConverter) GetUser(userid *userpb.UserId) (*userpb.User, error) {
+func (c *GatewayUserConverter) GetUser(ctx context.Context, userid *userpb.UserId) (*userpb.User, error) {
 	gwc, err := pool.GetGatewayServiceClient(c.gwAddr)
 	if err != nil {
 		return nil, err
 	}
-	return utils.GetUser(userid, gwc)
+	return utils.GetUser(ctx, userid, gwc)
 }
 
 func (m *mgr) formatGrantee(ctx context.Context, g *provider.Grantee) (int, string, error) {

--- a/pkg/share/manager/owncloudsql/mocks/UserConverter.go
+++ b/pkg/share/manager/owncloudsql/mocks/UserConverter.go
@@ -41,9 +41,9 @@ func (_m *UserConverter) EXPECT() *UserConverter_Expecter {
 	return &UserConverter_Expecter{mock: &_m.Mock}
 }
 
-// GetUser provides a mock function with given fields: userid
-func (_m *UserConverter) GetUser(userid *userv1beta1.UserId) (*userv1beta1.User, error) {
-	ret := _m.Called(userid)
+// GetUser provides a mock function with given fields: ctx, userid
+func (_m *UserConverter) GetUser(ctx context.Context, userid *userv1beta1.UserId) (*userv1beta1.User, error) {
+	ret := _m.Called(ctx, userid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUser")
@@ -51,19 +51,19 @@ func (_m *UserConverter) GetUser(userid *userv1beta1.UserId) (*userv1beta1.User,
 
 	var r0 *userv1beta1.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*userv1beta1.UserId) (*userv1beta1.User, error)); ok {
-		return rf(userid)
+	if rf, ok := ret.Get(0).(func(context.Context, *userv1beta1.UserId) (*userv1beta1.User, error)); ok {
+		return rf(ctx, userid)
 	}
-	if rf, ok := ret.Get(0).(func(*userv1beta1.UserId) *userv1beta1.User); ok {
-		r0 = rf(userid)
+	if rf, ok := ret.Get(0).(func(context.Context, *userv1beta1.UserId) *userv1beta1.User); ok {
+		r0 = rf(ctx, userid)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*userv1beta1.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*userv1beta1.UserId) error); ok {
-		r1 = rf(userid)
+	if rf, ok := ret.Get(1).(func(context.Context, *userv1beta1.UserId) error); ok {
+		r1 = rf(ctx, userid)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -77,14 +77,15 @@ type UserConverter_GetUser_Call struct {
 }
 
 // GetUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userid *userv1beta1.UserId
-func (_e *UserConverter_Expecter) GetUser(userid interface{}) *UserConverter_GetUser_Call {
-	return &UserConverter_GetUser_Call{Call: _e.mock.On("GetUser", userid)}
+func (_e *UserConverter_Expecter) GetUser(ctx interface{}, userid interface{}) *UserConverter_GetUser_Call {
+	return &UserConverter_GetUser_Call{Call: _e.mock.On("GetUser", ctx, userid)}
 }
 
-func (_c *UserConverter_GetUser_Call) Run(run func(userid *userv1beta1.UserId)) *UserConverter_GetUser_Call {
+func (_c *UserConverter_GetUser_Call) Run(run func(ctx context.Context, userid *userv1beta1.UserId)) *UserConverter_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*userv1beta1.UserId))
+		run(args[0].(context.Context), args[1].(*userv1beta1.UserId))
 	})
 	return _c
 }
@@ -94,7 +95,7 @@ func (_c *UserConverter_GetUser_Call) Return(_a0 *userv1beta1.User, _a1 error) *
 	return _c
 }
 
-func (_c *UserConverter_GetUser_Call) RunAndReturn(run func(*userv1beta1.UserId) (*userv1beta1.User, error)) *UserConverter_GetUser_Call {
+func (_c *UserConverter_GetUser_Call) RunAndReturn(run func(context.Context, *userv1beta1.UserId) (*userv1beta1.User, error)) *UserConverter_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/share/manager/owncloudsql/owncloudsql.go
+++ b/pkg/share/manager/owncloudsql/owncloudsql.go
@@ -339,7 +339,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.Filter) (
 func (m *mgr) ListReceivedShares(ctx context.Context, filters []*collaboration.Filter, forUser *userpb.UserId) ([]*collaboration.ReceivedShare, error) {
 	user := ctxpkg.ContextMustGetUser(ctx)
 	if user.GetId().GetType() == userpb.UserType_USER_TYPE_SERVICE {
-		u, err := m.userConverter.GetUser(forUser)
+		u, err := m.userConverter.GetUser(ctx, forUser)
 		if err != nil {
 			return nil, errtypes.BadRequest("user not found")
 		}

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -71,14 +71,21 @@ func GetServiceUserToken(ctx context.Context, gwc gateway.GatewayAPIClient, serv
 }
 
 // GetUser gets the specified user
-// Deprecated: Use GetUserWithContext()
-func GetUser(userID *user.UserId, gwc gateway.GatewayAPIClient) (*user.User, error) {
-	return GetUserWithContext(context.Background(), userID, gwc)
+func GetUser(ctx context.Context, userID *user.UserId, gwc gateway.GatewayAPIClient) (*user.User, error) {
+	return getUser(ctx, userID, false, gwc)
 }
 
-// GetUserWithContext gets the specified user
-func GetUserWithContext(ctx context.Context, userID *user.UserId, gwc gateway.GatewayAPIClient) (*user.User, error) {
-	getUserResponse, err := gwc.GetUser(ctx, &user.GetUserRequest{UserId: userID})
+// GetUserNoGroups gets the specified user without expanding groupmemberships
+func GetUserNoGroups(ctx context.Context, userID *user.UserId, gwc gateway.GatewayAPIClient) (*user.User, error) {
+	return getUser(ctx, userID, true, gwc)
+}
+
+// getUser gets the specified user
+func getUser(ctx context.Context, userID *user.UserId, skipGroups bool, gwc gateway.GatewayAPIClient) (*user.User, error) {
+	getUserResponse, err := gwc.GetUser(ctx, &user.GetUserRequest{
+		UserId:                 userID,
+		SkipFetchingUserGroups: skipGroups,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Introduce and use new help GetUserNoGroups to allow skipping resolving group memberships, which can be costly.
- Rename GetUserWithContext() to GetUser() and fix callers to always pass a context.

Related: https://github.com/opencloud-eu/opencloud/issues/1005