### PR TITLE
Set 'oc:downloadURL' WebDAV property for "normal" files

### DIFF
--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -33,8 +33,6 @@ type Config struct {
 	ProductVersion              string                            `mapstructure:"product_version"`
 	AllowPropfindDepthInfinitiy bool                              `mapstructure:"allow_depth_infinity"`
 
-	TransferSharedSecret string `mapstructure:"transfer_shared_secret"`
-
 	NameValidation NameValidation `mapstructure:"validation"`
 
 	MachineAuthAPIKey string `mapstructure:"machine_auth_apikey"`

--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -35,6 +35,9 @@ type Config struct {
 
 	NameValidation NameValidation `mapstructure:"validation"`
 
+	// SharedSecret used to sign the 'oc:download' URLs
+	URLSigningSharedSecret string `mapstructure:"url_signing_shared_secret"`
+
 	MachineAuthAPIKey string `mapstructure:"machine_auth_apikey"`
 }
 

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -156,6 +156,7 @@ var _ = Describe("ocdav", func() {
 				MaxLength:    255,
 				InvalidChars: []string{"\f", "\r", "\n", "\\"},
 			},
+			URLSigningSharedSecret: "testsecret",
 		}
 		sel := selector{
 			client: client,

--- a/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
@@ -117,7 +117,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			},
 		}
 
-		handler = propfind.NewHandler("127.0.0.1:3000", sel, cfg)
+		handler = propfind.NewHandler("127.0.0.1:3000", sel, nil, cfg)
 
 		foospace = &sprovider.StorageSpace{
 			Opaque: &typesv1beta1.Opaque{
@@ -948,7 +948,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			},
 		}
 
-		handler = propfind.NewHandler("127.0.0.1:3000", sel, cfg)
+		handler = propfind.NewHandler("127.0.0.1:3000", sel, nil, cfg)
 
 		foospace = &sprovider.StorageSpace{
 			Opaque: &typesv1beta1.Opaque{

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -147,7 +147,7 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 	prefer := net.ParsePrefer(r.Header.Get("prefer"))
 	returnMinimal := prefer[net.HeaderPreferReturn] == "minimal"
 
-	propRes, err := propfind.MultistatusResponse(ctx, &pf, infos, s.c.PublicURL, ns, nil, returnMinimal)
+	propRes, err := propfind.MultistatusResponse(ctx, &pf, infos, s.c.PublicURL, ns, nil, returnMinimal, nil)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/report.go
+++ b/internal/http/services/owncloud/ocdav/report.go
@@ -117,7 +117,7 @@ func (s *svc) doFilterFiles(w http.ResponseWriter, r *http.Request, ff *reportFi
 		prefer := net.ParsePrefer(r.Header.Get("prefer"))
 		returnMinimal := prefer[net.HeaderPreferReturn] == "minimal"
 
-		responsesXML, err := propfind.MultistatusResponse(ctx, &propfind.XML{Prop: ff.Prop}, infos, s.c.PublicURL, namespace, nil, returnMinimal)
+		responsesXML, err := propfind.MultistatusResponse(ctx, &propfind.XML{Prop: ff.Prop}, infos, s.c.PublicURL, namespace, nil, returnMinimal, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("error formatting propfind")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -82,7 +82,7 @@ func (h *SpacesHandler) Handler(s *svc, trashbinHandler *TrashbinHandler) http.H
 		var err error
 		switch r.Method {
 		case MethodPropfind:
-			p := propfind.NewHandler(config.PublicURL, s.gatewaySelector, config)
+			p := propfind.NewHandler(config.PublicURL, s.gatewaySelector, s.urlSigner, config)
 			p.HandleSpacesPropfind(w, r, spaceID)
 		case MethodProppatch:
 			status, err = s.handleSpacesProppatch(w, r, spaceID)

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -200,7 +200,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 	prefer := net.ParsePrefer(r.Header.Get("prefer"))
 	returnMinimal := prefer[net.HeaderPreferReturn] == "minimal"
 
-	propRes, err := propfind.MultistatusResponse(ctx, &pf, infos, s.c.PublicURL, "", nil, returnMinimal)
+	propRes, err := propfind.MultistatusResponse(ctx, &pf, infos, s.c.PublicURL, "", nil, returnMinimal, nil)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -72,7 +72,7 @@ func (h *WebDavHandler) Handler(s *svc) http.Handler {
 		var status int // status 0 means the handler already sent the response
 		switch r.Method {
 		case MethodPropfind:
-			p := propfind.NewHandler(config.PublicURL, s.gatewaySelector, config)
+			p := propfind.NewHandler(config.PublicURL, s.gatewaySelector, s.urlSigner, config)
 			p.HandlePathPropfind(w, r, ns)
 		case MethodLock:
 			status, err = s.handleLock(w, r, ns)

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -401,3 +401,10 @@ func RegisterInterval(interval time.Duration) Option {
 		o.RegisterInterval = interval
 	}
 }
+
+// URLSigningSharedSecret provides a function to set the URLSigningSharedSecret config option.
+func URLSigningSharedSecret(secret string) Option {
+	return func(o *Options) {
+		o.config.URLSigningSharedSecret = secret
+	}
+}

--- a/pkg/signedurl/jwt.go
+++ b/pkg/signedurl/jwt.go
@@ -1,0 +1,116 @@
+package signedurl
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JWTSignedURL implements the Signer and Verifier interfaces using JWT for signing URLs.
+type JWTSignedURL struct {
+	JWTOptions
+}
+
+type claims struct {
+	TargetURL string `json:"target_url"`
+	jwt.RegisteredClaims
+}
+
+// JWTOption defines a single option function.
+type JWTOption func(o *JWTOptions)
+
+// JWTOptions defines the available options for this package.
+type JWTOptions struct {
+	secret     string // Secret key used for signing and verifying JWTs
+	queryParam string // Name of the query parameter for the signature
+}
+
+func NewJWTSignedURL(opts ...JWTOption) (*JWTSignedURL, error) {
+	opt := JWTOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	if opt.secret == "" {
+		return nil, ErrInvalidKey
+	}
+
+	if opt.queryParam == "" {
+		opt.queryParam = "oc-jwt-sig"
+	}
+
+	return &JWTSignedURL{opt}, nil
+}
+
+func WithSecret(secret string) JWTOption {
+	return func(o *JWTOptions) {
+		o.secret = secret
+	}
+}
+
+func WithQueryParam(queryParam string) JWTOption {
+	return func(o *JWTOptions) {
+		o.queryParam = queryParam
+	}
+}
+
+// Sign signs a URL using JWT with a specified time-to-live (ttl).
+func (j *JWTSignedURL) Sign(unsignedURL, subject string, ttl time.Duration) (string, error) {
+	// Re-encode the Query parameters to ensure they are "normalized" (Values.Encode() does return them alphabetically ordered).
+	u, err := url.Parse(unsignedURL)
+	if err != nil {
+		return "", NewSignedURLError(err, "failed to parse url")
+	}
+	query := u.Query()
+	u.RawQuery = query.Encode()
+	c := claims{
+		TargetURL: u.String(),
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
+			Issuer:    "reva",
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   subject,
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, c)
+	signedToken, err := token.SignedString([]byte(j.secret))
+	if err != nil {
+		return "", fmt.Errorf("signing failed: %w", err)
+	}
+	query.Set(j.queryParam, signedToken)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+// Verify verifies a signed URL using a JWT. Returns the subject of the JWT if verification is successful.
+func (j *JWTSignedURL) Verify(signedURL string) (string, error) {
+	u, err := url.Parse(signedURL)
+	if err != nil {
+		return "", NewSignatureVerificationError(fmt.Errorf("could not parse URL: %w", err))
+	}
+	query := u.Query()
+	tokenString := query.Get(j.queryParam)
+	if tokenString == "" {
+		return "", NewSignatureVerificationError(errors.New("no signature in url"))
+	}
+	token, err := jwt.ParseWithClaims(tokenString, &claims{}, func(token *jwt.Token) (any, error) { return []byte(j.secret), nil })
+	if err != nil {
+		return "", NewSignatureVerificationError(err)
+	}
+	c, ok := token.Claims.(*claims)
+	if !ok {
+		return "", NewSignatureVerificationError(errors.New("invalid JWT claims"))
+	}
+
+	query.Del(j.queryParam)
+	u.RawQuery = query.Encode()
+
+	if c.TargetURL != u.String() {
+		return "", NewSignatureVerificationError(errors.New("url mismatch"))
+	}
+
+	return c.Subject, nil
+}

--- a/pkg/signedurl/jwt_test.go
+++ b/pkg/signedurl/jwt_test.go
@@ -1,0 +1,111 @@
+package signedurl_test
+
+import (
+	"net/url"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opencloud-eu/reva/v2/pkg/signedurl"
+)
+
+var _ = Describe("JWTSignedURL", func() {
+	It("should create a new JWTSignedURL with a valid key", func() {
+		key := "my-secret-key"
+		jwtURL, err := signedurl.NewJWTSignedURL(signedurl.WithSecret(key), signedurl.WithQueryParam("sig"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(jwtURL).ToNot(BeNil())
+	})
+
+	It("should return an error when creating JWTSignedURL with an empty key", func() {
+		jwtURL, err := signedurl.NewJWTSignedURL(signedurl.WithQueryParam("sig"))
+		Expect(err).To(HaveOccurred())
+		Expect(jwtURL).To(BeNil())
+		Expect(err).To(Equal(signedurl.ErrInvalidKey))
+	})
+	Context("with a valid JWTSignedURL", func() {
+		var jwtURL *signedurl.JWTSignedURL
+		var unsignedURL string
+
+		BeforeEach(func() {
+			var err error
+			jwtURL, err = signedurl.NewJWTSignedURL(signedurl.WithSecret("my-secret-key"), signedurl.WithQueryParam("sig"))
+			Expect(err).ToNot(HaveOccurred())
+			unsignedURL = "https://example.com/resource"
+		})
+
+		It("should return a signed URL", func() {
+			signedURL, err := jwtURL.Sign(unsignedURL, "", 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			url, err := url.Parse(signedURL)
+			Expect(err).ToNot(HaveOccurred())
+			query := url.Query()
+			sig := query.Get("sig")
+			Expect(sig).ToNot(BeEmpty())
+			query.Del("sig")
+			url.RawQuery = query.Encode()
+			Expect(url.String()).To(Equal(unsignedURL))
+		})
+		It("should return an error when signing with an invalid URL", func() {
+			invalidURL := "ht tp:not-a-valid-url"
+			signedURL, err := jwtURL.Sign(invalidURL, "", 10*time.Minute)
+			Expect(err).To(HaveOccurred())
+			Expect(signedURL).To(BeEmpty())
+			Expect(err).To(MatchError(ContainSubstring("failed to parse url")))
+		})
+	})
+	Context("verifying a signed URL", func() {
+		var jwtURL *signedurl.JWTSignedURL
+		var unsignedURL string
+
+		BeforeEach(func() {
+			var err error
+			jwtURL, err = signedurl.NewJWTSignedURL(signedurl.WithSecret("my-secret-key"), signedurl.WithQueryParam("sig"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("fails if the signature is missing", func() {
+			unsignedURL = "https://example.com/resource"
+			_, err := jwtURL.Verify(unsignedURL)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(signedurl.SignatureVerificationError{}))
+		})
+		It("fails if the urls to not match", func() {
+			signedURL, err := jwtURL.Sign(unsignedURL, "", 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			u, err := url.Parse(signedURL)
+			Expect(err).ToNot(HaveOccurred())
+			q := u.Query()
+			q.Set("other", "value")
+			u.RawQuery = q.Encode()
+			_, err = jwtURL.Verify(u.String())
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(signedurl.SignatureVerificationError{}))
+			Expect(err).To(MatchError(ContainSubstring("url mismatch")))
+		})
+		It("fails if the jwt is expired", func() {
+			signedURL, err := jwtURL.Sign(unsignedURL, "", 1*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(3 * time.Second) // wait for the JWT to expire
+			_, err = jwtURL.Verify(signedURL)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(signedurl.SignatureVerificationError{}))
+			Expect(err).To(MatchError(ContainSubstring("token is expired")))
+		})
+		It("succeeds if the signature is ok", func() {
+			signedURL, err := jwtURL.Sign(unsignedURL, "", 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = jwtURL.Verify(signedURL)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("returns the subject of the JWT", func() {
+			subject := "subject-id"
+			signedURL, err := jwtURL.Sign(unsignedURL, subject, 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+			s, err := jwtURL.Verify(signedURL)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s).To(Equal(subject))
+		})
+
+	})
+})

--- a/pkg/signedurl/signedurl.go
+++ b/pkg/signedurl/signedurl.go
@@ -1,0 +1,64 @@
+// Package signedurl provides interfaces and implementations for signing and verifying URLs.
+package signedurl
+
+import (
+	"time"
+)
+
+type Signer interface {
+	// Sign signs a URL
+	Sign(url, principal string, ttl time.Duration) (string, error)
+}
+
+type Verifier interface {
+	// Verify verifies a signed URL
+	Verify(signedURL string) (string, error)
+}
+
+type SignedURLError struct {
+	innerErr error
+	message  string
+}
+
+// NewSignedURLError creates a new SignedURLError with the provided inner error and message.
+func NewSignedURLError(innerErr error, message string) SignedURLError {
+	return SignedURLError{
+		innerErr: innerErr,
+		message:  message,
+	}
+}
+
+var ErrInvalidKey = NewSignedURLError(nil, "invalid key provided")
+
+type SignatureVerificationError struct {
+	SignedURLError
+}
+
+func NewSignatureVerificationError(innerErr error) SignatureVerificationError {
+	return SignatureVerificationError{
+		SignedURLError: SignedURLError{
+			innerErr: innerErr,
+			message:  "signature verification failed",
+		},
+	}
+}
+
+func (e SignatureVerificationError) Is(tgt error) bool {
+	// Check if the target error is of type SignatureVerificationError
+	if _, ok := tgt.(SignatureVerificationError); ok {
+		return true
+	}
+	return false
+}
+
+// Error implements the error interface for errorConst.
+func (e SignedURLError) Error() string {
+	if e.innerErr != nil {
+		return e.message + ": " + e.innerErr.Error()
+	}
+	return e.message
+}
+
+func (e SignedURLError) Unwrap() error {
+	return e.innerErr
+}

--- a/pkg/signedurl/signedurl_suite_test.go
+++ b/pkg/signedurl/signedurl_suite_test.go
@@ -1,0 +1,13 @@
+package signedurl_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSignedurl(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Signedurl Suite")
+}

--- a/tests/integration/grpc/fixtures/ocm-share/cernbox-webdav-server.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/cernbox-webdav-server.toml
@@ -12,3 +12,4 @@ token_strategy = "bearer"
 
 [http.services.ocdav]
 ocm_namespace = "/public"
+url_signing_shared_secret = "change-me-please"

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
@@ -38,3 +38,4 @@ cache_store = "noop"
 
 
 [http.services.ocdav]
+url_signing_shared_secret = "change-me-please"

--- a/tests/oc-integration-tests/ci/frontend.toml
+++ b/tests/oc-integration-tests/ci/frontend.toml
@@ -50,6 +50,7 @@ files_namespace = "/users/{{.Id.OpaqueId}}"
 # - TODO android? no sync ... but will see different tree
 webdav_namespace = "/users/{{.Id.OpaqueId}}"
 machine_auth_apikey = "change-me-please"
+url_signing_shared_secret = "change-me-please"
 
 allow_depth_infinity = true
 


### PR DESCRIPTION
Up to now we only returned the `oc:downloadurl` property for resources shared via public link. This changes the ocdav service to also provide a  signed url for downloading "normal" files. 

