### PR TITLE
Fix read permissions crash

### DIFF
--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -1117,12 +1117,12 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap *pro
 			continue
 		}
 
-		if isGrantExpired(g) {
-			continue
-		}
-
 		switch {
 		case err == nil:
+			if isGrantExpired(g) {
+				continue
+			}
+
 			// If all permissions are set to false we have a deny grant
 			if grants.PermissionsEqual(g.Permissions, &provider.ResourcePermissions{}) {
 				return NoPermissions(), true, nil

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -1129,10 +1129,10 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap *pro
 			}
 			AddPermissions(ap, g.GetPermissions())
 		case metadata.IsAttrUnset(err):
-			appctx.GetLogger(ctx).Error().Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Str("grant", grantees[i]).Interface("grantees", grantees).Msg("grant vanished from node after listing")
+			appctx.GetLogger(ctx).Error().Err(err).Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Str("path", n.InternalPath()).Str("grant", grantees[i]).Interface("grantees", grantees).Msg("grant vanished from node after listing")
 			// continue with next segment
 		default:
-			appctx.GetLogger(ctx).Error().Err(err).Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Str("grant", grantees[i]).Msg("error reading permissions")
+			appctx.GetLogger(ctx).Error().Err(err).Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Str("path", n.InternalPath()).Str("grant", grantees[i]).Msg("error reading permissions")
 			// continue with next segment
 		}
 	}


### PR DESCRIPTION
This PR fixes a panic when a grant can not be read from disk successfully and improves logging of the root cause.