### PR TITLE
🎉 Release 2.29.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@ScharfViktor
+@ScharfViktor, @aduffeck
 
+### 🐛 Bug Fixes
 
+- Backport 2.29 fix read permissions crash [[#273](https://github.com/opencloud-eu/reva/pull/273)]
 
 ## [2.29.3](https://github.com/opencloud-eu/reva/releases/tag/v2.29.3) - 2025-05-02
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.29.4` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.29` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.29.4](https://github.com/opencloud-eu/reva/releases/tag/v2.29.4) - 2025-07-10

### 🐛 Bug Fixes

- Backport 2.29 fix read permissions crash [[#273](https://github.com/opencloud-eu/reva/pull/273)]