### PR TITLE
Properly reindex moved items

### DIFF
--- a/pkg/storage/fs/posix/tree/cephfswatcher.go
+++ b/pkg/storage/fs/posix/tree/cephfswatcher.go
@@ -98,11 +98,13 @@ func (w *CephFSWatcher) Watch(topic string) {
 			switch {
 			case mask&CEPH_MDS_NOTIFY_DELETE > 0:
 				err = w.tree.Scan(path, ActionDelete, isDir)
-			case mask&CEPH_MDS_NOTIFY_CREATE > 0 || mask&CEPH_MDS_NOTIFY_MOVED_TO > 0:
+			case mask&CEPH_MDS_NOTIFY_MOVED_TO > 0:
 				if ev.SrcMask > 0 {
 					// This is a move, clean up the old path
 					err = w.tree.Scan(filepath.Join(w.tree.options.WatchRoot, ev.SrcPath), ActionMoveFrom, isDir)
 				}
+				err = w.tree.Scan(path, ActionMove, isDir)
+			case mask&CEPH_MDS_NOTIFY_CREATE > 0:
 				err = w.tree.Scan(path, ActionCreate, isDir)
 			case mask&CEPH_MDS_NOTIFY_CLOSE_WRITE > 0:
 				err = w.tree.Scan(path, ActionUpdate, isDir)

--- a/pkg/storage/fs/posix/tree/inotifywatcher.go
+++ b/pkg/storage/fs/posix/tree/inotifywatcher.go
@@ -92,7 +92,9 @@ func (iw *InotifyWatcher) Watch(path string) {
 						err = iw.tree.Scan(event.Filename, ActionDelete, event.IsDir)
 					case inotifywaitgo.MOVED_FROM:
 						err = iw.tree.Scan(event.Filename, ActionMoveFrom, event.IsDir)
-					case inotifywaitgo.CREATE, inotifywaitgo.MOVED_TO:
+					case inotifywaitgo.MOVED_TO:
+						err = iw.tree.Scan(event.Filename, ActionMove, event.IsDir)
+					case inotifywaitgo.CREATE:
 						err = iw.tree.Scan(event.Filename, ActionCreate, event.IsDir)
 					case inotifywaitgo.CLOSE_WRITE:
 						err = iw.tree.Scan(event.Filename, ActionUpdate, event.IsDir)


### PR DESCRIPTION
Treating them like created items can lead to cases where the item-assimilation is skipped because the parent directory assimilation is already pending. But directory assimilation isn't able to detect moved items, only new ones, and so the moved file would be left with old metadata.

Fixes opencloud-eu/opencloud#1100