### PR TITLE
ocdav: Make the url signer optional for now

### DIFF
--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -119,9 +119,13 @@ func NewWith(conf *config.Config, fm favorite.Manager, ls LockSystem, _ *zerolog
 	// be safe - init the conf again
 	conf.Init()
 
-	signer, err := signedurl.NewJWTSignedURL(signedurl.WithSecret(conf.URLSigningSharedSecret))
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize URL signer: %w", err)
+	var signer signedurl.Signer
+	if conf.URLSigningSharedSecret != "" {
+		var err error
+		signer, err = signedurl.NewJWTSignedURL(signedurl.WithSecret(conf.URLSigningSharedSecret))
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize URL signer: %w", err)
+		}
 	}
 
 	s := &svc{


### PR DESCRIPTION
When started without a signing secret just don't create signed url. Enforcing a secret now would mean that we'd break updates from older releases. We can think about that once the clients actually require the `oc:downloadURL` property.