### PR TITLE
log middleware: Implement Unwrap() method

### DIFF
--- a/internal/http/interceptors/log/log.go
+++ b/internal/http/interceptors/log/log.go
@@ -130,6 +130,7 @@ type commonLoggingResponseWriter interface {
 	http.Flusher
 	Status() int
 	Size() int
+	Unwrap() http.ResponseWriter
 }
 
 // responseLogger is wrapper of http.ResponseWriter that keeps track of its HTTP
@@ -168,6 +169,10 @@ func (l *responseLogger) Flush() {
 	if ok {
 		f.Flush()
 	}
+}
+
+func (l *responseLogger) Unwrap() http.ResponseWriter {
+	return l.w
 }
 
 type hijackLogger struct {


### PR DESCRIPTION
The tusd http.Handler uses the SetReadDeadline and SetWriteDeadline methods of the  net/http.NewResponseController API. For that to work it needs access to the underlying ResponseWriter that implement these calls. This is achieve by implementing the "Unwrap" method http.Handlers that implement wrappers for the underlying ResponseWriter. (See:
https://tus.github.io/tusd/advanced-topics/usage-package/#i-am-getting-warnings-regarding-networkcontrolerrornetworktimeouterror-and-feature-not-supported-why)

Fixes: https://github.com/opencloud-eu/opencloud/issues/713