### PR TITLE
Fix the reference sent in ItemPurged events

### DIFF
--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -19,6 +19,7 @@
 package eventsmiddleware
 
 import (
+	"strings"
 	"time"
 
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
@@ -28,6 +29,7 @@ import (
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/opencloud-eu/reva/v2/pkg/events"
+	"github.com/opencloud-eu/reva/v2/pkg/rhttp/router"
 	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 )
@@ -295,9 +297,23 @@ func ItemMoved(r *provider.MoveResponse, req *provider.MoveRequest, spaceOwner *
 
 // ItemPurged converts the response to an event
 func ItemPurged(r *provider.PurgeRecycleResponse, req *provider.PurgeRecycleRequest, executant *user.User) events.ItemPurged {
+	root, relativePath := router.ShiftPath(req.Key)
+	if relativePath == "/" && !strings.HasSuffix(req.Key, "/") {
+		relativePath = ""
+	}
+
+	ref := &provider.Reference{
+		ResourceId: &provider.ResourceId{
+			StorageId: req.Ref.GetResourceId().GetStorageId(),
+			SpaceId:   req.Ref.GetResourceId().GetSpaceId(),
+			OpaqueId:  root,
+		},
+		Path: relativePath,
+	}
+
 	return events.ItemPurged{
 		Executant:         executant.GetId(),
-		Ref:               req.Ref,
+		Ref:               ref,
 		Timestamp:         utils.TSNow(),
 		ImpersonatingUser: extractImpersonator(executant),
 	}


### PR DESCRIPTION
It was referring to the space root instead of the purged item until now.