### PR TITLE
fix(posixfs): Ignore Events for Spaceroots

### DIFF
--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -659,7 +659,16 @@ assimilate:
 
 	var n *node.Node
 	if fi.IsDir() {
-		attributes.SetInt64(prefixes.TypeAttr, int64(provider.ResourceType_RESOURCE_TYPE_CONTAINER))
+		// The Space's name attribute might not match the directory name. Use the name as
+		// it was set before. Also the space root doesn't have a 'type' attribute
+		// currently so only set it for normal directories.
+		if t.isSpaceRoot(path) {
+			if previousAttribs != nil && previousAttribs[prefixes.NameAttr] != nil {
+				attributes[prefixes.NameAttr] = previousAttribs[prefixes.NameAttr]
+			}
+		} else {
+			attributes.SetInt64(prefixes.TypeAttr, int64(provider.ResourceType_RESOURCE_TYPE_CONTAINER))
+		}
 		attributes.SetInt64(prefixes.TreesizeAttr, 0)
 		if previousAttribs != nil && previousAttribs[prefixes.TreesizeAttr] != nil {
 			attributes[prefixes.TreesizeAttr] = previousAttribs[prefixes.TreesizeAttr]

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -720,7 +720,7 @@ func (t *Tree) createDirNode(ctx context.Context, n *node.Node) (err error) {
 }
 
 func (t *Tree) isIgnored(path string) bool {
-	return isLockFile(path) || isTrash(path) || t.isUpload(path) || t.isInternal(path) || t.isRootPath(path)
+	return isLockFile(path) || isTrash(path) || t.isUpload(path) || t.isInternal(path) || t.isRootPath(path) || t.isSpaceRoot(path)
 }
 
 func (t *Tree) isUpload(path string) bool {
@@ -735,6 +735,11 @@ func (t *Tree) isRootPath(path string) bool {
 	return path == t.options.Root ||
 		path == t.personalSpacesRoot ||
 		path == t.projectSpacesRoot
+}
+
+func (t *Tree) isSpaceRoot(path string) bool {
+	parent := filepath.Dir(path)
+	return parent == t.personalSpacesRoot || parent == t.projectSpacesRoot
 }
 
 func (t *Tree) isInternal(path string) bool {


### PR DESCRIPTION
Events on the Spaceroots where treated like events on normal directories. This caused various issues. Especially when for the personal spaces root

Fixes: https://github.com/opencloud-eu/opencloud/issues/1368