### PR TITLE
feat: tracing instrumentation of for users and groups services

### DIFF
--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -108,7 +108,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 
 	filter := am.getLoginFilter(clientID)
 
-	userEntry, err := am.c.LDAPIdentity.GetLDAPUserByFilter(log, am.ldapClient, filter)
+	userEntry, err := am.c.LDAPIdentity.GetLDAPUserByFilter(ctx, am.ldapClient, filter)
 
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Adds some tracing to LDAP manager for the users and groups service. Include filters and other LDAP parameters into the traces.