### PR TITLE
users: Multi-Tenancy enhancements

### DIFF
--- a/examples/plugin/json/json.go
+++ b/examples/plugin/json/json.go
@@ -82,6 +82,9 @@ func (m *Manager) Configure(ml map[string]interface{}) error {
 
 // GetUser returns the user based on the uid.
 func (m *Manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported")
+	}
 	for _, u := range m.users {
 		if (u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId) && (uid.Idp == "" || uid.Idp == u.Id.GetIdp()) {
 			user := *u
@@ -95,7 +98,10 @@ func (m *Manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 }
 
 // GetUserByClaim returns user based on the claim
-func (m *Manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *Manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported")
+	}
 	for _, u := range m.users {
 		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
 			user := *u

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -224,6 +224,9 @@ func (m *manager) parseAndCacheUser(ctx context.Context, userData map[string]int
 }
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in rest user manager")
+	}
 	u, err := m.fetchCachedUserDetails(uid)
 	if err != nil {
 		return nil, err
@@ -240,7 +243,10 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 	return u, nil
 }
 
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in rest user manager")
+	}
 	u, err := m.fetchCachedUserByParam(claim, value)
 	if err != nil {
 		return nil, err

--- a/pkg/user/manager/demo/demo.go
+++ b/pkg/user/manager/demo/demo.go
@@ -57,7 +57,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
 	if user, ok := m.catalog[uid.OpaqueId]; ok {
-		if uid.Idp == "" || user.Id.Idp == uid.Idp {
+		if user.GetId().GetTenantId() == uid.GetTenantId() && (uid.Idp == "" || user.Id.Idp == uid.Idp) {
 			u := proto.Clone(user).(*userpb.User)
 			if skipFetchingGroups {
 				u.Groups = nil
@@ -68,9 +68,9 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.catalog {
-		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
+		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim && tenantID == u.Id.TenantId {
 			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil

--- a/pkg/user/manager/demo/demo_test.go
+++ b/pkg/user/manager/demo/demo_test.go
@@ -66,26 +66,26 @@ func TestUserManager(t *testing.T) {
 	groupsEinstein := []string{"sailing-lovers", "violin-haters", "physics-lovers"}
 
 	// positive test GetUserByClaim by uid
-	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123", false)
+	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123", "c239389d-c249-499d-ae80-07558429769a", false)
 	if !proto.Equal(resUserByUID, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByUID)
 	}
 
 	// negative test GetUserByClaim by uid
 	expectedErr := errtypes.NotFound("789")
-	_, err := manager.GetUserByClaim(ctx, "uid", "789", false)
+	_, err := manager.GetUserByClaim(ctx, "uid", "789", "c239389d-c249-499d-ae80-07558429769a", false)
 	if !reflect.DeepEqual(err, expectedErr) {
 		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
 	// positive test GetUserByClaim by mail
-	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", false)
+	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", "c239389d-c249-499d-ae80-07558429769a", false)
 	if !proto.Equal(resUserByEmail, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
 	// positive test GetUserByClaim by uid without groups
-	resUserByUIDWithoutGroups, _ := manager.GetUserByClaim(ctx, "uid", "123", true)
+	resUserByUIDWithoutGroups, _ := manager.GetUserByClaim(ctx, "uid", "123", "c239389d-c249-499d-ae80-07558429769a", true)
 	if !proto.Equal(resUserByUIDWithoutGroups, userEinsteinWithoutGroups) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinsteinWithoutGroups, resUserByUIDWithoutGroups)
 	}

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -97,7 +97,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.users {
-		if (u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId) && (uid.Idp == "" || uid.Idp == u.Id.GetIdp()) {
+		if (u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId) && (uid.Idp == "" || uid.Idp == u.Id.GetIdp()) && (uid.GetTenantId() == u.Id.GetTenantId()) {
 			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
@@ -108,9 +108,9 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.users {
-		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
+		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim && tenantID == u.Id.TenantId {
 			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -114,20 +114,20 @@ func TestUserManager(t *testing.T) {
 	}
 
 	// positive test GetUserByClaim by mail
-	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", false)
+	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", "", false)
 	if !proto.Equal(resUserByEmail, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
 	// negative test GetUserByClaim by mail
 	expectedErr = errtypes.NotFound("abc@example.com")
-	_, err = manager.GetUserByClaim(ctx, "mail", "abc@example.com", false)
+	_, err = manager.GetUserByClaim(ctx, "mail", "abc@example.com", "", false)
 	if !reflect.DeepEqual(err, expectedErr) {
 		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
 	// positive test GetUserByClaim by mail without groups
-	resUserByEmailWithoutGroups, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", true)
+	resUserByEmailWithoutGroups, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", "", true)
 	if !proto.Equal(resUserByEmailWithoutGroups, userEinsteinWithoutGroups) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinsteinWithoutGroups, resUserByEmailWithoutGroups)
 	}

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -114,7 +114,7 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 		return nil, errtypes.NotFound("idp mismatch")
 	}
 
-	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByID(ctx, m.ldapClient, uid.OpaqueId)
+	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByID(ctx, m.ldapClient, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 
 // GetUserByClaim implements the user.Manager interface. Looks up a user by
 // claim ('mail', 'username', 'userid') and returns the user.
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
 	log := appctx.GetLogger(ctx)
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetUserByClaim")
 	defer span.End()
@@ -152,7 +152,7 @@ func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipF
 		attribute.Bool("parameter.skipFetchingGroups", skipFetchingGroups),
 	)
 	log.Debug().Str("claim", claim).Str("value", value).Msg("GetUserByClaim")
-	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByAttribute(ctx, m.ldapClient, claim, value)
+	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByAttribute(ctx, m.ldapClient, claim, value, tenantID)
 	if err != nil {
 		log.Debug().Err(err).Msg("GetUserByClaim")
 		return nil, err
@@ -228,7 +228,7 @@ func (m *manager) GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]stri
 		log.Debug().Str("useridp", uid.Idp).Str("configured idp", m.c.Idp).Msg("IDP mismatch")
 		return nil, errtypes.NotFound("idp mismatch")
 	}
-	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByID(ctx, m.ldapClient, uid.OpaqueId)
+	userEntry, err := m.c.LDAPIdentity.GetLDAPUserByID(ctx, m.ldapClient, uid)
 	if err != nil {
 		log.Debug().Err(err).Interface("userid", uid).Msg("Failed to lookup user")
 		return []string{}, err

--- a/pkg/user/manager/memory/memory.go
+++ b/pkg/user/manager/memory/memory.go
@@ -84,6 +84,9 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in memory user manager")
+	}
 	if user, ok := m.catalog[uid.OpaqueId]; ok {
 		if uid.Idp == "" || user.ID.Idp == uid.Idp {
 			u := *user
@@ -106,7 +109,11 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in memory user manager")
+	}
+
 	for _, u := range m.catalog {
 		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
 			user := &userpb.User{

--- a/pkg/user/manager/memory/memory_test.go
+++ b/pkg/user/manager/memory/memory_test.go
@@ -73,26 +73,26 @@ func TestUserManager(t *testing.T) {
 	groupsEinstein := []string{"sailing-lovers", "violin-haters", "physics-lovers"}
 
 	// positive test GetUserByClaim by uid
-	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123", false)
+	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123", "", false)
 	if !reflect.DeepEqual(resUserByUID, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByUID)
 	}
 
 	// negative test GetUserByClaim by uid
 	expectedErr := errtypes.NotFound("789")
-	_, err := manager.GetUserByClaim(ctx, "uid", "789", false)
+	_, err := manager.GetUserByClaim(ctx, "uid", "789", "", false)
 	if !reflect.DeepEqual(err, expectedErr) {
 		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
 	// positive test GetUserByClaim by mail
-	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", false)
+	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", "", false)
 	if !reflect.DeepEqual(resUserByEmail, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
 	// positive test GetUserByClaim by uid without groups
-	resUserByUIDWithoutGroups, _ := manager.GetUserByClaim(ctx, "uid", "123", true)
+	resUserByUIDWithoutGroups, _ := manager.GetUserByClaim(ctx, "uid", "123", "", true)
 	if !reflect.DeepEqual(resUserByUIDWithoutGroups, userEinsteinWithoutGroups) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinsteinWithoutGroups, resUserByUIDWithoutGroups)
 	}

--- a/pkg/user/manager/nextcloud/nextcloud.go
+++ b/pkg/user/manager/nextcloud/nextcloud.go
@@ -151,6 +151,9 @@ func (um *Manager) Configure(ml map[string]interface{}) error {
 
 // GetUser method as defined in https://github.com/cs3org/reva/blob/v1.13.0/pkg/user/user.go#L29-L35
 func (um *Manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in nextcloud user manager")
+	}
 	bodyStr, _ := json.Marshal(uid)
 	_, respBody, err := um.do(ctx, Action{"GetUser", string(bodyStr)}, "unauthenticated")
 	if err != nil {
@@ -165,7 +168,10 @@ func (um *Manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetching
 }
 
 // GetUserByClaim method as defined in https://github.com/cs3org/reva/blob/v1.13.0/pkg/user/user.go#L29-L35
-func (um *Manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (um *Manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in nextcloud user manager")
+	}
 	type paramsObj struct {
 		Claim string `json:"claim"`
 		Value string `json:"value"`

--- a/pkg/user/manager/nextcloud/nextcloud_test.go
+++ b/pkg/user/manager/nextcloud/nextcloud_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Nextcloud", func() {
 			um, called, teardown := setUpNextcloudServer()
 			defer teardown()
 
-			user, err := um.GetUserByClaim(ctx, "claim-string", "value-string", false)
+			user, err := um.GetUserByClaim(ctx, "claim-string", "value-string", "", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(user).To(Equal(&userpb.User{
 				Id: &userpb.UserId{

--- a/pkg/user/manager/owncloudsql/owncloudsql.go
+++ b/pkg/user/manager/owncloudsql/owncloudsql.go
@@ -103,6 +103,9 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in opencloudsql user manager")
+	}
 	// search via the user_id
 	a, err := m.db.GetAccountByClaim(ctx, "userid", uid.OpaqueId)
 	if err == sql.ErrNoRows {
@@ -111,7 +114,11 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 	return m.convertToCS3User(ctx, a, skipFetchingGroups)
 }
 
-func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in opencloudsql user manager")
+	}
+
 	a, err := m.db.GetAccountByClaim(ctx, claim, value)
 	if err == sql.ErrNoRows {
 		return nil, errtypes.NotFound(claim + "=" + value)

--- a/pkg/user/rpc_user.go
+++ b/pkg/user/rpc_user.go
@@ -89,6 +89,9 @@ type GetUserReply struct {
 
 // GetUser RPCClient GetUser method
 func (m *RPCClient) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
+	if uid.GetTenantId() != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in rpc_user user manager")
+	}
 	ctxVal := appctx.GetKeyValuesFromCtx(ctx)
 	args := GetUserArg{Ctx: ctxVal, UID: uid, SkipFetchingGroups: skipFetchingGroups}
 	resp := GetUserReply{}
@@ -114,7 +117,11 @@ type GetUserByClaimReply struct {
 }
 
 // GetUserByClaim RPCClient GetUserByClaim method
-func (m *RPCClient) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
+func (m *RPCClient) GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error) {
+	if tenantID != "" {
+		return nil, errtypes.NotSupported("tenant filter not supported in rpc_user user manager")
+	}
+
 	ctxVal := appctx.GetKeyValuesFromCtx(ctx)
 	args := GetUserByClaimArg{Ctx: ctxVal, Claim: claim, Value: value, SkipFetchingGroups: skipFetchingGroups}
 	resp := GetUserByClaimReply{}
@@ -200,7 +207,7 @@ func (m *RPCServer) GetUser(args GetUserArg, resp *GetUserReply) error {
 // GetUserByClaim RPCServer GetUserByClaim method
 func (m *RPCServer) GetUserByClaim(args GetUserByClaimArg, resp *GetUserByClaimReply) error {
 	ctx := appctx.PutKeyValuesToCtx(args.Ctx)
-	resp.User, resp.Err = m.Impl.GetUserByClaim(ctx, args.Claim, args.Value, args.SkipFetchingGroups)
+	resp.User, resp.Err = m.Impl.GetUserByClaim(ctx, args.Claim, args.Value, "", args.SkipFetchingGroups)
 	return nil
 }
 

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -33,7 +33,7 @@ type Manager interface {
 	// and might involve computational overhead.
 	GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error)
 	// GetUserByClaim returns the user identified by a specific value for a given claim.
-	GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error)
+	GetUserByClaim(ctx context.Context, claim, value, tenantID string, skipFetchingGroups bool) (*userpb.User, error)
 	// GetUserGroups returns the groups a user identified by a uid belongs to.
 	GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]string, error)
 	// FindUsers returns all the user objects which match a query parameter.

--- a/tests/integration/grpc/userprovider_test.go
+++ b/tests/integration/grpc/userprovider_test.go
@@ -52,6 +52,7 @@ var _ = Describe("user providers", func() {
 			Id: &userpb.UserId{
 				Idp:      existingIdp,
 				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+				TenantId: "c239389d-c249-499d-ae80-07558429769a",
 				Type:     userpb.UserType_USER_TYPE_PRIMARY,
 			},
 		}


### PR DESCRIPTION
This makes the remain calls of the users service tenancy aware. Also fixes a bug where the tenantId was not set correctly on the result set.