### PR TITLE
[tests-only][full-ci] Bump latest opencloud commit id on main branch

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=56c387cfa03b433f3825acf01506d3ffe51c80a0
+APITESTS_COMMITID=0410c150a010ecdf540aa4a3a64a92915c93da97
 APITESTS_BRANCH=main
 APITESTS_REPO_GIT_URL=https://github.com/opencloud-eu/opencloud


### PR DESCRIPTION
## Description
Bump latest opencloud `main` branch commit id.