### PR TITLE
feat(multi-tenancy): Introduce global config flag

### DIFF
--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -150,7 +150,10 @@ func NewUnary(m map[string]interface{}, unprotected []string, tp trace.TracerPro
 			log.Warn().Err(err).Msg("access token is invalid")
 			return nil, status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
 		}
-
+		if sharedconf.MultiTenantEnabled() && u.GetId().GetTenantId() == "" {
+			log.Warn().Msg("user has no tenant id, rejecting request")
+			return nil, status.Errorf(codes.PermissionDenied, "auth: user has no tenant id, rejecting request")
+		}
 		// store user and scopes in context
 		ctx = ctxpkg.ContextSetUser(ctx, u)
 		ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -42,6 +42,7 @@ type conf struct {
 	GatewaySVC            string        `mapstructure:"gatewaysvc"`
 	DataGateway           string        `mapstructure:"datagateway"`
 	SkipUserGroupsInToken bool          `mapstructure:"skip_user_groups_in_token"`
+	MultiTenantEnabled    bool          `mapstructure:"multi_tenant_enabled"`
 	GRPCClientOptions     ClientOptions `mapstructure:"grpc_client_options"`
 }
 
@@ -105,6 +106,11 @@ func GetDataGateway(val string) string {
 // SkipUserGroupsInToken returns whether to skip encoding user groups in the access tokens.
 func SkipUserGroupsInToken() bool {
 	return sharedConf.SkipUserGroupsInToken
+}
+
+// MultiTenantEnabled returns whether this is a mulit-tenant enabled configuratio
+func MultiTenantEnabled() bool {
+	return sharedConf.MultiTenantEnabled
 }
 
 // GRPCClientOptions returns the global grpc client options

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
@@ -178,6 +179,16 @@ func (i *Identity) Setup() error {
 	case "", "none":
 	default:
 		return fmt.Errorf("invalid disable mechanism setting: %s", i.User.DisableMechanism)
+	}
+
+	if sharedconf.MultiTenantEnabled() {
+		if i.User.Schema.TenantID == "" {
+			return fmt.Errorf("Invalid configuration: a 'tenantId' user schema attribute must be defined for multi-tenant setups")
+		}
+	} else {
+		if i.User.Schema.TenantID != "" {
+			return fmt.Errorf("Invalid configuration: Superfluous 'tenantId' user schema attribute defined for single-tenant setups")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
For now this flag is used in the auth middlewares to reject tokens for users that do not have a tenant id assigned.
Also the ldap user manager refuses to start when not attribute mapping is defined for the tenantid

Related: https://github.com/opencloud-eu/opencloud/issues/1458