### PR TITLE
fix: Hex length of sha256 is 64, remove [:240]

### DIFF
--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -399,7 +399,7 @@ func (t *Tree) generateTempNodeId(path string) string {
 		return strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", "-")
 	} else {
 		// Use sha256 if path too long
-		pathHash := fmt.Sprintf("%x", sha256.Sum256([]byte(path)))[:240]
+		pathHash := fmt.Sprintf("%x", sha256.Sum256([]byte(path)))
 		t.log.Info().Str("path", path).Msg("path too long, using sha256 as lock: " + pathHash)
 		return pathHash
 	}


### PR DESCRIPTION
I'm really sorry to open another PR to fix a mistake in my [previous PR](https://github.com/opencloud-eu/reva/pull/352). Cuz the hex length of sha256 is actually 64 therefore the [:240] is causing a panic. I'm removing the trim operation so that it actually works. Thank you very much.