### PR TITLE
feat: add cssVariables param to app provider open request

### DIFF
--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -412,6 +412,10 @@ func (s *svc) handleOpen(openMode int) http.HandlerFunc {
 		if templateID != "" {
 			openReq.Opaque = utils.AppendPlainToOpaque(openReq.Opaque, "template", templateID)
 		}
+		cssVariables := r.Form.Get("css_variables")
+		if cssVariables != "" {
+			openReq.Opaque = utils.AppendPlainToOpaque(openReq.Opaque, "cssVariables", cssVariables)
+		}
 		openRes, err := client.OpenInApp(ctx, &openReq)
 		if err != nil {
 			writeError(w, r, appErrorServerError,


### PR DESCRIPTION
This is needed so the web client can specify css variables for styling app providers such as Collabora.

refs https://github.com/opencloud-eu/web/issues/516