### PR TITLE
🎉 Release 2.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.39.1](https://github.com/opencloud-eu/reva/releases/tag/v2.39.1) - 2025-10-24
+## [2.39.1](https://github.com/opencloud-eu/reva/releases/tag/v2.39.1) - 2025-10-27
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,7 @@
 
 ### 📦️ Dependencies
 
+- chore(deps): bump golang.org/x/oauth2 from 0.31.0 to 0.32.0 [[#392](https://github.com/opencloud-eu/reva/pull/392)]
 - chore(deps): bump golang.org/x/text from 0.29.0 to 0.30.0 [[#389](https://github.com/opencloud-eu/reva/pull/389)]
 - chore(deps): bump golang.org/x/term from 0.35.0 to 0.36.0 [[#375](https://github.com/opencloud-eu/reva/pull/375)]
 - chore(deps): bump google.golang.org/grpc from 1.75.1 to 1.76.0 [[#373](https://github.com/opencloud-eu/reva/pull/373)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.39.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.39.1](https://github.com/opencloud-eu/reva/releases/tag/v2.39.1) - 2025-10-27

### 📦️ Dependencies

- chore(deps): bump golang.org/x/oauth2 from 0.31.0 to 0.32.0 [[#392](https://github.com/opencloud-eu/reva/pull/392)]
- chore(deps): bump golang.org/x/text from 0.29.0 to 0.30.0 [[#389](https://github.com/opencloud-eu/reva/pull/389)]
- chore(deps): bump golang.org/x/term from 0.35.0 to 0.36.0 [[#375](https://github.com/opencloud-eu/reva/pull/375)]
- chore(deps): bump google.golang.org/grpc from 1.75.1 to 1.76.0 [[#373](https://github.com/opencloud-eu/reva/pull/373)]