### PR TITLE
Bugfix: Fix the OCM WebDAV protocol entity mismatch

### DIFF
--- a/changelog/unreleased/fix-ocm-webdav.md
+++ b/changelog/unreleased/fix-ocm-webdav.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the OCM WebDAV protocol entity mismatch
+
+Fixed the OCM WebDAV protocol entity mismatch
+
+https://github.com/opencloud-eu/reva/pull/382

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -186,7 +186,7 @@ func (s *service) getWebdavProtocol(ctx context.Context, share *ocm.Share, m *oc
 
 	return &ocmd.WebDAV{
 		Permissions:  perms,
-		URL:          s.webdavURL(ctx, share),
+		URI:          s.webdavURL(ctx, share),
 		SharedSecret: share.Token,
 	}
 }

--- a/internal/http/services/ocmd/protocols.go
+++ b/internal/http/services/ocmd/protocols.go
@@ -47,7 +47,37 @@ type Protocol interface {
 type WebDAV struct {
 	SharedSecret string   `json:"sharedSecret" validate:"required"`
 	Permissions  []string `json:"permissions" validate:"required,dive,required,oneof=read write share"`
-	URL          string   `json:"url" validate:"required"`
+	URI          string   `json:"uri" validate:"required"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for backward compatibility.
+// It supports both "url" (legacy) and "uri" (new) field names.
+func (w *WebDAV) UnmarshalJSON(data []byte) error {
+	// Define a temporary struct with both url and uri fields
+	type WebDAVAlias struct {
+		SharedSecret string   `json:"sharedSecret"`
+		Permissions  []string `json:"permissions"`
+		URL          string   `json:"url"`
+		URI          string   `json:"uri"`
+	}
+
+	var alias WebDAVAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	// Copy common fields
+	w.SharedSecret = alias.SharedSecret
+	w.Permissions = alias.Permissions
+
+	// Use URI if present, otherwise fall back to URL for backward compatibility
+	if alias.URI != "" {
+		w.URI = alias.URI
+	} else {
+		w.URI = alias.URL
+	}
+
+	return nil
 }
 
 // ToOCMProtocol convert the protocol to a ocm Protocol struct.
@@ -76,7 +106,7 @@ func (w *WebDAV) ToOCMProtocol() *ocm.Protocol {
 		}
 	}
 
-	return ocmshare.NewWebDAVProtocol(w.URL, w.SharedSecret, perms)
+	return ocmshare.NewWebDAVProtocol(w.URI, w.SharedSecret, perms)
 }
 
 // Webapp contains the parameters for the Webapp protocol.

--- a/internal/http/services/ocmd/protocols_test.go
+++ b/internal/http/services/ocmd/protocols_test.go
@@ -49,12 +49,22 @@ func TestUnmarshalProtocol(t *testing.T) {
 			err: "protocol unsupported not recognised",
 		},
 		{
+			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"uri":"http://example.org"}}`,
+			expected: []Protocol{
+				&WebDAV{
+					SharedSecret: "secret",
+					Permissions:  []string{"read", "write"},
+					URI:          "http://example.org",
+				},
+			},
+		},
+		{
 			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"url":"http://example.org"}}`,
 			expected: []Protocol{
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read", "write"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 			},
 		},
@@ -82,7 +92,25 @@ func TestUnmarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read", "write"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
+				},
+				&Webapp{
+					URITemplate: "http://example.org/{test}",
+				},
+				&Datatx{
+					SharedSecret: "secret",
+					SourceURI:    "http://example.org",
+					Size:         10,
+				},
+			},
+		},
+		{
+			raw: `{"name":"multi","options":{},"webdav":{"sharedSecret":"secret","permissions":["read","write"],"uri":"http://example.org"},"webapp":{"uriTemplate":"http://example.org/{test}"},"datatx":{"sharedSecret":"secret","srcUri":"http://example.org","size":10}}`,
+			expected: []Protocol{
+				&WebDAV{
+					SharedSecret: "secret",
+					Permissions:  []string{"read", "write"},
+					URI:          "http://example.org",
 				},
 				&Webapp{
 					URITemplate: "http://example.org/{test}",
@@ -145,7 +173,7 @@ func TestMarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 			},
 			expected: map[string]any{
@@ -154,7 +182,7 @@ func TestMarshalProtocol(t *testing.T) {
 				"webdav": map[string]any{
 					"sharedSecret": "secret",
 					"permissions":  []any{"read"},
-					"url":          "http://example.org",
+					"uri":          "http://example.org",
 				},
 			},
 		},
@@ -197,7 +225,7 @@ func TestMarshalProtocol(t *testing.T) {
 				&WebDAV{
 					SharedSecret: "secret",
 					Permissions:  []string{"read"},
-					URL:          "http://example.org",
+					URI:          "http://example.org",
 				},
 				&Webapp{
 					URITemplate: "http://example.org",
@@ -215,7 +243,7 @@ func TestMarshalProtocol(t *testing.T) {
 				"webdav": map[string]any{
 					"sharedSecret": "secret",
 					"permissions":  []any{"read"},
-					"url":          "http://example.org",
+					"uri":          "http://example.org",
 				},
 				"webapp": map[string]any{
 					"uriTemplate": "http://example.org",


### PR DESCRIPTION
Fixed https://github.com/opencloud-eu/opencloud/issues/1672 the OCM WebDAV protocol entity mismatch

`url` -> `uri`


``` json
"protocol": {
    "name": "multi",
    "options": {},
    "webdav": {
      "sharedSecret": "redact",
      "permissions": [
        "read"
      ],
      "uri": "https://1.opencloud.cloud.test.azadehafzar.io/dav/ocm/redact"
    }
  }
```