### PR TITLE
🎉 Release 2.39.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@butonic, @micbar, @rhafer
+@JammingBen, @butonic, @micbar, @rhafer
 
 ### 🐛 Bug Fixes
 
+- fix: signed URLs containing a hash [[#415](https://github.com/opencloud-eu/reva/pull/415)]
 - fix metadata locking [[#411](https://github.com/opencloud-eu/reva/pull/411)]
 - fix: isTemporary() check for absolute paths [[#406](https://github.com/opencloud-eu/reva/pull/406)]
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.39.2` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.39.2](https://github.com/opencloud-eu/reva/releases/tag/v2.39.2) - 2025-11-12

### 🐛 Bug Fixes

- fix: signed URLs containing a hash [[#415](https://github.com/opencloud-eu/reva/pull/415)]
- fix metadata locking [[#411](https://github.com/opencloud-eu/reva/pull/411)]
- fix: isTemporary() check for absolute paths [[#406](https://github.com/opencloud-eu/reva/pull/406)]

### 📦️ Dependencies

- chore(deps): bump golang.org/x/sync from 0.17.0 to 0.18.0 [[#413](https://github.com/opencloud-eu/reva/pull/413)]
- chore(deps): bump github.com/nats-io/nats-server/v2 from 2.12.0 to 2.12.1 [[#409](https://github.com/opencloud-eu/reva/pull/409)]
- chore(deps): bump github.com/prometheus/alertmanager from 0.28.1 to 0.29.0 [[#408](https://github.com/opencloud-eu/reva/pull/408)]
- chore(deps): bump github.com/minio/minio-go/v7 from 7.0.95 to 7.0.97 [[#407](https://github.com/opencloud-eu/reva/pull/407)]
- chore(deps): bump github.com/ceph/go-ceph from 0.35.0 to 0.36.0 [[#404](https://github.com/opencloud-eu/reva/pull/404)]
- chore(deps): bump github.com/gomodule/redigo from 1.9.2 to 1.9.3 [[#405](https://github.com/opencloud-eu/reva/pull/405)]
- chore(deps): bump github.com/onsi/ginkgo/v2 from 2.26.0 to 2.27.2 [[#402](https://github.com/opencloud-eu/reva/pull/402)]
- chore(deps): bump golang.org/x/crypto from 0.42.0 to 0.43.0 [[#401](https://github.com/opencloud-eu/reva/pull/401)]
- chore(deps): bump github.com/shamaton/msgpack/v2 from 2.3.1 to 2.4.0 [[#396](https://github.com/opencloud-eu/reva/pull/396)]
- chore(deps): bump github.com/nats-io/nats.go from 1.46.1 to 1.47.0 [[#395](https://github.com/opencloud-eu/reva/pull/395)]
- chore(deps): bump github.com/gofrs/flock from 0.12.1 to 0.13.0 [[#390](https://github.com/opencloud-eu/reva/pull/390)]