### PR TITLE
🎉 Release 2.29.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- fix(posixfs): make blobstore uploads atomic [[#399](https://github.com/opencloud-eu/reva/pull/399)]
 - fix(posixfs): trash-bin restore collision handling [[#398](https://github.com/opencloud-eu/reva/pull/398)]
 
 ## [2.29.4](https://github.com/opencloud-eu/reva/releases/tag/v2.29.4) - 2025-07-10


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.29.5` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.29` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.29.5](https://github.com/opencloud-eu/reva/releases/tag/v2.29.5) - 2025-10-29

### 🐛 Bug Fixes

- fix(posixfs): make blobstore uploads atomic [[#399](https://github.com/opencloud-eu/reva/pull/399)]
- fix(posixfs): trash-bin restore collision handling [[#398](https://github.com/opencloud-eu/reva/pull/398)]