### PR TITLE
fix: Ignore files in .oc-tmp in assimilation

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -727,7 +727,7 @@ func (t *Tree) isIndex(path string) bool {
 }
 
 func (t *Tree) isTemporary(path string) bool {
-	return path == blobstore.TMPDir
+	return path == blobstore.TMPDir || filepath.Dir(path) == blobstore.TMPDir
 }
 
 func (t *Tree) isRootPath(path string) bool {


### PR DESCRIPTION
The isTemporary() needs to also match files in the Folder not just the folder to properly ignore the tempfiles when watchfs is enabled.

Fixes: https://github.com/opencloud-eu/opencloud/issues/1747