### PR TITLE
fix: isTemporary() check for absolute paths

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -727,6 +727,20 @@ func (t *Tree) isIndex(path string) bool {
 }
 
 func (t *Tree) isTemporary(path string) bool {
+	if filepath.IsAbs(path) {
+		tmpDirPattern := filepath.Join(t.options.Root, "*", "*", blobstore.TMPDir)
+		isTempDir, err := filepath.Match(tmpDirPattern, path)
+		if err != nil {
+			t.log.Error().Err(err).Str("pattern", tmpDirPattern).Str("path", path).Msg("error matching temporary path")
+			return false
+		}
+		isTempParentDir, err := filepath.Match(tmpDirPattern, filepath.Dir(path))
+		if err != nil {
+			t.log.Error().Err(err).Str("pattern", tmpDirPattern).Str("path", filepath.Dir(path)).Msg("error matching temporary path")
+			return false
+		}
+		return isTempDir || isTempParentDir
+	}
 	return path == blobstore.TMPDir || filepath.Dir(path) == blobstore.TMPDir
 }
 


### PR DESCRIPTION
The `isTemporary()` check can be called with relative Paths (from ListFolder) and absolute path (from the filesystem Watcher). This should fix it to work in both case. While assuring that it does the most apropriate match for absolute paths.

Closes: https://github.com/opencloud-eu/opencloud/issues/1774