### PR TITLE
🎉 Release 2.39.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- handle objectguid endianness [[#431](https://github.com/opencloud-eu/reva/pull/431)]
 - reap children [[#432](https://github.com/opencloud-eu/reva/pull/432)]
 - fix(posixfs): Only copy user.oc xattrs in blobstore.Upload [[#430](https://github.com/opencloud-eu/reva/pull/430)]
 - fix: restore revision after negative post-processing outcome [[#424](https://github.com/opencloud-eu/reva/pull/424)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.39.3` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.39.3](https://github.com/opencloud-eu/reva/releases/tag/v2.39.3) - 2025-11-25

### 🐛 Bug Fixes

- handle objectguid endianness [[#431](https://github.com/opencloud-eu/reva/pull/431)]
- reap children [[#432](https://github.com/opencloud-eu/reva/pull/432)]
- fix(posixfs): Only copy user.oc xattrs in blobstore.Upload [[#430](https://github.com/opencloud-eu/reva/pull/430)]
- fix: restore revision after negative post-processing outcome [[#424](https://github.com/opencloud-eu/reva/pull/424)]
- Prevent space admin from listing other tennants spaces [[#412](https://github.com/opencloud-eu/reva/pull/412)]

### 📚 Documentation

- change link it testing docs [[#420](https://github.com/opencloud-eu/reva/pull/420)]

### 📦️ Dependencies

- chore(deps): bump github.com/coreos/go-oidc/v3 from 3.16.0 to 3.17.0 [[#429](https://github.com/opencloud-eu/reva/pull/429)]
- chore(deps): bump golang.org/x/oauth2 from 0.32.0 to 0.33.0 [[#417](https://github.com/opencloud-eu/reva/pull/417)]
- chore(deps): bump golang.org/x/crypto from 0.43.0 to 0.44.0 [[#423](https://github.com/opencloud-eu/reva/pull/423)]
- chore(deps): bump github.com/google/renameio/v2 from 2.0.0 to 2.0.1 [[#422](https://github.com/opencloud-eu/reva/pull/422)]
- chore(deps): bump golang.org/x/sys from 0.37.0 to 0.38.0 [[#410](https://github.com/opencloud-eu/reva/pull/410)]