### PR TITLE
delete mlock files on delete or purge

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -581,6 +581,9 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) error {
 		}
 	}
 
+	// Remove metadata mlock file if it exists
+	_ = os.Remove(t.lookup.MetadataBackend().LockfilePath(n))
+
 	err := t.trashbin.MoveToTrash(ctx, n, path)
 	if err != nil {
 		return err

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -125,7 +125,8 @@ func (b HybridBackend) list(ctx context.Context, n MetadataNode, acquireLock boo
 		if err != nil {
 			return nil, err
 		}
-		defer cleanupLockfile(ctx, f)
+		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
+		defer f.Close()
 
 	}
 	return xattr.List(filePath)
@@ -378,7 +379,8 @@ func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, a
 		if err != nil {
 			return err
 		}
-		defer cleanupLockfile(ctx, lockedFile)
+		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
+		defer lockedFile.Close()
 	}
 
 	if isOffloadingAttribute(key) {
@@ -466,9 +468,6 @@ func (b HybridBackend) Purge(ctx context.Context, n MetadataNode) error {
 			}
 		}
 	}
-
-	// delete the metadata lockfile
-	_ = os.Remove(b.LockfilePath(n))
 
 	return b.metaCache.RemoveMetadata(b.cacheKey(n))
 }

--- a/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
@@ -285,15 +285,6 @@ func (b MessagePackBackend) Purge(_ context.Context, n MetadataNode) error {
 		return err
 	}
 
-	internalPath := n.InternalPath()
-	// for trash files always use the path without the timestamp
-	parts := strings.SplitN(n.GetID(), ".T.", 2)
-	if len(parts) > 1 {
-		internalPath = strings.TrimSuffix(internalPath, ".T."+parts[1])
-	}
-
-	_ = os.Remove(internalPath + ".mlock")
-
 	return os.Remove(b.MetadataPath(n))
 }
 


### PR DESCRIPTION
fixes the deletion of a nodes mlock file when a revision is deleted.
discovered in https://github.com/opencloud-eu/opencloud/pull/1849#issuecomment-3526796419

also fixes https://github.com/opencloud-eu/opencloud/issues/1855:

create file with three revisions:
```
❯ tree -ah /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
[4.0K]  /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
├── [   3]  New file.txt
├── [   0]  New file.txt.flock
├── [4.0K]  .oc-nodes
│   ├── [4.0K]  f8
│   │   └── [4.0K]  c6
│   │       └── [4.0K]  b8
│   │           └── [4.0K]  d7
│   │               ├── [   0]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:18.561410797Z
│   │               ├── [   1]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:20.241340088Z
│   │               └── [   2]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:21.359596459Z
│   └── [4.0K]  locks
│       ├── [   0]  8869ee7d-8e27-4400-9605-f52298a32404.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:18.561410797Z.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:20.241340088Z.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:21.359596459Z.mlock
│       └── [   0]  .mlock
├── [4.0K]  .oc-tmp
└── [4.0K]  .Trash
    ├── [4.0K]  files
    └── [4.0K]  info

11 directories, 11 files
```
move to trash and the f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.mlock gets deleted
```
❯ tree -ah /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
[4.0K]  /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
├── [4.0K]  .oc-nodes
│   ├── [4.0K]  f8
│   │   └── [4.0K]  c6
│   │       └── [4.0K]  b8
│   │           └── [4.0K]  d7
│   │               ├── [   0]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:18.561410797Z
│   │               ├── [   1]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:20.241340088Z
│   │               └── [   2]  -a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:21.359596459Z
│   └── [4.0K]  locks
│       ├── [   0]  8869ee7d-8e27-4400-9605-f52298a32404.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:18.561410797Z.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:20.241340088Z.mlock
│       ├── [   0]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.REV.2025-11-13T13:58:21.359596459Z.mlock
│       └── [   0]  .mlock
├── [4.0K]  .oc-tmp
└── [4.0K]  .Trash
    ├── [4.0K]  files
    │   └── [   3]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.trashitem
    └── [4.0K]  info
        └── [  63]  f8c6b8d7-a6bf-4dca-a6bc-0ed785ea7cdb.trashinfo

11 directories, 10 files
```
purge from trash and the revisions as well as their mlock files get deleted
```
❯ tree -ah /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
[4.0K]  /home/jfd/.opencloud/storage/users/users/cd88bf9a-dd7f-11ef-a609-7f78deb2345f/
├── [4.0K]  .oc-nodes
│   ├── [4.0K]  f8
│   │   └── [4.0K]  c6
│   │       └── [4.0K]  b8
│   │           └── [4.0K]  d7
│   └── [4.0K]  locks
│       ├── [   0]  8869ee7d-8e27-4400-9605-f52298a32404.mlock
│       └── [   0]  .mlock
├── [4.0K]  .oc-tmp
└── [4.0K]  .Trash
    ├── [4.0K]  files
    └── [4.0K]  info

11 directories, 2 files
```