### PR TITLE
Bump go.opentelemetry.io/otel/semconv to v1.37.0

### DIFF
--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/rs/zerolog"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 )
@@ -42,7 +42,7 @@ func NewUnary(log zerolog.Logger, tp trace.TracerProvider) grpc.UnaryServerInter
 		}
 		_, file, _, ok := runtime.Caller(1)
 		if ok {
-			span.SetAttributes(semconv.CodeFilepathKey.String(file))
+			span.SetAttributes(semconv.CodeFilePathKey.String(file))
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
@@ -67,7 +67,7 @@ func NewStream(log zerolog.Logger, tp trace.TracerProvider) grpc.StreamServerInt
 		}
 		_, file, _, ok := runtime.Caller(1)
 		if ok {
-			span.SetAttributes(semconv.CodeFilepathKey.String(file))
+			span.SetAttributes(semconv.CodeFilePathKey.String(file))
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -38,7 +38,7 @@ import (
 	tokenmgr "github.com/opencloud-eu/reva/v2/pkg/token/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -49,7 +49,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 )

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -37,7 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -127,8 +127,8 @@ func (s *svc) setHandler() {
 		ctx, span := tracer.Start(ctx, "HandlerFunc")
 		defer span.End()
 		span.SetAttributes(
-			semconv.HTTPMethodKey.String(r.Method),
-			semconv.HTTPURLKey.String(r.URL.String()),
+			semconv.HTTPRequestMethodKey.String(r.Method),
+			semconv.URLFullKey.String(r.URL.String()),
 		)
 		r = r.WithContext(ctx)
 		s.doRequest(w, r)

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -58,7 +58,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -243,7 +243,7 @@ func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns 
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Invalid Depth header value")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)
@@ -255,7 +255,7 @@ func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns 
 	if depth == net.DepthInfinity && !p.c.AllowPropfindDepthInfinitiy {
 		span.RecordError(errors.ErrInvalidDepth)
 		span.SetStatus(codes.Error, "DEPTH: infinity is not supported")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(errors.ErrInvalidDepth.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)
@@ -312,7 +312,7 @@ func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, s
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Invalid Depth header value")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)
@@ -324,7 +324,7 @@ func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, s
 	if depth == net.DepthInfinity && !p.c.AllowPropfindDepthInfinitiy {
 		span.RecordError(errors.ErrInvalidDepth)
 		span.SetStatus(codes.Error, "DEPTH: infinity is not supported")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(errors.ErrInvalidDepth.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -32,7 +32,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp/router"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 )
 
 // PublicFileHandler handles requests on a shared file. it needs to be wrapped in a collection
@@ -100,7 +100,7 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 	if !ok {
 		span.RecordError(ocdaverrors.ErrTokenStatInfoMissing)
 		span.SetStatus(codes.Error, ocdaverrors.ErrTokenStatInfoMissing.Error())
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusInternalServerError))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusInternalServerError))
 		w.WriteHeader(http.StatusInternalServerError)
 		b, err := ocdaverrors.Marshal(http.StatusInternalServerError, ocdaverrors.ErrTokenStatInfoMissing.Error(), "", "")
 		ocdaverrors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
@@ -114,7 +114,7 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Invalid Depth header value")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)
@@ -126,7 +126,7 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 	if depth == net.DepthInfinity && !s.c.AllowPropfindDepthInfinitiy {
 		span.RecordError(ocdaverrors.ErrInvalidDepth)
 		span.SetStatus(codes.Error, "DEPTH: infinity is not supported")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", dh).Msg(ocdaverrors.ErrInvalidDepth.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", dh)

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -41,7 +41,7 @@ import (
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
@@ -200,7 +200,7 @@ func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "Invalid Depth header value")
-		span.SetAttributes(semconv.HTTPStatusCodeKey.Int(http.StatusBadRequest))
+		span.SetAttributes(semconv.HTTPResponseStatusCodeKey.Int(http.StatusBadRequest))
 		sublog.Debug().Str("depth", r.Header.Get(net.HeaderDepth)).Msg(err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		m := fmt.Sprintf("Invalid Depth header value: %v", r.Header.Get(net.HeaderDepth))

--- a/pkg/storage/cache/stat.go
+++ b/pkg/storage/cache/stat.go
@@ -28,7 +28,7 @@ import (
 	"go-micro.dev/v4/store"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
is actually part of the go.opentelemetry.io/otel package ... so this is not detected by dependabot