### PR TITLE
reap children

### DIFF
--- a/tests/integration/grpc/grpc_suite_test.go
+++ b/tests/integration/grpc/grpc_suite_test.go
@@ -260,6 +260,11 @@ func startRevads(configs []RevadConfig, variables map[string]string) (map[string
 				if err != nil {
 					return errors.Wrap(err, "Could not kill revad")
 				}
+
+				// Wait for the process to actually terminate and reap it
+				// This prevents zombie processes
+				_ = cmd.Wait()
+
 				_ = waitForPort(ownAddress, "close")
 				if keepLogs {
 					fmt.Println("Test failed, keeping root", tmpRoot, "around for debugging")


### PR DESCRIPTION
get rid of these defunct processes when running `make test-integration`:
```
3058804 pts/12   Z+     0:00 [revad] <defunct>
3058824 pts/12   Z+     0:00 [revad] <defunct>
3058847 pts/12   Z+     0:00 [revad] <defunct>
3058863 pts/12   Z+     0:00 [revad] <defunct>
3058879 pts/12   Z+     0:00 [revad] <defunct>
3058895 pts/12   Z+     0:00 [revad] <defunct>
3058914 pts/12   Z+     0:00 [revad] <defunct>
3058938 pts/12   Z+     0:00 [revad] <defunct>
3058956 pts/12   Z+     0:00 [revad] <defunct>
3058976 pts/12   Z+     0:00 [revad] <defunct>
3058991 pts/12   Z+     0:00 [revad] <defunct>
3059009 pts/12   Z+     0:00 [revad] <defunct>
3059028 pts/12   Z+     0:00 [revad] <defunct>
3059044 pts/12   Z+     0:00 [revad] <defunct>
3059063 pts/12   Z+     0:00 [revad] <defunct>
3059080 pts/12   Z+     0:00 [revad] <defunct>
3059098 pts/12   Z+     0:00 [revad] <defunct>
```