### PR TITLE
🎉 Release 2.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@aduffeck, @butonic, @dragonchaser, @rhafer
+@MahdiBaghbani, @aduffeck, @butonic, @dragonchaser, @rhafer
 
 ### 📈 Enhancement
 
+- feat(ocm): add wayf specific /discover and /federations endpoints to sciencemesh package [[#393](https://github.com/opencloud-eu/reva/pull/393)]
 - add ConsumerOptions [[#205](https://github.com/opencloud-eu/reva/pull/205)]
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.40.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.40.0](https://github.com/opencloud-eu/reva/releases/tag/v2.40.0) - 2025-11-27

### 📈 Enhancement

- feat(ocm): add wayf specific /discover and /federations endpoints to sciencemesh package [[#393](https://github.com/opencloud-eu/reva/pull/393)]
- add ConsumerOptions [[#205](https://github.com/opencloud-eu/reva/pull/205)]

### 🐛 Bug Fixes

- fix(ocm): OCM Specification Compliance [[#434](https://github.com/opencloud-eu/reva/pull/434)]
- more objectguid endianess swapping [[#435](https://github.com/opencloud-eu/reva/pull/435)]
- fix(watchfs): upload to a revision if a file was touched during postprocessing [[#426](https://github.com/opencloud-eu/reva/pull/426)]

### 📦️ Dependencies

- chore(deps): bump go.etcd.io/etcd/client/v3 from 3.6.5 to 3.6.6 [[#441](https://github.com/opencloud-eu/reva/pull/441)]
- chore(deps): bump github.com/nats-io/nats-server/v2 from 2.12.1 to 2.12.2 [[#440](https://github.com/opencloud-eu/reva/pull/440)]
- chore(deps): bump google.golang.org/grpc from 1.76.0 to 1.77.0 [[#433](https://github.com/opencloud-eu/reva/pull/433)]
- chore(deps): bump golang.org/x/crypto from 0.43.0 to 0.45.0 in the go_modules group across 1 directory [[#425](https://github.com/opencloud-eu/reva/pull/425)]