### PR TITLE
🎉 Release 2.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 @butonic, @rhafer
 
+### 🐛 Bug Fixes
 
+- ocm fixes [[#444](https://github.com/opencloud-eu/reva/pull/444)]
+- fix(ocm): Fix userids sent, when accepting an ocm invite [[#442](https://github.com/opencloud-eu/reva/pull/442)]
 
 ## [2.40.0](https://github.com/opencloud-eu/reva/releases/tag/v2.40.0) - 2025-11-27
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.40.1` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.40.1](https://github.com/opencloud-eu/reva/releases/tag/v2.40.1) - 2025-11-28

### 🐛 Bug Fixes

- ocm fixes [[#444](https://github.com/opencloud-eu/reva/pull/444)]
- fix(ocm): Fix userids sent, when accepting an ocm invite [[#442](https://github.com/opencloud-eu/reva/pull/442)]
- Treesize propagation [[#439](https://github.com/opencloud-eu/reva/pull/439)]