### PR TITLE
🎉 Release 2.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@
 
 @aduffeck, @anon-pradip, @butonic, @prashant-gurung899
 
+### 📈 Enhancement
+
+- Write mtime from filesystem to metadata to preven re-assimilation [[#457](https://github.com/opencloud-eu/reva/pull/457)]
+- introduce Natswatcher [[#449](https://github.com/opencloud-eu/reva/pull/449)]
+
 ### 🐛 Bug Fixes
 
 - Do not log EOF as error, it is expected behavior when reading empty dirs [[#454](https://github.com/opencloud-eu/reva/pull/454)]
-
-### 📈 Enhancement
-
-- introduce Natswatcher [[#449](https://github.com/opencloud-eu/reva/pull/449)]
 
 ## [2.40.1](https://github.com/opencloud-eu/reva/releases/tag/v2.40.1) - 2025-11-28
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.41.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.41.0](https://github.com/opencloud-eu/reva/releases/tag/v2.41.0) - 2025-12-15

### 📈 Enhancement

- Write mtime from filesystem to metadata to preven re-assimilation [[#457](https://github.com/opencloud-eu/reva/pull/457)]
- introduce Natswatcher [[#449](https://github.com/opencloud-eu/reva/pull/449)]

### 🐛 Bug Fixes

- Do not log EOF as error, it is expected behavior when reading empty dirs [[#454](https://github.com/opencloud-eu/reva/pull/454)]