### PR TITLE
jsoncs3 incremental backoff when persisting

### DIFF
--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -196,18 +197,24 @@ func (c *Cache) Add(ctx context.Context, storageID, spaceID, shareID string, sha
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting added provider share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting added provider share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting added provider share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting added provider share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.AlreadyExists:
-			log.Debug().Msg("already exists when persisting added provider share. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("already exists when persisting added provider share. retrying...")
 			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
 			// Thas happens when the cache thinks there is no file.
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting added provider share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting added provider share failed")
@@ -269,13 +276,17 @@ func (c *Cache) Remove(ctx context.Context, storageID, spaceID, shareID string) 
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting removed provider share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting removed provider share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting removed provider share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting removed provider share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting removed provider share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting removed provider share failed")

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -139,18 +140,24 @@ func (c *Cache) Add(ctx context.Context, userID, spaceID string, rs *collaborati
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting added received share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting added received share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting added received share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting added received share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.AlreadyExists:
-			log.Debug().Msg("already exists when persisting added received share. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("already exists when persisting added received share. retrying...")
 			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
 			// Thas happens when the cache thinks there is no file.
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting added received share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting added received share failed")
@@ -226,18 +233,24 @@ func (c *Cache) Remove(ctx context.Context, userID, spaceID, shareID string) err
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting added received share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting added received share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting added received share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting added received share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.AlreadyExists:
-			log.Debug().Msg("already exists when persisting added received share. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("already exists when persisting added received share. retrying...")
 			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
 			// Thas happens when the cache thinks there is no file.
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting added received share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting added received share failed")

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -132,18 +133,24 @@ func (c *Cache) Add(ctx context.Context, userid, shareID string) error {
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting added share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting added share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting added share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting added share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.AlreadyExists:
-			log.Debug().Msg("already exists when persisting added share. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("already exists when persisting added share. retrying...")
 			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
 			// Thas happens when the cache thinks there is no file.
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting added share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting added share failed")
@@ -207,18 +214,24 @@ func (c *Cache) Remove(ctx context.Context, userid, shareID string) error {
 			span.SetStatus(codes.Ok, "")
 			return nil
 		case errtypes.Aborted:
-			log.Debug().Msg("aborted when persisting removed share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("aborted when persisting removed share: etag changed. retrying...")
 			// this is the expected status code from the server when the if-match etag check fails
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.PreconditionFailed:
-			log.Debug().Msg("precondition failed when persisting removed share: etag changed. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("precondition failed when persisting removed share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+			time.Sleep(backoff)
 		case errtypes.AlreadyExists:
-			log.Debug().Msg("file already existed when persisting removed share. retrying...")
+			backoff := time.Duration(rand.Intn(1<<(min(7, 100-retries)))) * time.Millisecond
+			log.Debug().Dur("backoff", backoff).Msg("file already existed when persisting removed share. retrying...")
 			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
 			// Thas happens when the cache thinks there is no file.
 			// continue with sync below
+			time.Sleep(backoff)
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting removed share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting removed share failed")


### PR DESCRIPTION
When investigating why the jsoncs3 backend was "giving up" persisting shares I noticed that we did not add an incremental backoff. that means multiple pods will fight keep writing the file under load, leading to ... "giving up"