### PR TITLE
Disable favorite proppatch

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=c33850f21355b94dcd2e380a39d6f8d11cf7d82f
-APITESTS_BRANCH=main
+APITESTS_COMMITID=b1b76c6c7b82d3f6dfd1b2da9914df629e725a46
+APITESTS_BRANCH=remove-webdave-favorite-tests
 APITESTS_REPO_GIT_URL=https://github.com/opencloud-eu/opencloud

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -155,6 +155,13 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 		}
 		for j := range patches[i].Props {
 			propNameXML := patches[i].Props[j].XMLName
+
+			// favorites are now managed by the Graph API and can no longer be set using PROPPATCH. To avoid confusion, we return a 403 Forbidden when clients try to set the oc:favorites property
+			if propNameXML.Local == "favorite" {
+				w.WriteHeader(http.StatusForbidden)
+				return nil, nil, false
+			}
+
 			// don't use path.Join. It removes the double slash! concatenate with a /
 			key := fmt.Sprintf("%s/%s", patches[i].Props[j].XMLName.Space, patches[i].Props[j].XMLName.Local)
 			value := string(patches[i].Props[j].InnerXML)

--- a/pkg/storage/fs/posix/idcache/idcache.go
+++ b/pkg/storage/fs/posix/idcache/idcache.go
@@ -65,12 +65,12 @@ func (c *IDCache) DeleteByPath(ctx context.Context, path string) error {
 	} else {
 		err := c.kv.Purge(ctx, baseKey)
 		if err != nil && err != nats.ErrKeyNotFound {
-			appctx.GetLogger(ctx).Error().Err(err).Str("record", path).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not get spaceID and nodeID from cache")
+			appctx.GetLogger(ctx).Error().Err(err).Str("record", baseKey).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not purge from cache")
 		}
 
 		err = c.kv.Purge(ctx, cacheKey(spaceID, nodeID))
 		if err != nil && err != nats.ErrKeyNotFound {
-			appctx.GetLogger(ctx).Error().Err(err).Str("record", path).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not get spaceID and nodeID from cache")
+			appctx.GetLogger(ctx).Error().Err(err).Str("record", cacheKey(spaceID, nodeID)).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not purge from cache")
 		}
 	}
 
@@ -85,7 +85,6 @@ func (c *IDCache) DeleteByPath(ctx context.Context, path string) error {
 			break
 		}
 		key := update.Key()
-
 		spaceID, nodeID, ok := c.getByReverseCacheKey(ctx, key)
 		if !ok {
 			appctx.GetLogger(ctx).Error().Str("record", key).Msg("could not get spaceID and nodeID from cache")
@@ -94,12 +93,12 @@ func (c *IDCache) DeleteByPath(ctx context.Context, path string) error {
 
 		err := c.kv.Purge(ctx, key)
 		if err != nil && err != nats.ErrKeyNotFound {
-			appctx.GetLogger(ctx).Error().Err(err).Str("record", key).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not get spaceID and nodeID from cache")
+			appctx.GetLogger(ctx).Error().Err(err).Str("record", key).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not purge from cache")
 		}
 
 		err = c.kv.Purge(ctx, cacheKey(spaceID, nodeID))
 		if err != nil && err != nats.ErrKeyNotFound {
-			appctx.GetLogger(ctx).Error().Err(err).Str("record", key).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not get spaceID and nodeID from cache")
+			appctx.GetLogger(ctx).Error().Err(err).Str("record", cacheKey(spaceID, nodeID)).Str("spaceID", spaceID).Str("nodeID", nodeID).Msg("could not purge from cache")
 		}
 	}
 	return nil

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -37,7 +37,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
-	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
@@ -812,12 +811,4 @@ func isLockFile(path string) bool {
 
 func isTrash(path string) bool {
 	return strings.HasSuffix(path, ".trashinfo") || strings.HasSuffix(path, ".trashitem") || strings.Contains(path, ".Trash")
-}
-
-func (t *Tree) AddLabel(ctx context.Context, ref *provider.Reference, userID *user.UserId, label string) error {
-	return errtypes.NotSupported("AddLabel not implemented")
-}
-
-func (t *Tree) RemoveLabel(ctx context.Context, ref *provider.Reference, userID *user.UserId, label string) error {
-	return errtypes.NotSupported("RemoveLabel not implemented")
 }


### PR DESCRIPTION
favorites are now managed by the Graph API and can no longer be set using PROPPATCH. To avoid confusion, we return a 403 Forbidden when clients try to set the oc:favorites property