### PR TITLE
Implement TenantAPI Service in usersprovider

### DIFF
--- a/cmd/revad/runtime/loader.go
+++ b/cmd/revad/runtime/loader.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/opencloud-eu/reva/v2/pkg/share/manager/loader"
 	_ "github.com/opencloud-eu/reva/v2/pkg/storage/fs/loader"
 	_ "github.com/opencloud-eu/reva/v2/pkg/storage/registry/loader"
+	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/loader"
 	_ "github.com/opencloud-eu/reva/v2/pkg/token/manager/loader"
 	_ "github.com/opencloud-eu/reva/v2/pkg/user/manager/loader"
 )

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20260310080202-fb97596763d6
+	github.com/cs3org/go-cs3apis v0.0.0-20260407125717-5d69ba49048b
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/emvi/iso-639-1 v1.1.1
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20260310080202-fb97596763d6 h1:Akwn9gHJugKd8M48LyV+WeIQ6yMXoxZdgZabR53I9q4=
-github.com/cs3org/go-cs3apis v0.0.0-20260310080202-fb97596763d6/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260407125717-5d69ba49048b h1:WNwuveokaUXIAGrwVLWqJSk0BdJv8k+9RXipBItGuyY=
+github.com/cs3org/go-cs3apis v0.0.0-20260407125717-5d69ba49048b/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -60,6 +60,7 @@ type config struct {
 	OCMCoreEndpoint               string `mapstructure:"ocmcoresvc"`
 	UserProviderEndpoint          string `mapstructure:"userprovidersvc"`
 	GroupProviderEndpoint         string `mapstructure:"groupprovidersvc"`
+	TenantProviderEndpoint        string `mapstructure:"tenantprovidersvc"`
 	DataTxEndpoint                string `mapstructure:"datatx"`
 	DataGatewayEndpoint           string `mapstructure:"datagateway"`
 	PermissionsEndpoint           string `mapstructure:"permissionssvc"`
@@ -110,6 +111,12 @@ func (c *config) init() {
 	c.OCMCoreEndpoint = sharedconf.GetGatewaySVC(c.OCMCoreEndpoint)
 	c.UserProviderEndpoint = sharedconf.GetGatewaySVC(c.UserProviderEndpoint)
 	c.GroupProviderEndpoint = sharedconf.GetGatewaySVC(c.GroupProviderEndpoint)
+	// Fall back to userprovidersvc when no dedicated tenant provider is configured.
+	if c.TenantProviderEndpoint == "" {
+		c.TenantProviderEndpoint = c.UserProviderEndpoint
+	} else {
+		c.TenantProviderEndpoint = sharedconf.GetGatewaySVC(c.TenantProviderEndpoint)
+	}
 	c.DataTxEndpoint = sharedconf.GetGatewaySVC(c.DataTxEndpoint)
 
 	c.DataGatewayEndpoint = sharedconf.GetDataGateway(c.DataGatewayEndpoint)

--- a/internal/grpc/services/gateway/tenantprovider.go
+++ b/internal/grpc/services/gateway/tenantprovider.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (s *svc) GetTenant(ctx context.Context, req *tenant.GetTenantRequest) (*tenant.GetTenantResponse, error) {
-	c, err := pool.GetTenantProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetTenantProviderServiceClient(s.c.TenantProviderEndpoint)
 	if err != nil {
 		return &tenant.GetTenantResponse{
 			Status: status.NewInternal(ctx, "error getting tenant service client"),
@@ -45,7 +45,7 @@ func (s *svc) GetTenant(ctx context.Context, req *tenant.GetTenantRequest) (*ten
 }
 
 func (s *svc) GetTenantByClaim(ctx context.Context, req *tenant.GetTenantByClaimRequest) (*tenant.GetTenantByClaimResponse, error) {
-	c, err := pool.GetTenantProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetTenantProviderServiceClient(s.c.TenantProviderEndpoint)
 	if err != nil {
 		return &tenant.GetTenantByClaimResponse{
 			Status: status.NewInternal(ctx, "error getting tenant service client"),

--- a/internal/grpc/services/gateway/tenantprovider.go
+++ b/internal/grpc/services/gateway/tenantprovider.go
@@ -1,0 +1,61 @@
+// Copyright 2018-2021 CERN
+// Copyright 2026 OpenCloud GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package gateway
+
+import (
+	"context"
+
+	tenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/pkg/errors"
+)
+
+func (s *svc) GetTenant(ctx context.Context, req *tenant.GetTenantRequest) (*tenant.GetTenantResponse, error) {
+	c, err := pool.GetTenantProviderServiceClient(s.c.UserProviderEndpoint)
+	if err != nil {
+		return &tenant.GetTenantResponse{
+			Status: status.NewInternal(ctx, "error getting tenant service client"),
+		}, nil
+	}
+
+	res, err := c.GetTenant(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling GetTenant")
+	}
+
+	return res, nil
+}
+
+func (s *svc) GetTenantByClaim(ctx context.Context, req *tenant.GetTenantByClaimRequest) (*tenant.GetTenantByClaimResponse, error) {
+	c, err := pool.GetTenantProviderServiceClient(s.c.UserProviderEndpoint)
+	if err != nil {
+		return &tenant.GetTenantByClaimResponse{
+			Status: status.NewInternal(ctx, "error getting tenant service client"),
+		}, nil
+	}
+
+	res, err := c.GetTenantByClaim(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling GetTenantByClaim")
+	}
+
+	return res, nil
+}

--- a/internal/grpc/services/userprovider/tenant_test.go
+++ b/internal/grpc/services/userprovider/tenant_test.go
@@ -1,0 +1,58 @@
+package userprovider_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tenantpb "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+	rpcpb "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/opencloud-eu/reva/v2/internal/grpc/services/userprovider"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc"
+	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/loader"
+	_ "github.com/opencloud-eu/reva/v2/pkg/user/manager/loader"
+)
+
+var _ = Describe("the tenant api service", func() {
+	var (
+		config   map[string]any
+		svc      rgrpc.Service
+		provider tenantpb.TenantAPIServer
+	)
+
+	BeforeEach(func() {
+		var err error
+		config = map[string]any{
+			"driver": "memory",
+			"tenants": []map[string]any{
+				{
+					"id":         "id1",
+					"externalid": "externalid1",
+					"name":       "tenant1",
+				},
+				{
+					"id":         "id2",
+					"externalid": "externalid2",
+					"name":       "tenant2",
+				},
+			},
+		}
+		svc, err = userprovider.New(config, nil, nil)
+		Expect(err).To(BeNil())
+		Expect(svc).ToNot(BeNil())
+		provider = svc.(tenantpb.TenantAPIServer)
+		Expect(provider).ToNot(BeNil())
+	})
+
+	It("returns a not found error for unknown tenants", func() {
+		resp, err := provider.GetTenant(context.Background(),
+			&tenantpb.GetTenantRequest{
+				TenantId: "test",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(resp).ToNot(BeNil())
+		Expect(resp.GetStatus().GetCode()).To(Equal(rpcpb.Code_CODE_NOT_FOUND))
+	})
+})

--- a/internal/grpc/services/userprovider/tenant_test.go
+++ b/internal/grpc/services/userprovider/tenant_test.go
@@ -10,6 +10,7 @@ import (
 	rpcpb "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/opencloud-eu/reva/v2/internal/grpc/services/userprovider"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc"
+	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/loader"
 	_ "github.com/opencloud-eu/reva/v2/pkg/user/manager/loader"
 )
@@ -23,6 +24,9 @@ var _ = Describe("the tenant api service", func() {
 
 	BeforeEach(func() {
 		var err error
+		sharedconf.Decode(map[string]any{
+			"multi_tenant_enabled": true,
+		})
 		config = map[string]any{
 			"driver": "memory",
 			"drivers": map[string]any{

--- a/internal/grpc/services/userprovider/tenant_test.go
+++ b/internal/grpc/services/userprovider/tenant_test.go
@@ -25,16 +25,20 @@ var _ = Describe("the tenant api service", func() {
 		var err error
 		config = map[string]any{
 			"driver": "memory",
-			"tenants": []map[string]any{
-				{
-					"id":         "id1",
-					"externalid": "externalid1",
-					"name":       "tenant1",
-				},
-				{
-					"id":         "id2",
-					"externalid": "externalid2",
-					"name":       "tenant2",
+			"drivers": map[string]any{
+				"memory": map[string]any{
+					"tenants": map[string]any{
+						"id1": map[string]any{
+							"id":          "id1",
+							"external_id": "externalid1",
+							"name":        "tenant1",
+						},
+						"id2": map[string]any{
+							"id":          "id2",
+							"external_id": "externalid2",
+							"name":        "tenant2",
+						},
+					},
 				},
 			},
 		}
@@ -54,5 +58,29 @@ var _ = Describe("the tenant api service", func() {
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(resp.GetStatus().GetCode()).To(Equal(rpcpb.Code_CODE_NOT_FOUND))
+	})
+
+	It("returns a tenant for a given tenant id ", func() {
+		resp, err := provider.GetTenant(context.Background(),
+			&tenantpb.GetTenantRequest{
+				TenantId: "id1",
+			},
+		)
+		Expect(err).To(BeNil())
+		Expect(resp).ToNot(BeNil())
+		Expect(resp.GetStatus().GetCode()).To(Equal(rpcpb.Code_CODE_OK))
+	})
+
+	It("returns a tenant for a given external id ", func() {
+		tbR := tenantpb.GetTenantByClaimRequest{
+			Claim: "externalid",
+			Value: "externalid1",
+		}
+		resp, err := provider.GetTenantByClaim(context.Background(),
+			&tbR,
+		)
+		Expect(err).To(BeNil())
+		Expect(resp).ToNot(BeNil())
+		Expect(resp.GetStatus().GetCode()).To(Equal(rpcpb.Code_CODE_OK))
 	})
 })

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -103,11 +103,11 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 }
 
 func getTenantManager(c *config) (tenant.Manager, error) {
-	if f, ok := tenantRegistry.NewFuncs[c.Driver]; ok {
-		mgr, err := f(c.Drivers[c.Driver])
+	if f, ok := tenantRegistry.NewFuncs[c.TenantDriver]; ok {
+		mgr, err := f(c.TenantDrivers[c.TenantDriver])
 		return mgr, err
 	}
-	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for tenant manager", c.Driver))
+	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for tenant manager", c.TenantDriver))
 }
 
 // New returns a new UserProviderServiceServer.

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -48,13 +48,22 @@ func init() {
 }
 
 type config struct {
-	Driver  string                            `mapstructure:"driver"`
-	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
+	Driver        string                            `mapstructure:"driver"`
+	Drivers       map[string]map[string]interface{} `mapstructure:"drivers"`
+	TenantDriver  string                            `mapstructure:"tenant_driver"`
+	TenantDrivers map[string]map[string]interface{} `mapstructure:"tenant_drivers"`
 }
 
 func (c *config) init() {
 	if c.Driver == "" {
 		c.Driver = "json"
+	}
+	// Fall back to user driver/drivers when no tenant-specific config is provided.
+	if c.TenantDriver == "" {
+		c.TenantDriver = c.Driver
+	}
+	if c.TenantDrivers == nil {
+		c.TenantDrivers = c.Drivers
 	}
 }
 

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -116,13 +116,16 @@ func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Se
 		return nil, err
 	}
 
-	svc := &service{
-		usermgr:   userManager,
-		tenantmgr: tenantManager,
+	return NewWithManagers(userManager, tenantManager, plug), nil
+}
+
+// NewWithManagers returns a new UserProviderService with the given managers.
+func NewWithManagers(um user.Manager, tm tenant.Manager, plug *plugin.RevaPlugin) rgrpc.Service {
+	return &service{
+		usermgr:   um,
+		tenantmgr: tm,
 		plugin:    plug,
 	}
-
-	return svc, nil
 }
 
 type service struct {

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -94,8 +94,8 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 }
 
 func getTenantManager(c *config) (tenant.Manager, error) {
-	if f, ok := tenantRegistry.NewFuncs["memory"]; ok {
-		mgr, err := f(c.Drivers["memory"])
+	if f, ok := tenantRegistry.NewFuncs[c.Driver]; ok {
+		mgr, err := f(c.Drivers[c.Driver])
 		return mgr, err
 	}
 	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for tenant manager", c.Driver))

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/plugin"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
+	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant"
 	tenantRegistry "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/user"
@@ -58,12 +59,18 @@ func (c *config) init() {
 	if c.Driver == "" {
 		c.Driver = "json"
 	}
+
 	// Fall back to user driver/drivers when no tenant-specific config is provided.
 	if c.TenantDriver == "" {
 		c.TenantDriver = c.Driver
 	}
 	if c.TenantDrivers == nil {
 		c.TenantDrivers = c.Drivers
+	}
+
+	// Force "null" driver if multi-tenancy is disabled
+	if !sharedconf.MultiTenantEnabled() {
+		c.TenantDriver = "null"
 	}
 }
 

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 
+	tenantpb "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	revactx "github.com/opencloud-eu/reva/v2/pkg/ctx"
@@ -36,8 +37,10 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/plugin"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+	tenantRegistry "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/user"
-	"github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
+	userRegistry "github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
 )
 
 func init() {
@@ -80,7 +83,7 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 		return manager, p, nil
 	} else if _, ok := err.(errtypes.NotFound); ok {
 		// plugin not found, fetch the driver from the in-memory registry
-		if f, ok := registry.NewFuncs[c.Driver]; ok {
+		if f, ok := userRegistry.NewFuncs[c.Driver]; ok {
 			mgr, err := f(c.Drivers[c.Driver])
 			return mgr, nil, err
 		}
@@ -88,6 +91,14 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 		return nil, nil, err
 	}
 	return nil, nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for user manager", c.Driver))
+}
+
+func getTenantManager(c *config) (tenant.Manager, error) {
+	if f, ok := tenantRegistry.NewFuncs["memory"]; ok {
+		mgr, err := f(c.Drivers["memory"])
+		return mgr, err
+	}
+	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for tenant manager", c.Driver))
 }
 
 // New returns a new UserProviderServiceServer.
@@ -100,17 +111,24 @@ func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Se
 	if err != nil {
 		return nil, err
 	}
+	tenantManager, err := getTenantManager(c)
+	if err != nil {
+		return nil, err
+	}
+
 	svc := &service{
-		usermgr: userManager,
-		plugin:  plug,
+		usermgr:   userManager,
+		tenantmgr: tenantManager,
+		plugin:    plug,
 	}
 
 	return svc, nil
 }
 
 type service struct {
-	usermgr user.Manager
-	plugin  *plugin.RevaPlugin
+	usermgr   user.Manager
+	tenantmgr tenant.Manager
+	plugin    *plugin.RevaPlugin
 }
 
 func (s *service) Close() error {
@@ -126,6 +144,7 @@ func (s *service) UnprotectedEndpoints() []string {
 
 func (s *service) Register(ss *grpc.Server) {
 	userpb.RegisterUserAPIServer(ss, s)
+	tenantpb.RegisterTenantAPIServer(ss, s)
 }
 
 func (s *service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (*userpb.GetUserResponse, error) {
@@ -231,4 +250,42 @@ func (s *service) GetUserGroups(ctx context.Context, req *userpb.GetUserGroupsRe
 		Groups: groups,
 	}
 	return res, nil
+}
+
+func (s *service) GetTenant(ctx context.Context, req *tenantpb.GetTenantRequest) (*tenantpb.GetTenantResponse, error) {
+	log := appctx.GetLogger(ctx)
+	t, err := s.tenantmgr.GetTenant(ctx, req.GetTenantId())
+	if err != nil {
+		log.Warn().Err(err).Interface("tenantid", req.GetTenantId()).Msg("error getting tenant")
+		res := &tenantpb.GetTenantResponse{
+			Status: status.NewInternal(ctx, "error getting tenant"),
+		}
+		if _, ok := err.(errtypes.NotFound); ok {
+			res.Status = status.NewNotFound(ctx, "tenant not found")
+		}
+		return res, nil
+	}
+	return &tenantpb.GetTenantResponse{
+		Status: status.NewOK(ctx),
+		Tenant: t,
+	}, nil
+}
+
+func (s *service) GetTenantByClaim(ctx context.Context, req *tenantpb.GetTenantByClaimRequest) (*tenantpb.GetTenantByClaimResponse, error) {
+	log := appctx.GetLogger(ctx)
+	t, err := s.tenantmgr.GetTenantByClaim(ctx, req.GetClaim(), req.GetValue())
+	if err != nil {
+		log.Warn().Err(err).Interface("claim", req.GetClaim()).Interface("value", req.GetValue()).Msg("error getting tenant")
+		res := &tenantpb.GetTenantByClaimResponse{
+			Status: status.NewInternal(ctx, "error getting tenant"),
+		}
+		if _, ok := err.(errtypes.NotFound); ok {
+			res.Status = status.NewNotFound(ctx, "tenant not found")
+		}
+		return res, nil
+	}
+	return &tenantpb.GetTenantByClaimResponse{
+		Status: status.NewOK(ctx),
+		Tenant: t,
+	}, nil
 }

--- a/internal/grpc/services/userprovider/userprovider_suite_test.go
+++ b/internal/grpc/services/userprovider/userprovider_suite_test.go
@@ -1,0 +1,13 @@
+package userprovider_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUserprovider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Userprovider Suite")
+}

--- a/pkg/rgrpc/todo/pool/client.go
+++ b/pkg/rgrpc/todo/pool/client.go
@@ -26,6 +26,7 @@ import (
 	authregistry "github.com/cs3org/go-cs3apis/cs3/auth/registry/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	tenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
@@ -49,6 +50,12 @@ func GetGatewayServiceClient(id string, opts ...Option) (gateway.GatewayAPIClien
 // GetUserProviderServiceClient returns a UserProviderServiceClient.
 func GetUserProviderServiceClient(id string, opts ...Option) (user.UserAPIClient, error) {
 	selector, _ := IdentityUserSelector(id, opts...)
+	return selector.Next()
+}
+
+// GetTenantProviderServiceClient returns a TenantProviderServiceClient.
+func GetTenantProviderServiceClient(id string, opts ...Option) (tenant.TenantAPIClient, error) {
+	selector, _ := IdentityTenantSelector(id, opts...)
 	return selector.Next()
 }
 

--- a/pkg/rgrpc/todo/pool/selector.go
+++ b/pkg/rgrpc/todo/pool/selector.go
@@ -30,6 +30,7 @@ import (
 	authRegistry "github.com/cs3org/go-cs3apis/cs3/auth/registry/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	identityGroup "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	identityTenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
 	identityUser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocmCore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	ocmInvite "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
@@ -170,6 +171,16 @@ func IdentityGroupSelector(id string, options ...Option) (*Selector[identityGrou
 		"IdentityGroupSelector",
 		id,
 		identityGroup.NewGroupAPIClient,
+		options...,
+	), nil
+}
+
+// IdentityTentantSelector returns a Selector[identityTenant.TenantAPIClient].
+func IdentityTenantSelector(id string, options ...Option) (*Selector[identityTenant.TenantAPIClient], error) {
+	return GetSelector[identityTenant.TenantAPIClient](
+		"IdentityTenantSelector",
+		id,
+		identityTenant.NewTenantAPIClient,
 		options...,
 	), nil
 }

--- a/pkg/tenant/manager/ldap/ldap.go
+++ b/pkg/tenant/manager/ldap/ldap.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-ldap/ldap/v3"
 	"github.com/mitchellh/mapstructure"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
-	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
@@ -105,7 +104,11 @@ func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, e
 }
 
 func (m *manager) GetTenantByClaim(ctx context.Context, claim, value string) (*tenantpb.Tenant, error) {
-	return nil, errtypes.NotFound(value)
+	tenantEntry, err := m.conf.LDAPIdentity.GetLDAPTenantByAttribute(ctx, m.ldap, claim, value)
+	if err != nil {
+		return nil, err
+	}
+	return m.ldapEntryToTenant(tenantEntry)
 }
 
 func (m *manager) ldapEntryToTenant(entry *ldap.Entry) (*tenantpb.Tenant, error) {

--- a/pkg/tenant/manager/ldap/ldap.go
+++ b/pkg/tenant/manager/ldap/ldap.go
@@ -1,0 +1,118 @@
+// Copyright 2018-2021 CERN
+// Copyright 2026 OpenCloud GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ldap
+
+import (
+	"context"
+	"fmt"
+
+	tenantpb "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+	"github.com/go-ldap/ldap/v3"
+	"github.com/mitchellh/mapstructure"
+	"github.com/opencloud-eu/reva/v2/pkg/appctx"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
+	"github.com/opencloud-eu/reva/v2/pkg/utils"
+	ldapIdentity "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	registry.Register("ldap", New)
+}
+
+type config struct {
+	utils.LDAPConn `mapstructure:",squash"`
+	LDAPIdentity   ldapIdentity.Identity `mapstructure:",squash"`
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{
+		LDAPIdentity: ldapIdentity.New(),
+	}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error decoding conf")
+		return nil, err
+	}
+	return c, nil
+}
+
+type manager struct {
+	conf *config
+	ldap ldap.Client
+}
+
+// New returns a new user manager.
+func New(m map[string]interface{}) (tenant.Manager, error) {
+	mgr := &manager{}
+	err := mgr.Configure(m)
+	if err != nil {
+		return nil, err
+	}
+
+	mgr.ldap, err = utils.GetLDAPClientWithReconnect(&mgr.conf.LDAPConn)
+
+	return mgr, err
+}
+
+func (m *manager) Configure(ml map[string]interface{}) error {
+	c, err := parseConfig(ml)
+	if err != nil {
+		return err
+	}
+	if err = c.LDAPIdentity.Setup(); err != nil {
+		return fmt.Errorf("error setting up Identity config: %w", err)
+	}
+	m.conf = c
+
+	return nil
+}
+
+func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, error) {
+	log := appctx.GetLogger(ctx)
+
+	tenantEntry, err := m.conf.LDAPIdentity.GetLDAPTenantByID(ctx, m.ldap, id)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug().Interface("entry", tenantEntry).Msg("entries")
+
+	t, err := m.ldapEntryToTenant(tenantEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
+}
+
+func (m *manager) GetTenantByClaim(ctx context.Context, claim, value string) (*tenantpb.Tenant, error) {
+	return nil, errtypes.NotFound(value)
+}
+
+func (m *manager) ldapEntryToTenant(entry *ldap.Entry) (*tenantpb.Tenant, error) {
+	t := &tenantpb.Tenant{
+		Id:         entry.GetEqualFoldAttributeValue(m.conf.LDAPIdentity.Tenant.Schema.ID),
+		ExternalId: entry.GetEqualFoldAttributeValue(m.conf.LDAPIdentity.Tenant.Schema.ExternalID),
+		Name:       entry.GetEqualFoldAttributeValue(m.conf.LDAPIdentity.Tenant.Schema.Name),
+	}
+	return t, nil
+}

--- a/pkg/tenant/manager/loader/loader.go
+++ b/pkg/tenant/manager/loader/loader.go
@@ -21,6 +21,7 @@ package loader
 
 import (
 	// Load core user manager drivers.
+	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/ldap"
 	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/memory"
 	// Add your own here
 )

--- a/pkg/tenant/manager/loader/loader.go
+++ b/pkg/tenant/manager/loader/loader.go
@@ -23,5 +23,6 @@ import (
 	// Load core user manager drivers.
 	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/ldap"
 	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/memory"
+	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/null"
 	// Add your own here
 )

--- a/pkg/tenant/manager/loader/loader.go
+++ b/pkg/tenant/manager/loader/loader.go
@@ -1,0 +1,26 @@
+// Copyright 2018-2021 CERN
+// Copyright 2026 OpenCloud GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package loader
+
+import (
+	// Load core user manager drivers.
+	_ "github.com/opencloud-eu/reva/v2/pkg/tenant/manager/memory"
+	// Add your own here
+)

--- a/pkg/tenant/manager/memory/memory.go
+++ b/pkg/tenant/manager/memory/memory.go
@@ -1,0 +1,123 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package memory
+
+import (
+	"context"
+
+	tenantpb "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+	"github.com/mitchellh/mapstructure"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	registry.Register("memory", New)
+}
+
+type config struct {
+	// Users holds a map with userid and user
+	Tenants map[string]*Tenant `mapstructure:"tenants"`
+}
+
+// User holds a user but uses in mapstructure names
+type Tenant struct {
+	ID         string `mapstructure:"id" json:"id"`
+	ExternalID string `mapstructure:"external_id" json:"external_id"`
+	Name       string `mapstructure:"name" json:"name"`
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error decoding conf")
+		return nil, err
+	}
+	if len(c.Tenants) == 0 {
+		c.Tenants = map[string]*Tenant{
+			"f65b26f8-2ce2-11f1-b0af-7f3198d25769": &Tenant{
+				ID:         "f65b26f8-2ce2-11f1-b0af-7f3198d25769",
+				ExternalID: "externalid_1",
+				Name:       "Tenant One",
+			},
+			"f76a25ee-2ce2-11f1-9852-4fa5a531eb10": {
+				ID:         "f76a25ee-2ce2-11f1-9852-4fa5a531eb10",
+				ExternalID: "externalid_2",
+				Name:       "Tenant Two",
+			},
+		}
+	}
+	return c, nil
+}
+
+type manager struct {
+	catalog map[string]*Tenant
+}
+
+// New returns a new user manager.
+func New(m map[string]interface{}) (tenant.Manager, error) {
+	mgr := &manager{}
+	err := mgr.Configure(m)
+	return mgr, err
+}
+
+func (m *manager) Configure(ml map[string]interface{}) error {
+	c, err := parseConfig(ml)
+	if err != nil {
+		return err
+	}
+	m.catalog = c.Tenants
+	return nil
+}
+
+func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, error) {
+	if t, ok := m.catalog[id]; ok {
+		return &tenantpb.Tenant{
+			Id:         t.ID,
+			ExternalId: t.ExternalID,
+			Name:       t.Name,
+		}, nil
+	}
+	return nil, errtypes.NotFound(id)
+}
+
+func (m *manager) GetTenantByClaim(ctx context.Context, claim, value string) (*tenantpb.Tenant, error) {
+	for _, t := range m.catalog {
+		if tenantClaim, err := extractClaim(t, claim); err == nil && value == tenantClaim {
+			return &tenantpb.Tenant{
+				Id:         t.ID,
+				ExternalId: t.ExternalID,
+				Name:       t.Name,
+			}, nil
+		}
+	}
+	return nil, errtypes.NotFound(value)
+}
+
+func extractClaim(t *Tenant, claim string) (string, error) {
+	switch claim {
+	case "id":
+		return t.ID, nil
+	case "externalid":
+		return t.ExternalID, nil
+	}
+	return "", errors.New("memory: invalid field")
+}

--- a/pkg/tenant/manager/memory/memory.go
+++ b/pkg/tenant/manager/memory/memory.go
@@ -33,46 +33,30 @@ func init() {
 	registry.Register("memory", New)
 }
 
-type config struct {
-	// Users holds a map with userid and user
-	Tenants map[string]*Tenant `mapstructure:"tenants"`
+// tenantEntry is used only for mapstructure decoding of the config.
+type tenantEntry struct {
+	ID         string `mapstructure:"id"`
+	ExternalID string `mapstructure:"external_id"`
+	Name       string `mapstructure:"name"`
 }
 
-// User holds a user but uses in mapstructure names
-type Tenant struct {
-	ID         string `mapstructure:"id" json:"id"`
-	ExternalID string `mapstructure:"external_id" json:"external_id"`
-	Name       string `mapstructure:"name" json:"name"`
+type config struct {
+	Tenants map[string]*tenantEntry `mapstructure:"tenants"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
 	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	if len(c.Tenants) == 0 {
-		c.Tenants = map[string]*Tenant{
-			"f65b26f8-2ce2-11f1-b0af-7f3198d25769": &Tenant{
-				ID:         "f65b26f8-2ce2-11f1-b0af-7f3198d25769",
-				ExternalID: "externalid_1",
-				Name:       "Tenant One",
-			},
-			"f76a25ee-2ce2-11f1-9852-4fa5a531eb10": {
-				ID:         "f76a25ee-2ce2-11f1-9852-4fa5a531eb10",
-				ExternalID: "externalid_2",
-				Name:       "Tenant Two",
-			},
-		}
+		return nil, errors.Wrap(err, "error decoding conf")
 	}
 	return c, nil
 }
 
 type manager struct {
-	catalog map[string]*Tenant
+	catalog map[string]*tenantpb.Tenant
 }
 
-// New returns a new user manager.
+// New returns a new tenant manager.
 func New(m map[string]interface{}) (tenant.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
@@ -84,17 +68,20 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	m.catalog = c.Tenants
+	m.catalog = make(map[string]*tenantpb.Tenant, len(c.Tenants))
+	for k, t := range c.Tenants {
+		m.catalog[k] = &tenantpb.Tenant{
+			Id:         t.ID,
+			ExternalId: t.ExternalID,
+			Name:       t.Name,
+		}
+	}
 	return nil
 }
 
 func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, error) {
 	if t, ok := m.catalog[id]; ok {
-		return &tenantpb.Tenant{
-			Id:         t.ID,
-			ExternalId: t.ExternalID,
-			Name:       t.Name,
-		}, nil
+		return t, nil
 	}
 	return nil, errtypes.NotFound(id)
 }
@@ -102,22 +89,18 @@ func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, e
 func (m *manager) GetTenantByClaim(ctx context.Context, claim, value string) (*tenantpb.Tenant, error) {
 	for _, t := range m.catalog {
 		if tenantClaim, err := extractClaim(t, claim); err == nil && value == tenantClaim {
-			return &tenantpb.Tenant{
-				Id:         t.ID,
-				ExternalId: t.ExternalID,
-				Name:       t.Name,
-			}, nil
+			return t, nil
 		}
 	}
 	return nil, errtypes.NotFound(value)
 }
 
-func extractClaim(t *Tenant, claim string) (string, error) {
+func extractClaim(t *tenantpb.Tenant, claim string) (string, error) {
 	switch claim {
 	case "id":
-		return t.ID, nil
+		return t.Id, nil
 	case "externalid":
-		return t.ExternalID, nil
+		return t.ExternalId, nil
 	}
-	return "", errors.New("memory: invalid field")
+	return "", errors.New("memory: invalid claim")
 }

--- a/pkg/tenant/manager/null/null.go
+++ b/pkg/tenant/manager/null/null.go
@@ -1,0 +1,49 @@
+// Copyright 2018-2020 CERN
+// Copyright 2026 OpenCloud GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package null
+
+import (
+	"context"
+
+	tenantpb "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
+)
+
+func init() {
+	registry.Register("null", New)
+}
+
+type manager struct {
+}
+
+// New returns a tenant manager implementation that return NOT FOUND or empty result set for every call
+func New(m map[string]interface{}) (tenant.Manager, error) {
+	return &manager{}, nil
+}
+
+func (m *manager) GetTenant(ctx context.Context, id string) (*tenantpb.Tenant, error) {
+	return nil, errtypes.NotFound(id)
+}
+
+func (m *manager) GetTenantByClaim(ctx context.Context, claim, value string) (*tenantpb.Tenant, error) {
+	return nil, errtypes.NotFound(value)
+}

--- a/pkg/tenant/manager/registry/registry.go
+++ b/pkg/tenant/manager/registry/registry.go
@@ -1,0 +1,36 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package registry
+
+import (
+	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+)
+
+// NewFunc is the function that tenant managers
+// should register at init time.
+type NewFunc func(map[string]interface{}) (tenant.Manager, error)
+
+// NewFuncs is a map containing all the registered user managers.
+var NewFuncs = map[string]NewFunc{}
+
+// Register registers a new user manager new function.
+// Not safe for concurrent use. Safe for use from package init.
+func Register(name string, f NewFunc) {
+	NewFuncs[name] = f
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -1,0 +1,34 @@
+// Copyright 2018-2021 CERN
+// Copyright 2026 OpenCloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package tenant
+
+import (
+	"context"
+
+	tenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+)
+
+// Manager is the interface to implement to manipulate users.
+type Manager interface {
+	// GetTenant returns the tenant metadata identified by an id.
+	GetTenant(ctx context.Context, id string) (*tenant.Tenant, error)
+	// GetUserByClaim returns the user identified by a specific value for a given claim.
+	GetTenantByClaim(ctx context.Context, claim, value string) (*tenant.Tenant, error)
+}

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -915,14 +915,14 @@ func (i *Identity) GetLDAPTenantByFilter(ctx context.Context, lc ldap.Client, fi
 	)
 
 	setLDAPSearchSpanAttributes(span, searchRequest)
-	log.Debug().Str("backend", "ldap").Str("basedn", i.User.BaseDN).Str("filter", filter).Int("scope", i.User.scopeVal).Msg("LDAP Search")
+	log.Debug().Str("backend", "ldap").Str("basedn", i.Tenant.BaseDN).Str("filter", filter).Int("scope", i.Tenant.scopeVal).Msg("LDAP Search")
 	res, err := lc.Search(searchRequest)
 	if err != nil {
-		log.Debug().Str("backend", "ldap").Err(err).Str("tenantfilter", filter).Msg("Error looking up user by filter")
+		log.Debug().Str("backend", "ldap").Err(err).Str("tenantfilter", filter).Msg("Error looking up tenant by filter")
 		var errmsg string
 		if lerr, ok := err.(*ldap.Error); ok {
 			if lerr.ResultCode == ldap.LDAPResultSizeLimitExceeded {
-				errmsg = fmt.Sprintf("too many results searching for user '%s'", filter)
+				errmsg = fmt.Sprintf("too many results searching for tenant '%s'", filter)
 			}
 		}
 		span.SetAttributes(attribute.String("ldap.error", errmsg))
@@ -968,13 +968,15 @@ func (i *Identity) getTenantAttributeFilter(attribute, value string) (string, er
 	case "externalid":
 		attribute = i.Tenant.Schema.ExternalID
 	}
-	// we can ignore the error here, filterEscapeAttribute only returns error when binary (the 2nd parameter) is `true`
-	value, _ = filterEscapeAttribute("", false, value)
+	escapedValue, err := filterEscapeAttribute("", false, value)
+	if err != nil {
+		return "", fmt.Errorf("error escaping filter value %q: %w", value, err)
+	}
 	return fmt.Sprintf("(&%s(objectclass=%s)(%s=%s))",
 		i.Tenant.Filter,
 		i.Tenant.Objectclass,
 		attribute,
-		value,
+		escapedValue,
 	), nil
 }
 

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -38,8 +38,9 @@ import (
 
 // Identity provides methods to query users and groups from an LDAP server
 type Identity struct {
-	User  userConfig  `mapstructure:",squash"`
-	Group groupConfig `mapstructure:",squash"`
+	User   userConfig   `mapstructure:",squash"`
+	Group  groupConfig  `mapstructure:",squash"`
+	Tenant tenantConfig `mapstructure:",squash"`
 }
 
 const tracerName = "pkg/utils/ldap"
@@ -69,6 +70,15 @@ type groupConfig struct {
 	substringFilterVal  int
 	// LocalDisabledDN contains the full DN of a group that contains disabled users.
 	LocalDisabledDN string `mapstructure:"group_local_disabled_dn"`
+}
+
+type tenantConfig struct {
+	BaseDN      string `mapstructure:"tenant_base_dn"`
+	Scope       string `mapstructure:"tenant_search_scope"`
+	scopeVal    int
+	Filter      string       `mapstructure:"tenant_filter"`
+	Objectclass string       `mapstructure:"tenant_objectclass"`
+	Schema      tenantSchema `mapstructure:"tenant_schema"`
 }
 
 type groupSchema struct {
@@ -106,6 +116,12 @@ type userSchema struct {
 	TenantID string `mapstructure:"tenantId"`
 }
 
+type tenantSchema struct {
+	ID         string `mapstructure:"id"`
+	ExternalID string `mapstructure:"externalId"`
+	Name       string `mapstructure:"name"`
+}
+
 // Default userConfig (somewhat inspired by Active Directory)
 var userDefaults = userConfig{
 	Scope:       "sub",
@@ -138,11 +154,23 @@ var groupDefaults = groupConfig{
 	SubstringFilterType: "initial",
 }
 
+// Default tenantConfig (works with OpenCloud's education Schema)
+var tenantDefaults = tenantConfig{
+	Scope:       "sub",
+	Objectclass: "openCloudEducationSchool",
+	Schema: tenantSchema{
+		ID:         "openCloudUUID",
+		ExternalID: "openCloudEducationExternalId",
+		Name:       "ou",
+	},
+}
+
 // New initializes the default config
 func New() Identity {
 	return Identity{
-		User:  userDefaults,
-		Group: groupDefaults,
+		User:   userDefaults,
+		Group:  groupDefaults,
+		Tenant: tenantDefaults,
 	}
 }
 
@@ -157,6 +185,10 @@ func (i *Identity) Setup() error {
 
 	if i.Group.scopeVal, err = stringToScope(i.Group.Scope); err != nil {
 		return fmt.Errorf("error configuring group scope: %w", err)
+	}
+
+	if i.Tenant.scopeVal, err = stringToScope(i.Tenant.Scope); err != nil {
+		return fmt.Errorf("error configuring tenant scope: %w", err)
 	}
 
 	if i.User.substringFilterVal, err = stringToFilterType(i.User.SubstringFilterType); err != nil {
@@ -847,6 +879,105 @@ func (i *Identity) getUserLDAPAttrTypes() []string {
 	}
 	return attrs
 }
+
+// GetLDAPTenantByID looks up a tenant by the supplied Id. Returns the corresponding
+// ldap.Entry
+func (i *Identity) GetLDAPTenantByID(ctx context.Context, lc ldap.Client, id string) (*ldap.Entry, error) {
+	var filter string
+	var err error
+	if filter, err = i.getTenantFilter(id); err != nil {
+		return nil, err
+	}
+	return i.GetLDAPTenantByFilter(ctx, lc, filter)
+}
+
+// GetLDAPTenantByAttribute looks up a single user by attribute (can be "externalid" or "id")
+func (i *Identity) GetLDAPTenantByAttribute(ctx context.Context, lc ldap.Client, attribute, value string) (*ldap.Entry, error) {
+	var filter string
+	var err error
+	if filter, err = i.getTenantAttributeFilter(attribute, value); err != nil {
+		return nil, err
+	}
+	return i.GetLDAPTenantByFilter(ctx, lc, filter)
+}
+
+// GetLDAPTenantByFilter looks up a single user by the supplied LDAP filter
+// returns the corresponding ldap.Entry
+func (i *Identity) GetLDAPTenantByFilter(ctx context.Context, lc ldap.Client, filter string) (*ldap.Entry, error) {
+	log := appctx.GetLogger(ctx)
+	_, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetLDAPTenantByFilter")
+	defer span.End()
+	searchRequest := ldap.NewSearchRequest(
+		i.Tenant.BaseDN, i.Tenant.scopeVal, ldap.NeverDerefAliases, 1, 0, false,
+		filter,
+		i.getTenantLDAPAttrTypes(),
+		nil,
+	)
+
+	setLDAPSearchSpanAttributes(span, searchRequest)
+	log.Debug().Str("backend", "ldap").Str("basedn", i.User.BaseDN).Str("filter", filter).Int("scope", i.User.scopeVal).Msg("LDAP Search")
+	res, err := lc.Search(searchRequest)
+	if err != nil {
+		log.Debug().Str("backend", "ldap").Err(err).Str("tenantfilter", filter).Msg("Error looking up user by filter")
+		var errmsg string
+		if lerr, ok := err.(*ldap.Error); ok {
+			if lerr.ResultCode == ldap.LDAPResultSizeLimitExceeded {
+				errmsg = fmt.Sprintf("too many results searching for user '%s'", filter)
+			}
+		}
+		span.SetAttributes(attribute.String("ldap.error", errmsg))
+		span.SetStatus(codes.Error, errmsg)
+		return nil, errtypes.NotFound(errmsg)
+	}
+	if len(res.Entries) == 0 {
+		return nil, errtypes.NotFound(filter)
+	}
+	span.SetStatus(codes.Ok, "")
+
+	return res.Entries[0], nil
+}
+
+func (i *Identity) getTenantLDAPAttrTypes() []string {
+	// The are the attributes we request unconditionally when looking up users
+	// as they are needed to populate a user object
+	return []string{
+		i.Tenant.Schema.ID,
+		i.Tenant.Schema.ExternalID,
+		i.Tenant.Schema.Name,
+	}
+}
+
+func (i *Identity) getTenantFilter(id string) (string, error) {
+	var escapedUUID string
+	escapedUUID, err := filterEscapeAttribute(i.Tenant.Schema.ID, false, id)
+	if err != nil {
+		return "", fmt.Errorf("error parsing id '%s' as UUID: %w", id, err)
+	}
+	return fmt.Sprintf("(&%s(objectclass=%s)(%s=%s))",
+		i.Tenant.Filter,
+		i.Tenant.Objectclass,
+		i.Tenant.Schema.ID,
+		escapedUUID,
+	), nil
+}
+
+func (i *Identity) getTenantAttributeFilter(attribute, value string) (string, error) {
+	switch attribute {
+	case "id":
+		attribute = i.Tenant.Schema.ID
+	case "externalid":
+		attribute = i.Tenant.Schema.ExternalID
+	}
+	// we can ignore the error here, filterEscapeAttribute only returns error when binary (the 2nd parameter) is `true`
+	value, _ = filterEscapeAttribute("", false, value)
+	return fmt.Sprintf("(&%s(objectclass=%s)(%s=%s))",
+		i.Tenant.Filter,
+		i.Tenant.Objectclass,
+		attribute,
+		value,
+	), nil
+}
+
 func setLDAPSearchSpanAttributes(span trace.Span, request *ldap.SearchRequest) {
 	span.SetAttributes(
 		attribute.String("ldap.basedn", request.BaseDN),

--- a/tests/cs3mocks/mocks/GatewayAPIClient.go
+++ b/tests/cs3mocks/mocks/GatewayAPIClient.go
@@ -56,6 +56,8 @@ import (
 
 	registryv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 
+	tenantv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
+
 	txv1beta1 "github.com/cs3org/go-cs3apis/cs3/tx/v1beta1"
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -3503,6 +3505,152 @@ func (_c *GatewayAPIClient_GetShare_Call) Return(_a0 *collaborationv1beta1.GetSh
 }
 
 func (_c *GatewayAPIClient_GetShare_Call) RunAndReturn(run func(context.Context, *collaborationv1beta1.GetShareRequest, ...grpc.CallOption) (*collaborationv1beta1.GetShareResponse, error)) *GatewayAPIClient_GetShare_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTenant provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayAPIClient) GetTenant(ctx context.Context, in *tenantv1beta1.GetTenantRequest, opts ...grpc.CallOption) (*tenantv1beta1.GetTenantResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _m.Called(ctx, in, opts)
+	} else {
+		tmpRet = _m.Called(ctx, in)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTenant")
+	}
+
+	var r0 *tenantv1beta1.GetTenantResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *tenantv1beta1.GetTenantRequest, ...grpc.CallOption) (*tenantv1beta1.GetTenantResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *tenantv1beta1.GetTenantRequest, ...grpc.CallOption) *tenantv1beta1.GetTenantResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tenantv1beta1.GetTenantResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *tenantv1beta1.GetTenantRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GatewayAPIClient_GetTenant_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTenant'
+type GatewayAPIClient_GetTenant_Call struct {
+	*mock.Call
+}
+
+// GetTenant is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *tenantv1beta1.GetTenantRequest
+//   - opts ...grpc.CallOption
+func (_e *GatewayAPIClient_Expecter) GetTenant(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_GetTenant_Call {
+	return &GatewayAPIClient_GetTenant_Call{Call: _e.mock.On("GetTenant",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *GatewayAPIClient_GetTenant_Call) Run(run func(ctx context.Context, in *tenantv1beta1.GetTenantRequest, opts ...grpc.CallOption)) *GatewayAPIClient_GetTenant_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*tenantv1beta1.GetTenantRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *GatewayAPIClient_GetTenant_Call) Return(_a0 *tenantv1beta1.GetTenantResponse, _a1 error) *GatewayAPIClient_GetTenant_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GatewayAPIClient_GetTenant_Call) RunAndReturn(run func(context.Context, *tenantv1beta1.GetTenantRequest, ...grpc.CallOption) (*tenantv1beta1.GetTenantResponse, error)) *GatewayAPIClient_GetTenant_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTenantByClaim provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayAPIClient) GetTenantByClaim(ctx context.Context, in *tenantv1beta1.GetTenantByClaimRequest, opts ...grpc.CallOption) (*tenantv1beta1.GetTenantByClaimResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _m.Called(ctx, in, opts)
+	} else {
+		tmpRet = _m.Called(ctx, in)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTenantByClaim")
+	}
+
+	var r0 *tenantv1beta1.GetTenantByClaimResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *tenantv1beta1.GetTenantByClaimRequest, ...grpc.CallOption) (*tenantv1beta1.GetTenantByClaimResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *tenantv1beta1.GetTenantByClaimRequest, ...grpc.CallOption) *tenantv1beta1.GetTenantByClaimResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*tenantv1beta1.GetTenantByClaimResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *tenantv1beta1.GetTenantByClaimRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GatewayAPIClient_GetTenantByClaim_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTenantByClaim'
+type GatewayAPIClient_GetTenantByClaim_Call struct {
+	*mock.Call
+}
+
+// GetTenantByClaim is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *tenantv1beta1.GetTenantByClaimRequest
+//   - opts ...grpc.CallOption
+func (_e *GatewayAPIClient_Expecter) GetTenantByClaim(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_GetTenantByClaim_Call {
+	return &GatewayAPIClient_GetTenantByClaim_Call{Call: _e.mock.On("GetTenantByClaim",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *GatewayAPIClient_GetTenantByClaim_Call) Run(run func(ctx context.Context, in *tenantv1beta1.GetTenantByClaimRequest, opts ...grpc.CallOption)) *GatewayAPIClient_GetTenantByClaim_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*tenantv1beta1.GetTenantByClaimRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *GatewayAPIClient_GetTenantByClaim_Call) Return(_a0 *tenantv1beta1.GetTenantByClaimResponse, _a1 error) *GatewayAPIClient_GetTenantByClaim_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GatewayAPIClient_GetTenantByClaim_Call) RunAndReturn(run func(context.Context, *tenantv1beta1.GetTenantByClaimRequest, ...grpc.CallOption) (*tenantv1beta1.GetTenantByClaimResponse, error)) *GatewayAPIClient_GetTenantByClaim_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
The Tenant API Service is used for resolving Tenant IDs. (See https://github.com/opencloud-eu/opencloud/issues/2310 for details). The API is served as part of the userprovider service as seemed overkill to add you another service for this.

We added three drivers:
- memory: Simple in-memory configuration. Mainly just for testing purposes. E.g. used in the unit-tests
- null: Similar to the "null" driver for the groupprovider. Always returns `NotFound` as a result. This is used in configuration where multi-tenancy is disabled.
- ldap: To be able to lookup in LDAP, the default configuration is modeled around the "openCloudEducationSchool" LDAP schema.

OpenCloud side of the feature is here: https://github.com/opencloud-eu/opencloud/pull/2569