### PR TITLE
Manage space membership in shareprovider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -273,3 +273,5 @@ tool (
 replace github.com/go-micro/plugins/v4/store/nats-js-kv => github.com/opencloud-eu/go-micro-plugins/v4/store/nats-js-kv v0.0.0-20250512152754-23325793059a
 
 replace github.com/pablodz/inotifywaitgo v0.0.9 => github.com/opencloud-eu/inotifywaitgo v0.0.0-20251111171128-a390bae3c5e9
+
+replace github.com/cs3org/go-cs3apis => github.com/rhafer/go-cs3apis v0.0.0-20260413131235-e7986512ba10

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20260407125717-5d69ba49048b h1:WNwuveokaUXIAGrwVLWqJSk0BdJv8k+9RXipBItGuyY=
-github.com/cs3org/go-cs3apis v0.0.0-20260407125717-5d69ba49048b/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -753,6 +751,8 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
+github.com/rhafer/go-cs3apis v0.0.0-20260413131235-e7986512ba10 h1:Mq6trS+bIizTyGYwifCtkj1mLsvdhlvLjhZLD1Yw6j4=
+github.com/rhafer/go-cs3apis v0.0.0-20260413131235-e7986512ba10/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -414,38 +414,45 @@ func SpaceEnabled(r *provider.UpdateStorageSpaceResponse, req *provider.UpdateSt
 }
 
 // SpaceShared converts the response to an event
-// func SpaceShared(req *provider.AddGrantRequest, executant, sharer *user.UserId, grantee *provider.Grantee) events.SpaceShared {
-func SpaceShared(r *provider.AddGrantResponse, req *provider.AddGrantRequest, executant *user.User) events.SpaceShared {
-	id := storagespace.FormatStorageID(req.Ref.ResourceId.StorageId, req.Ref.ResourceId.SpaceId)
+func SpaceShared(r *collaboration.CreateShareResponse, executant *user.User) events.SpaceShared {
+	id := storagespace.FormatStorageID(r.GetShare().GetResourceId().GetStorageId(), r.GetShare().GetResourceId().GetSpaceId())
 	return events.SpaceShared{
 		Executant:      executant.GetId(),
-		Creator:        req.Grant.Creator,
-		GranteeUserID:  req.Grant.GetGrantee().GetUserId(),
-		GranteeGroupID: req.Grant.GetGrantee().GetGroupId(),
+		Creator:        r.Share.GetCreator(),
+		GranteeUserID:  r.Share.GetGrantee().GetUserId(),
+		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
 		ID:             &provider.StorageSpaceId{OpaqueId: id},
 		Timestamp:      time.Now(),
 	}
 }
 
 // SpaceShareUpdated converts the response to an events
-func SpaceShareUpdated(r *provider.UpdateGrantResponse, req *provider.UpdateGrantRequest, executant *user.User) events.SpaceShareUpdated {
-	id := storagespace.FormatStorageID(req.Ref.ResourceId.StorageId, req.Ref.ResourceId.SpaceId)
+func SpaceShareUpdated(r *collaboration.UpdateShareResponse, executant *user.User) events.SpaceShareUpdated {
+	id := storagespace.FormatStorageID(r.GetShare().GetResourceId().GetStorageId(), r.GetShare().GetResourceId().GetSpaceId())
 	return events.SpaceShareUpdated{
 		Executant:      executant.GetId(),
-		GranteeUserID:  req.Grant.GetGrantee().GetUserId(),
-		GranteeGroupID: req.Grant.GetGrantee().GetGroupId(),
+		GranteeUserID:  r.GetShare().GetGrantee().GetUserId(),
+		GranteeGroupID: r.GetShare().GetGrantee().GetGroupId(),
 		ID:             &provider.StorageSpaceId{OpaqueId: id},
 		Timestamp:      time.Now(),
 	}
 }
 
 // SpaceUnshared  converts the response to an event
-func SpaceUnshared(r *provider.RemoveGrantResponse, req *provider.RemoveGrantRequest, executant *user.User) events.SpaceUnshared {
-	id := storagespace.FormatStorageID(req.Ref.ResourceId.StorageId, req.Ref.ResourceId.SpaceId)
+func SpaceUnshared(r *collaboration.RemoveShareResponse, req *collaboration.RemoveShareRequest, executant *user.User) events.SpaceUnshared {
+	var (
+		userid  *user.UserId
+		groupid *group.GroupId
+		rid     *provider.ResourceId
+	)
+	_ = utils.ReadJSONFromOpaque(r.Opaque, "granteeuserid", &userid)
+	_ = utils.ReadJSONFromOpaque(r.Opaque, "granteegroupid", &groupid)
+	_ = utils.ReadJSONFromOpaque(r.Opaque, "resourceid", &rid)
+	id := storagespace.FormatStorageID(rid.StorageId, rid.SpaceId)
 	return events.SpaceUnshared{
 		Executant:      executant.GetId(),
-		GranteeUserID:  req.Grant.GetGrantee().GetUserId(),
-		GranteeGroupID: req.Grant.GetGrantee().GetGroupId(),
+		GranteeUserID:  userid,
+		GranteeGroupID: groupid,
 		ID:             &provider.StorageSpaceId{OpaqueId: id},
 		Timestamp:      time.Now(),
 	}

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -81,15 +81,27 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		switch v := res.(type) {
 		case *collaboration.CreateShareResponse:
 			if isSuccess(v) {
-				ev = ShareCreated(v, executant)
+				if utils.ExistsInOpaque(v.Opaque, "spacegrant") {
+					ev = SpaceShared(v, executant)
+				} else {
+					ev = ShareCreated(v, executant)
+				}
 			}
 		case *collaboration.RemoveShareResponse:
 			if isSuccess(v) {
-				ev = ShareRemoved(v, req.(*collaboration.RemoveShareRequest), executant)
+				if utils.ExistsInOpaque(v.Opaque, "spacegrant") {
+					ev = SpaceUnshared(v, req.(*collaboration.RemoveShareRequest), executant)
+				} else {
+					ev = ShareRemoved(v, req.(*collaboration.RemoveShareRequest), executant)
+				}
 			}
 		case *collaboration.UpdateShareResponse:
 			if isSuccess(v) {
-				ev = ShareUpdated(v, req.(*collaboration.UpdateShareRequest), executant)
+				if utils.ExistsInOpaque(v.Opaque, "spacegrant") {
+					ev = SpaceShareUpdated(v, executant)
+				} else {
+					ev = ShareUpdated(v, req.(*collaboration.UpdateShareRequest), executant)
+				}
 			}
 		case *collaboration.UpdateReceivedShareResponse:
 			if isSuccess(v) {
@@ -116,24 +128,6 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		case *ocmcore.CreateOCMCoreShareResponse:
 			if isSuccess(v) {
 				ev = OCMCoreShareCreated(v, req.(*ocmcore.CreateOCMCoreShareRequest), executant)
-			}
-		case *provider.AddGrantResponse:
-			// TODO: update CS3 APIs
-			// FIXME these should be part of the RemoveGrantRequest object
-			// https://github.com/owncloud/ocis/issues/4312
-			r := req.(*provider.AddGrantRequest)
-			if isSuccess(v) && utils.ExistsInOpaque(r.Opaque, "spacegrant") {
-				ev = SpaceShared(v, r, executant)
-			}
-		case *provider.UpdateGrantResponse:
-			r := req.(*provider.UpdateGrantRequest)
-			if isSuccess(v) && utils.ExistsInOpaque(r.Opaque, "spacegrant") {
-				ev = SpaceShareUpdated(v, r, executant)
-			}
-		case *provider.RemoveGrantResponse:
-			r := req.(*provider.RemoveGrantRequest)
-			if isSuccess(v) && utils.ExistsInOpaque(r.Opaque, "spacegrant") {
-				ev = SpaceUnshared(v, req.(*provider.RemoveGrantRequest), executant)
 			}
 		case *provider.CreateContainerResponse:
 			if isSuccess(v) {

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -81,6 +81,9 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		switch v := res.(type) {
 		case *collaboration.CreateShareResponse:
 			if isSuccess(v) {
+				if utils.ExistsInOpaque(v.Opaque, "noevent") {
+					break
+				}
 				if utils.ExistsInOpaque(v.Opaque, "spacegrant") {
 					ev = SpaceShared(v, executant)
 				} else {

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -36,6 +36,8 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/conversions"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -224,6 +226,34 @@ func (s *svc) CreateStorageSpace(ctx context.Context, req *provider.CreateStorag
 		return &provider.CreateStorageSpaceResponse{
 			Status: status.NewStatusFromErrType(ctx, "gateway could not call CreateStorageSpace", err),
 		}, nil
+	}
+
+	// If the create space is not a "personal" space, we add a Share to the ShareProvider to give the creator
+	// of the space "manager" access to it.
+	// Note: the DecomposedFS storagadriver already adds a grant to the space root giving that access, the "CreateShare"
+	//       here is happeing so that that grant is also visible when listing permission (shares) on the spaceroot.
+	if req.GetType() != "personal" && createRes.GetStatus().GetCode() == rpc.Code_CODE_OK {
+		u := ctxpkg.ContextMustGetUser(ctx)
+		shareReq := &collaborationv1beta1.CreateShareRequest{
+			ResourceInfo: &provider.ResourceInfo{
+				Id: createRes.GetStorageSpace().GetRoot(),
+			},
+			Grant: &collaborationv1beta1.ShareGrant{
+				Grantee: &provider.Grantee{
+					Type: provider.GranteeType_GRANTEE_TYPE_USER,
+					Id: &provider.Grantee_UserId{
+						UserId: u.GetId(),
+					},
+				},
+				Permissions: &collaborationv1beta1.SharePermissions{
+					Permissions: conversions.NewManagerRole().CS3ResourcePermissions(),
+				},
+			},
+		}
+		csResp, err := s.CreateShare(ctx, shareReq)
+		if err != nil || csResp.GetStatus().GetCode() != rpc.Code_CODE_OK {
+			log.Error().Err(err).Interface("status", csResp.GetStatus()).Interface("space_id", createRes.GetStorageSpace().GetId()).Msg("failed to create share for space owner")
+		}
 	}
 
 	return createRes, nil

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -760,6 +760,9 @@ func (s *svc) removeShare(ctx context.Context, req *collaboration.RemoveShareReq
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling RemoveShare")
 	}
+	if res.Status.Code != rpc.Code_CODE_OK {
+		return res, nil
+	}
 
 	if s.c.CommitShareToStorageGrant {
 		var opaque *typesv1beta1.Opaque

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -150,7 +150,16 @@ func (s *svc) updateShare(ctx context.Context, req *collaboration.UpdateShareReq
 			Expiration:  res.GetShare().GetExpiration(),
 			Creator:     creator.GetId(),
 		}
-		updateGrantStatus, err := s.updateGrant(ctx, res.GetShare().GetResourceId(), grant, nil)
+		var opaque *typesv1beta1.Opaque
+		if refIsSpaceRoot(res.GetShare().GetResourceId()) {
+			opaque = &typesv1beta1.Opaque{
+				Map: map[string]*typesv1beta1.OpaqueEntry{
+					"spacegrant": {},
+				},
+			}
+			utils.AppendPlainToOpaque(opaque, "spacetype", utils.ReadPlainFromOpaque(req.GetOpaque(), "spacetype"))
+		}
+		updateGrantStatus, err := s.updateGrant(ctx, res.GetShare().GetResourceId(), grant, opaque)
 
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error calling updateGrant")
@@ -613,13 +622,22 @@ func (s *svc) addShare(ctx context.Context, req *collaboration.CreateShareReques
 	if s.c.CommitShareToStorageGrant {
 		// If the share is a denial we call denyGrant instead.
 		var status *rpc.Status
+		var opaque *typesv1beta1.Opaque
+		if refIsSpaceRoot(req.ResourceInfo.Id) {
+			opaque = &typesv1beta1.Opaque{
+				Map: map[string]*typesv1beta1.OpaqueEntry{
+					"spacegrant": {},
+				},
+			}
+			utils.AppendPlainToOpaque(opaque, "spacetype", req.ResourceInfo.GetSpace().GetSpaceType())
+		}
 		if grants.PermissionsEqual(req.Grant.Permissions.Permissions, &provider.ResourcePermissions{}) {
-			status, err = s.denyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, nil)
+			status, err = s.denyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, opaque)
 			if err != nil {
 				return nil, errors.Wrap(err, "gateway: error denying grant in storage")
 			}
 		} else {
-			status, err = s.addGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, req.Grant.Permissions.Permissions, req.Grant.Expiration, nil)
+			status, err = s.addGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, req.Grant.Permissions.Permissions, req.Grant.Expiration, opaque)
 			if err != nil {
 				appctx.GetLogger(ctx).Debug().Interface("status", status).Interface("req", req).Msg(err.Error())
 				rollBackFn(status)
@@ -744,7 +762,15 @@ func (s *svc) removeShare(ctx context.Context, req *collaboration.RemoveShareReq
 	}
 
 	if s.c.CommitShareToStorageGrant {
-		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions, nil)
+		var opaque *typesv1beta1.Opaque
+		if refIsSpaceRoot(share.ResourceId) {
+			opaque = &typesv1beta1.Opaque{
+				Map: map[string]*typesv1beta1.OpaqueEntry{
+					"spacegrant": {},
+				},
+			}
+		}
+		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions, opaque)
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error removing grant from storage")
 		}

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -646,7 +646,7 @@ func (s *svc) addShare(ctx context.Context, req *collaboration.CreateShareReques
 		}
 
 		switch status.Code {
-		case rpc.Code_CODE_OK:
+		case rpc.Code_CODE_OK, rpc.Code_CODE_ALREADY_EXISTS:
 			// ok
 		case rpc.Code_CODE_UNIMPLEMENTED:
 			appctx.GetLogger(ctx).Debug().Interface("status", status).Interface("req", req).Msg("storing grants not supported, ignoring")

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -46,6 +46,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/opencloud-eu/reva/v2/pkg/share"
 	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
@@ -1093,12 +1094,8 @@ func (s *service) resolveAcceptedShare(ctx context.Context, ref *provider.Refere
 	if ref.ResourceId.OpaqueId == utils.ShareStorageProviderID && ref.Path != "." {
 		lsRes, err := sharingCollaborationClient.ListReceivedShares(ctx, &collaboration.ListReceivedSharesRequest{
 			Filters: []*collaboration.Filter{
-				{
-					Type: collaboration.Filter_TYPE_STATE,
-					Term: &collaboration.Filter_State{
-						State: collaboration.ShareState_SHARE_STATE_ACCEPTED,
-					},
-				},
+				share.StateFilter(collaboration.ShareState_SHARE_STATE_ACCEPTED),
+				share.SpaceRootFilter(false),
 				// TODO filter by mountpoint?
 			},
 		})
@@ -1179,12 +1176,8 @@ func (s *service) fetchAcceptedShares(ctx context.Context, opaque *typesv1beta1.
 
 	lsRes, err := sharingCollaborationClient.ListReceivedShares(ctx, &collaboration.ListReceivedSharesRequest{
 		Filters: []*collaboration.Filter{
-			{
-				Type: collaboration.Filter_TYPE_STATE,
-				Term: &collaboration.Filter_State{
-					State: collaboration.ShareState_SHARE_STATE_ACCEPTED,
-				},
-			},
+			share.StateFilter(collaboration.ShareState_SHARE_STATE_ACCEPTED),
+			share.SpaceRootFilter(false),
 		},
 	})
 	if err != nil {

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -220,15 +220,38 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 		}, err
 	}
 
+	isSpaceRoot := utils.IsSpaceRoot(sRes.GetInfo())
+
 	// do not allow share to myself or the owner if share is for a user
 	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_USER &&
 		(utils.UserEqual(req.GetGrant().GetGrantee().GetUserId(), user.Id) || utils.UserEqual(req.GetGrant().GetGrantee().GetUserId(), sRes.GetInfo().GetOwner())) {
-		err := errtypes.BadRequest("jsoncs3: owner/creator and grantee are the same")
-		return nil, err
+
+		denySelfShare := true
+		// To allow adding the initial "mananger" share for the creator of a space when need to make an exception here
+		// if the shared resource is a space root, that does not have any Share existin yet. Note, that we have already
+		// verified that the user adding the share does really have "AddGrant" permissions on the affected resource, so
+		// this "hack" should be ok.
+		if isSpaceRoot {
+			shares, err := s.sm.ListShares(
+				ctx,
+				[]*collaboration.Filter{share.ResourceIDFilter(req.GetResourceInfo().GetId())},
+			)
+			if err != nil {
+				return &collaboration.CreateShareResponse{
+					Status: status.NewInternal(ctx, "failed to list existing shares"),
+				}, nil
+			}
+			if len(shares) == 0 {
+				denySelfShare = false
+			}
+		}
+		if denySelfShare {
+			err := errtypes.BadRequest("jsoncs3: owner/creator and grantee are the same")
+			return nil, err
+		}
 	}
 
 	// resharing is forbidden for not space roots
-	isSpaceRoot := utils.IsSpaceRoot(sRes.GetInfo())
 	if !isSpaceRoot {
 		// Resharing of Files/Directories is forbidden. So the grants must not allow the "grant" permissions
 		if HasGrantPermissions(req.GetGrant().GetPermissions().GetPermissions()) {

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -218,6 +218,14 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 			Status: status.NewPermissionDenied(ctx, nil, "no permission to add grants on shared resource"),
 		}, err
 	}
+
+	// do not allow share to myself or the owner if share is for a user
+	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_USER &&
+		(utils.UserEqual(req.GetGrant().GetGrantee().GetUserId(), user.Id) || utils.UserEqual(req.GetGrant().GetGrantee().GetUserId(), sRes.GetInfo().GetOwner())) {
+		err := errtypes.BadRequest("jsoncs3: owner/creator and grantee are the same")
+		return nil, err
+	}
+
 	// resharing is forbidden for not space roots
 	if !utils.IsSpaceRoot(sRes.GetInfo()) {
 		// Resharing of Files/Directories is forbidden. So the grants must not allow the "grant" permissions

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -31,6 +31,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -227,7 +228,8 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	}
 
 	// resharing is forbidden for not space roots
-	if !utils.IsSpaceRoot(sRes.GetInfo()) {
+	isSpaceRoot := utils.IsSpaceRoot(sRes.GetInfo())
+	if !isSpaceRoot {
 		// Resharing of Files/Directories is forbidden. So the grants must not allow the "grant" permissions
 		if HasGrantPermissions(req.GetGrant().GetPermissions().GetPermissions()) {
 			return &collaboration.CreateShareResponse{
@@ -266,10 +268,18 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 		}, nil
 	}
 
+	var opaque *typesv1beta1.Opaque
+	if isSpaceRoot {
+		opaque = &typesv1beta1.Opaque{
+			Map: map[string]*typesv1beta1.OpaqueEntry{
+				"spacegrant": {},
+			},
+		}
+	}
 	return &collaboration.CreateShareResponse{
 		Status: status.NewOK(ctx),
 		Share:  createdShare,
-		Opaque: utils.AppendPlainToOpaque(nil, "resourcename", sRes.GetInfo().GetName()),
+		Opaque: utils.AppendPlainToOpaque(opaque, "resourcename", sRes.GetInfo().GetName()),
 	}, nil
 }
 
@@ -317,16 +327,24 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 		}, nil
 	}
 
-	o := utils.AppendJSONToOpaque(nil, "resourceid", share.GetResourceId())
-	o = utils.AppendPlainToOpaque(o, "resourcename", sRes.GetInfo().GetName())
+	var opaque *typesv1beta1.Opaque
+	if utils.IsSpaceRoot(sRes.GetInfo()) {
+		opaque = &typesv1beta1.Opaque{
+			Map: map[string]*typesv1beta1.OpaqueEntry{
+				"spacegrant": {},
+			},
+		}
+	}
+	opaque = utils.AppendJSONToOpaque(opaque, "resourceid", share.GetResourceId())
+	opaque = utils.AppendPlainToOpaque(opaque, "resourcename", sRes.GetInfo().GetName())
 	if user := share.GetGrantee().GetUserId(); user != nil {
-		o = utils.AppendJSONToOpaque(o, "granteeuserid", user)
+		opaque = utils.AppendJSONToOpaque(opaque, "granteeuserid", user)
 	} else {
-		o = utils.AppendJSONToOpaque(o, "granteegroupid", share.GetGrantee().GetGroupId())
+		opaque = utils.AppendJSONToOpaque(opaque, "granteegroupid", share.GetGrantee().GetGroupId())
 	}
 
 	return &collaboration.RemoveShareResponse{
-		Opaque: o,
+		Opaque: opaque,
 		Status: status.NewOK(ctx),
 	}, nil
 }
@@ -469,10 +487,19 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 		}, nil
 	}
 
+	var opaque *typesv1beta1.Opaque
+	if utils.IsSpaceRoot(sRes.GetInfo()) {
+		opaque = &typesv1beta1.Opaque{
+			Map: map[string]*typesv1beta1.OpaqueEntry{
+				"spacegrant": {},
+			},
+		}
+	}
+
 	res := &collaboration.UpdateShareResponse{
 		Status: status.NewOK(ctx),
 		Share:  share,
-		Opaque: utils.AppendPlainToOpaque(nil, "resourcename", sRes.GetInfo().GetName()),
+		Opaque: utils.AppendPlainToOpaque(opaque, "resourcename", sRes.GetInfo().GetName()),
 	}
 	return res, nil
 }

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -253,6 +253,7 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 			}
 			if len(shares) == 0 {
 				denySelfShare = false
+				noEvent = true
 			}
 		}
 		if denySelfShare {
@@ -306,6 +307,14 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 		opaque = &typesv1beta1.Opaque{
 			Map: map[string]*typesv1beta1.OpaqueEntry{
 				"spacegrant": {},
+			},
+		}
+	}
+
+	if noEvent {
+		opaque = &typesv1beta1.Opaque{
+			Map: map[string]*typesv1beta1.OpaqueEntry{
+				"noevent": {},
 			},
 		}
 	}

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -340,6 +340,30 @@ func HasGrantPermissions(p *provider.ResourcePermissions) bool {
 	return p.GetAddGrant() || p.GetUpdateGrant() || p.GetRemoveGrant() || p.GetDenyGrant()
 }
 
+// spaceRootHasRemainingManager returns true if the given resource has at least one share
+// (excluding the share with excludeShareOpaqueID) that grants both AddGrant and RemoveGrant.
+func (s *service) spaceRootHasRemainingManager(ctx context.Context, resourceID *provider.ResourceId, excludeShareOpaqueID string) (bool, error) {
+	shares, err := s.sm.ListShares(ctx, []*collaboration.Filter{
+		{
+			Type: collaboration.Filter_TYPE_RESOURCE_ID,
+			Term: &collaboration.Filter_ResourceId{ResourceId: resourceID},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, s := range shares {
+		if s.GetId().GetOpaqueId() == excludeShareOpaqueID {
+			continue
+		}
+		perms := s.GetPermissions().GetPermissions()
+		if perms.GetAddGrant() && perms.GetRemoveGrant() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShareRequest) (*collaboration.RemoveShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	user := ctxpkg.ContextMustGetUser(ctx)
@@ -371,6 +395,20 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 		return &collaboration.RemoveShareResponse{
 			Status: status.NewPermissionDenied(ctx, nil, "no permission to remove grants on shared resource"),
 		}, err
+	}
+
+	// For space root shares, ensure at least one share with both AddGrant and RemoveGrant will remain
+	// so the space always has a manager who can administer grants.
+	if utils.IsSpaceRoot(sRes.GetInfo()) {
+		if ok, err := s.spaceRootHasRemainingManager(ctx, share.GetResourceId(), share.GetId().GetOpaqueId()); err != nil {
+			return &collaboration.RemoveShareResponse{
+				Status: status.NewInternal(ctx, "failed to list shares for space root"),
+			}, nil
+		} else if !ok {
+			return &collaboration.RemoveShareResponse{
+				Status: status.NewPermissionDenied(ctx, nil, "cannot remove the last share with manager permissions on a space root"),
+			}, nil
+		}
 	}
 
 	err = s.sm.Unshare(ctx, req.Ref)
@@ -521,6 +559,20 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 		return &collaboration.UpdateShareResponse{
 			Status: status.NewPermissionDenied(ctx, nil, "insufficient permissions to create that kind of share"),
 		}, nil
+	}
+
+	// For space root shares, if the new permissions would strip AddGrant or RemoveGrant from this share,
+	// ensure at least one other share still has both so the space retains a manager.
+	if utils.IsSpaceRoot(sRes.GetInfo()) && newPermissions != nil && (!newPermissions.GetAddGrant() || !newPermissions.GetRemoveGrant()) {
+		if ok, err := s.spaceRootHasRemainingManager(ctx, currentShare.GetResourceId(), currentShare.GetId().GetOpaqueId()); err != nil {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewInternal(ctx, "failed to list shares for space root"),
+			}, nil
+		} else if !ok {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewPermissionDenied(ctx, nil, "cannot remove the last share with manager permissions on a space root"),
+			}, nil
+		}
 	}
 
 	// check if the requested permission are plausible for the Resource

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -166,13 +166,6 @@ func (s *service) isPathAllowed(path string) bool {
 func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShareRequest) (*collaboration.CreateShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	user := ctxpkg.ContextMustGetUser(ctx)
-	// Grants must not allow grant permissions
-	if HasGrantPermissions(req.GetGrant().GetPermissions().GetPermissions()) {
-		return &collaboration.CreateShareResponse{
-			Status: status.NewInvalidArg(ctx, "resharing not supported"),
-		}, nil
-	}
-
 	// check if the grantee is a user or group
 	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_USER {
 		// check if the tenantId of the user matches the tenantId of the target user
@@ -224,6 +217,15 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 		return &collaboration.CreateShareResponse{
 			Status: status.NewPermissionDenied(ctx, nil, "no permission to add grants on shared resource"),
 		}, err
+	}
+	// resharing is forbidden for not space roots
+	if !utils.IsSpaceRoot(sRes.GetInfo()) {
+		// Resharing of Files/Directories is forbidden. So the grants must not allow the "grant" permissions
+		if HasGrantPermissions(req.GetGrant().GetPermissions().GetPermissions()) {
+			return &collaboration.CreateShareResponse{
+				Status: status.NewInvalidArg(ctx, "resharing not supported"),
+			}, nil
+		}
 	}
 	// check if the share creator has sufficient permissions to do so.
 	if shareCreationAllowed := conversions.SufficientCS3Permissions(
@@ -361,13 +363,6 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 	log := appctx.GetLogger(ctx)
 	user := ctxpkg.ContextMustGetUser(ctx)
 
-	// Grants must not allow grant permissions
-	if HasGrantPermissions(req.GetShare().GetPermissions().GetPermissions()) {
-		return &collaboration.UpdateShareResponse{
-			Status: status.NewInvalidArg(ctx, "resharing not supported"),
-		}, nil
-	}
-
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
 		return nil, err
@@ -427,6 +422,15 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 		}, err
 	}
 
+	// resharing is forbidden for not space roots
+	if !utils.IsSpaceRoot(sRes.GetInfo()) {
+		// Resharing of Files/Directories is forbidden. So the grants must not allow the "grant" permissions
+		if HasGrantPermissions(req.GetShare().GetPermissions().GetPermissions()) {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewInvalidArg(ctx, "resharing not supported"),
+			}, nil
+		}
+	}
 	// If this is a permissions update, check if user's permissions on the resource are sufficient to set the desired permissions
 	var newPermissions *provider.ResourcePermissions
 	if slices.Contains(req.GetUpdateMask().GetPaths(), _fieldMaskPathPermissions) {

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -55,6 +55,9 @@ const (
 	_fieldMaskPathMountPoint  = "mount_point"
 	_fieldMaskPathPermissions = "permissions"
 	_fieldMaskPathState       = "state"
+	_spaceTypePersonal        = "personal"
+	_spaceTypeProject         = "project"
+	_spaceTypeVirtual         = "virtual"
 )
 
 func init() {
@@ -221,6 +224,13 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	}
 
 	isSpaceRoot := utils.IsSpaceRoot(sRes.GetInfo())
+	var noEvent bool
+
+	if isSpaceRoot {
+		if sRes.GetInfo().GetSpace().GetSpaceType() == _spaceTypePersonal || sRes.GetInfo().GetSpace().GetSpaceType() == _spaceTypeVirtual {
+			return &collaboration.CreateShareResponse{Status: status.NewInvalid(ctx, "space type is not eligible for sharing")}, nil
+		}
+	}
 
 	// do not allow share to myself or the owner if share is for a user
 	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_USER &&

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
@@ -199,13 +200,23 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 		}, nil
 	}
 
+	// use logged in user Idp as default, if the Grantee does not have an IDP set.
 	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_USER && req.GetGrant().GetGrantee().GetUserId().GetIdp() == "" {
-		// use logged in user Idp as default.
 		req.GetGrant().GetGrantee().Id = &provider.Grantee_UserId{
 			UserId: &userpb.UserId{
 				OpaqueId: req.GetGrant().GetGrantee().GetUserId().GetOpaqueId(),
 				Idp:      user.GetId().GetIdp(),
 				Type:     userpb.UserType_USER_TYPE_PRIMARY},
+		}
+	}
+	// some for group grantees
+	if req.GetGrant().GetGrantee().GetType() == provider.GranteeType_GRANTEE_TYPE_GROUP && req.GetGrant().GetGrantee().GetGroupId().GetIdp() == "" {
+		// use logged in user Idp as default.
+		req.GetGrant().GetGrantee().Id = &provider.Grantee_GroupId{
+			GroupId: &grouppb.GroupId{
+				OpaqueId: req.GetGrant().GetGrantee().GetGroupId().GetOpaqueId(),
+				Idp:      user.GetId().GetIdp(),
+				Type:     grouppb.GroupType_GROUP_TYPE_REGULAR},
 		}
 	}
 

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -113,6 +113,11 @@ var _ = Describe("user share provider service", func() {
 		statResourceResponse = &providerpb.StatResponse{
 			Status: status.NewOK(ctx),
 			Info: &providerpb.ResourceInfo{
+				Id: &providerpb.ResourceId{
+					StorageId: "1",
+					SpaceId:   "2",
+					OpaqueId:  "3",
+				},
 				PermissionSet: &providerpb.ResourcePermissions{},
 			},
 		}
@@ -357,7 +362,7 @@ var _ = Describe("user share provider service", func() {
 				conversions.RoleFromName("spaceeditor").CS3ResourcePermissions(),
 				conversions.RoleFromName("manager").CS3ResourcePermissions(),
 				rpcpb.Code_CODE_OK,
-				rpcpb.Code_CODE_INVALID_ARGUMENT,
+				rpcpb.Code_CODE_PERMISSION_DENIED,
 				0,
 			),
 			Entry(

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -551,7 +551,7 @@ var _ = Describe("user share provider service", func() {
 
 			manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 0)
 		})
-		It("succeeds when the user is not the owner/creator and does not have the UpdateGrant permissions", func() {
+		It("fails when the user is not the owner/creator and does not have the UpdateGrant permissions", func() {
 			// user has only read access
 			statResourceResponse.Info.PermissionSet = &providerpb.ResourcePermissions{
 				InitiateFileDownload: true,
@@ -931,6 +931,60 @@ var _ = Describe("user share provider service", func() {
 				manager.AssertNumberOfCalls(GinkgoT(), "ListShares", 0)
 				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 1)
 			})
+
+			DescribeTable("only the share creator, owner, or a user with RemoveGrant permission may delete the share",
+				func(
+					resourcePermissions *providerpb.ResourcePermissions,
+					shareCreator *userpb.UserId,
+					shareOwner *userpb.UserId,
+					expectedCode rpcpb.Code,
+					expectedUnshareCalls int,
+				) {
+					statResourceResponse.Info.PermissionSet = resourcePermissions
+					getShareResponse.Creator = shareCreator
+					getShareResponse.Owner = shareOwner
+
+					removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+						Ref: removeShareRef,
+					})
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(removeShareResponse.Status.Code).To(Equal(expectedCode))
+					manager.AssertNumberOfCalls(GinkgoT(), "Unshare", expectedUnshareCalls)
+				},
+				Entry(
+					"denies deletion when user is neither the owner/creator nor has RemoveGrant",
+					&providerpb.ResourcePermissions{Stat: true, InitiateFileDownload: true},
+					bob.GetId(), // creator = bob
+					bob.GetId(), // owner = bob
+					rpcpb.Code_CODE_PERMISSION_DENIED,
+					0,
+				),
+				Entry(
+					"allows deletion when user is the creator of the share",
+					&providerpb.ResourcePermissions{Stat: true, InitiateFileDownload: true},
+					alice.GetId(), // creator = alice (the logged-in user)
+					bob.GetId(),   // owner = bob
+					rpcpb.Code_CODE_OK,
+					1,
+				),
+				Entry(
+					"allows deletion when user is the owner of the share",
+					&providerpb.ResourcePermissions{Stat: true, InitiateFileDownload: true},
+					bob.GetId(),   // creator = bob
+					alice.GetId(), // owner = alice (the logged-in user)
+					rpcpb.Code_CODE_OK,
+					1,
+				),
+				Entry(
+					"allows deletion when user has RemoveGrant permission on the resource",
+					&providerpb.ResourcePermissions{Stat: true, InitiateFileDownload: true, RemoveGrant: true},
+					bob.GetId(), // creator = bob
+					bob.GetId(), // owner = bob
+					rpcpb.Code_CODE_OK,
+					1,
+				),
+			)
 		})
 
 	})

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -658,6 +658,281 @@ var _ = Describe("user share provider service", func() {
 
 			manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 1)
 		})
+
+		Context("last manager check on space root", func() {
+			var (
+				spaceRootStatResponse *providerpb.StatResponse
+				managerPerms          *providerpb.ResourcePermissions
+				updateShareRef        *collaborationpb.ShareReference
+			)
+
+			BeforeEach(func() {
+				managerPerms = conversions.RoleFromName("manager").CS3ResourcePermissions()
+
+				spaceRootStatResponse = &providerpb.StatResponse{
+					Status: status.NewOK(ctx),
+					Info: &providerpb.ResourceInfo{
+						Id: &providerpb.ResourceId{
+							StorageId: "storage1",
+							SpaceId:   "space1",
+							OpaqueId:  "space1",
+						},
+						Space: &providerpb.StorageSpace{
+							Root: &providerpb.ResourceId{
+								StorageId: "storage1",
+								SpaceId:   "space1",
+								OpaqueId:  "space1",
+							},
+						},
+						PermissionSet: managerPerms,
+					},
+				}
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Unset()
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(spaceRootStatResponse, nil)
+
+				getShareResponse.Id = &collaborationpb.ShareId{OpaqueId: "share-to-update"}
+				getShareResponse.Permissions = &collaborationpb.SharePermissions{Permissions: managerPerms}
+				getShareResponse.ResourceId = spaceRootStatResponse.Info.Id
+
+				updateShareRef = &collaborationpb.ShareReference{
+					Spec: &collaborationpb.ShareReference_Id{
+						Id: &collaborationpb.ShareId{OpaqueId: "share-to-update"},
+					},
+				}
+			})
+
+			It("does not check when new permissions still have both AddGrant and RemoveGrant", func() {
+				updateShareResponse, err := provider.UpdateShare(ctx, &collaborationpb.UpdateShareRequest{
+					Ref:        updateShareRef,
+					Share:      &collaborationpb.Share{Permissions: &collaborationpb.SharePermissions{Permissions: managerPerms}},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"permissions"}},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_OK))
+				manager.AssertNumberOfCalls(GinkgoT(), "ListShares", 0)
+				manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 1)
+			})
+
+			It("does not check when the update mask does not include permissions", func() {
+				updateShareResponse, err := provider.UpdateShare(ctx, &collaborationpb.UpdateShareRequest{
+					Ref:        updateShareRef,
+					Share:      &collaborationpb.Share{},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"mount_point"}},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_OK))
+				manager.AssertNumberOfCalls(GinkgoT(), "ListShares", 0)
+				manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 1)
+			})
+
+			It("denies downgrade when it would strip the last manager share", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse, // only this share, which is being downgraded
+				}, nil)
+
+				updateShareResponse, err := provider.UpdateShare(ctx, &collaborationpb.UpdateShareRequest{
+					Ref: updateShareRef,
+					Share: &collaborationpb.Share{Permissions: &collaborationpb.SharePermissions{
+						Permissions: &providerpb.ResourcePermissions{Stat: true},
+					}},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"permissions"}},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_PERMISSION_DENIED))
+				manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 0)
+			})
+
+			It("allows downgrade when another manager share remains", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse,
+					{
+						Id:          &collaborationpb.ShareId{OpaqueId: "other-manager"},
+						Permissions: &collaborationpb.SharePermissions{Permissions: managerPerms},
+					},
+				}, nil)
+
+				updateShareResponse, err := provider.UpdateShare(ctx, &collaborationpb.UpdateShareRequest{
+					Ref: updateShareRef,
+					Share: &collaborationpb.Share{Permissions: &collaborationpb.SharePermissions{
+						Permissions: &providerpb.ResourcePermissions{Stat: true},
+					}},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"permissions"}},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_OK))
+				manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 1)
+			})
+
+			It("returns internal error when listing shares fails", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return(nil, errors.New("storage error"))
+
+				updateShareResponse, err := provider.UpdateShare(ctx, &collaborationpb.UpdateShareRequest{
+					Ref: updateShareRef,
+					Share: &collaborationpb.Share{Permissions: &collaborationpb.SharePermissions{
+						Permissions: &providerpb.ResourcePermissions{Stat: true},
+					}},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"permissions"}},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_INTERNAL))
+				manager.AssertNumberOfCalls(GinkgoT(), "UpdateShare", 0)
+			})
+		})
+	})
+
+	Describe("RemoveShare", func() {
+		var (
+			spaceRootStatResponse *providerpb.StatResponse
+			managerPerms          *providerpb.ResourcePermissions
+			removeShareRef        *collaborationpb.ShareReference
+		)
+
+		BeforeEach(func() {
+			managerPerms = conversions.RoleFromName("manager").CS3ResourcePermissions()
+
+			// statResourceResponse that represents a space root
+			spaceRootStatResponse = &providerpb.StatResponse{
+				Status: status.NewOK(ctx),
+				Info: &providerpb.ResourceInfo{
+					Id: &providerpb.ResourceId{
+						StorageId: "storage1",
+						SpaceId:   "space1",
+						OpaqueId:  "space1",
+					},
+					Space: &providerpb.StorageSpace{
+						Root: &providerpb.ResourceId{
+							StorageId: "storage1",
+							SpaceId:   "space1",
+							OpaqueId:  "space1",
+						},
+					},
+					PermissionSet: managerPerms,
+				},
+			}
+			getShareResponse.Id = &collaborationpb.ShareId{OpaqueId: "share-to-remove"}
+			getShareResponse.Permissions = &collaborationpb.SharePermissions{Permissions: managerPerms}
+			getShareResponse.ResourceId = spaceRootStatResponse.Info.Id
+
+			removeShareRef = &collaborationpb.ShareReference{
+				Spec: &collaborationpb.ShareReference_Id{
+					Id: &collaborationpb.ShareId{OpaqueId: "share-to-remove"},
+				},
+			}
+
+			manager.On("Unshare", mock.Anything, mock.Anything).Return(nil)
+		})
+
+		// When removing a Space Member, we want to ensure that at least one Grantee remains that has Permission
+		// to invite new members to the space.
+		Context("when removing a share on a space root", func() {
+			BeforeEach(func() {
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Unset()
+				gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(spaceRootStatResponse, nil)
+			})
+
+			It("denies removal when it would be the last manager share", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse, // only the share being removed
+				}, nil)
+
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_PERMISSION_DENIED))
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 0)
+			})
+
+			It("denies removal when remaining shares only have AddGrant but not RemoveGrant", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse,
+					{
+						Id: &collaborationpb.ShareId{OpaqueId: "other-share"},
+						Permissions: &collaborationpb.SharePermissions{
+							Permissions: &providerpb.ResourcePermissions{AddGrant: true, RemoveGrant: false},
+						},
+					},
+				}, nil)
+
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_PERMISSION_DENIED))
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 0)
+			})
+
+			It("denies removal when remaining shares only have RemoveGrant but not AddGrant", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse,
+					{
+						Id: &collaborationpb.ShareId{OpaqueId: "other-share"},
+						Permissions: &collaborationpb.SharePermissions{
+							Permissions: &providerpb.ResourcePermissions{AddGrant: false, RemoveGrant: true},
+						},
+					},
+				}, nil)
+
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_PERMISSION_DENIED))
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 0)
+			})
+
+			It("allows removal when another share with both AddGrant and RemoveGrant remains", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return([]*collaborationpb.Share{
+					getShareResponse,
+					{
+						Id:          &collaborationpb.ShareId{OpaqueId: "manager-share"},
+						Permissions: &collaborationpb.SharePermissions{Permissions: managerPerms},
+					},
+				}, nil)
+
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_OK))
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 1)
+			})
+
+			It("returns internal error when listing shares fails", func() {
+				manager.On("ListShares", mock.Anything, mock.Anything).Return(nil, errors.New("storage error"))
+
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_INTERNAL))
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 0)
+			})
+		})
+		Context("when removing a share on a non-space-root resource", func() {
+			It("does not check for remaining manager shares and succeeds", func() {
+				// statResourceResponse (default) is not a space root
+				removeShareResponse, err := provider.RemoveShare(ctx, &collaborationpb.RemoveShareRequest{
+					Ref: removeShareRef,
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(removeShareResponse.Status.Code).To(Equal(rpcpb.Code_CODE_OK))
+				manager.AssertNumberOfCalls(GinkgoT(), "ListShares", 0)
+				manager.AssertNumberOfCalls(GinkgoT(), "Unshare", 1)
+			})
+		})
+
 	})
 })
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -179,6 +179,10 @@ func (h *Handler) UpdateReceivedShare(w http.ResponseWriter, r *http.Request) {
 	response.WriteOCSSuccess(w, r, []*conversions.ShareData{data})
 }
 
+func (h *Handler) ReceivedShareNotFound(w http.ResponseWriter, r *http.Request) {
+	response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "cannot find share", nil)
+}
+
 func (h *Handler) updateReceivedShare(ctx context.Context, receivedShare *collaboration.ReceivedShare, fieldMask *fieldmaskpb.FieldMask) (*conversions.ShareData, response.Meta, error) {
 	logger := appctx.GetLogger(ctx)
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -78,7 +78,6 @@ var (
 type Handler struct {
 	gatewayAddr                           string
 	machineAuthAPIKey                     string
-	storageRegistryAddr                   string
 	publicURL                             string
 	sharePrefix                           string
 	homeNamespace                         string
@@ -129,7 +128,6 @@ type GatewayClientGetter func() (gateway.GatewayAPIClient, error)
 func (h *Handler) Init(c *config.Config) error {
 	h.gatewayAddr = c.GatewaySvc
 	h.machineAuthAPIKey = c.MachineAuthAPIKey
-	h.storageRegistryAddr = c.StorageregistrySvc
 	h.publicURL = c.Config.Host
 	h.sharePrefix = c.SharePrefix
 	h.homeNamespace = c.HomeNamespace
@@ -941,12 +939,11 @@ func (h *Handler) RemoveShare(w http.ResponseWriter, r *http.Request) {
 		h.removeFederatedShare(w, r, shareID)
 		return
 	}
-
-	if prov, ok := h.isSpaceShare(r, shareID); ok {
-		// The request is a remove space member request.
-		h.removeSpaceMember(w, r, shareID, prov)
+	if h.isSpaceShare(r, shareID) {
+		h.removeSpaceMember(w, r, shareID)
 		return
 	}
+
 	response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "cannot find share", nil)
 }
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -29,18 +29,12 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaborationv1beta1 "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocs/response"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/conversions"
-	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
-	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
-	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
-	sdk "github.com/opencloud-eu/reva/v2/pkg/sdk/common"
 	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -131,45 +125,34 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 		fieldmask = append(fieldmask, "expiration")
 	}
 
-	ref := provider.Reference{ResourceId: info.GetId()}
-	p, err := h.findProvider(ctx, &ref)
-	if err != nil {
-		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "error getting storage provider", err)
+	lsRes, err := client.ListShares(ctx, &collaborationv1beta1.ListSharesRequest{
+		Filters: []*collaborationv1beta1.Filter{
+			{
+				Type: collaborationv1beta1.Filter_TYPE_RESOURCE_ID,
+				Term: &collaborationv1beta1.Filter_ResourceId{
+					ResourceId: info.GetId(),
+				},
+			},
+		},
+	})
+	if err != nil || lsRes.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error listing space members", err)
 		return
 	}
 
-	providerClient, err := h.getStorageProviderClient(p)
-	if err != nil {
-		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "error getting storage provider client", err)
-		return
-	}
-
-	lgRes, err := providerClient.ListGrants(ctx, &provider.ListGrantsRequest{Ref: &ref})
-	if err != nil || lgRes.Status.Code != rpc.Code_CODE_OK {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error listing space grants", err)
-		return
-	}
-
-	if !isSpaceManagerRemaining(lgRes.Grants, &grantee) {
+	if !isSpaceManagerRemainingInShares(lsRes.Shares, &grantee) {
 		response.WriteOCSError(w, r, http.StatusForbidden, "the space must have at least one manager", nil)
 		return
 	}
 
-	// we have to send the update request to the gateway to give it a chance to invalidate its cache
-	// TODO the gateway no longer should cache stuff because invalidation is to expensive. The decomposedfs already has a better cache.
-	if granteeExists(lgRes.Grants, &grantee) {
+	if existingShare := findShareByGrantee(lsRes.Shares, &grantee); existingShare != nil {
 		if permissions != nil {
 			fieldmask = append(fieldmask, "permissions")
 		}
 		updateShareReq := &collaborationv1beta1.UpdateShareRequest{
-			// TODO: change CS3 APIs
-			Opaque: &types.Opaque{
-				Map: map[string]*types.OpaqueEntry{
-					"spacegrant": {},
-				},
-			},
+			Opaque: utils.AppendPlainToOpaque(nil, "spacetype", info.GetSpace().GetSpaceType()),
 			Share: &collaborationv1beta1.Share{
-				ResourceId: ref.GetResourceId(),
+				Id: existingShare.Id,
 				Permissions: &collaborationv1beta1.SharePermissions{
 					Permissions: permissions,
 				},
@@ -180,10 +163,9 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 				Paths: fieldmask,
 			},
 		}
-		updateShareReq.Opaque = utils.AppendPlainToOpaque(updateShareReq.Opaque, "spacetype", info.GetSpace().GetSpaceType())
 		updateShareRes, err := client.UpdateShare(ctx, updateShareReq)
 		if err != nil || updateShareRes.Status.Code != rpc.Code_CODE_OK {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not update space member grant", err)
+			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not update space member", err)
 			return
 		}
 	} else {
@@ -198,7 +180,7 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 			},
 		})
 		if err != nil || createShareRes.Status.Code != rpc.Code_CODE_OK {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not add space member grant", err)
+			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not add space member", err)
 			return
 		}
 	}
@@ -206,21 +188,12 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 	response.WriteOCSSuccess(w, r, nil)
 }
 
-func (h *Handler) isSpaceShare(r *http.Request, spaceID string) (*registry.ProviderInfo, bool) {
-	ref, err := storagespace.ParseReference(spaceID)
-	if err != nil {
-		return nil, false
-	}
-
-	if ref.ResourceId.OpaqueId == "" {
-		ref.ResourceId.OpaqueId = ref.ResourceId.SpaceId
-	}
-
-	p, err := h.findProvider(r.Context(), &ref)
-	return p, err == nil
+func (h *Handler) isSpaceShare(r *http.Request, shareID string) bool {
+	_, err := storagespace.ParseReference(shareID)
+	return err == nil
 }
 
-func (h *Handler) removeSpaceMember(w http.ResponseWriter, r *http.Request, spaceID string, prov *registry.ProviderInfo) {
+func (h *Handler) removeSpaceMember(w http.ResponseWriter, r *http.Request, spaceID string) {
 	ctx := r.Context()
 
 	shareWith := r.URL.Query().Get("shareWith")
@@ -245,129 +218,73 @@ func (h *Handler) removeSpaceMember(w http.ResponseWriter, r *http.Request, spac
 		ref.ResourceId.OpaqueId = ref.ResourceId.SpaceId
 	}
 
-	providerClient, err := h.getStorageProviderClient(prov)
-	if err != nil {
-		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "error getting storage provider client", err)
-		return
-	}
-
-	lgRes, err := providerClient.ListGrants(ctx, &provider.ListGrantsRequest{Ref: &ref})
-	if err != nil || lgRes.Status.Code != rpc.Code_CODE_OK {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error listing space grants", err)
-		return
-	}
-
-	if len(lgRes.Grants) == 1 || !isSpaceManagerRemaining(lgRes.Grants, &grantee) {
-		response.WriteOCSError(w, r, http.StatusForbidden, "can't remove the last manager", nil)
-		return
-	}
-
-	gatewayClient, err := h.getClient()
+	client, err := h.getClient()
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "error getting gateway client", err)
 		return
 	}
 
-	removeShareRes, err := gatewayClient.RemoveShare(ctx, &collaborationv1beta1.RemoveShareRequest{
-		Ref: &collaborationv1beta1.ShareReference{
-			Spec: &collaborationv1beta1.ShareReference_Key{
-				Key: &collaborationv1beta1.ShareKey{
+	lsRes, err := client.ListShares(ctx, &collaborationv1beta1.ListSharesRequest{
+		Filters: []*collaborationv1beta1.Filter{
+			{
+				Type: collaborationv1beta1.Filter_TYPE_RESOURCE_ID,
+				Term: &collaborationv1beta1.Filter_ResourceId{
 					ResourceId: ref.ResourceId,
-					Grantee:    &grantee,
 				},
 			},
 		},
 	})
+	if err != nil || lsRes.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error listing space members", err)
+		return
+	}
+
+	if len(lsRes.Shares) == 1 || !isSpaceManagerRemainingInShares(lsRes.Shares, &grantee) {
+		response.WriteOCSError(w, r, http.StatusForbidden, "can't remove the last manager", nil)
+		return
+	}
+
+	s := findShareByGrantee(lsRes.Shares, &grantee)
+	if s == nil {
+		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "cannot find share", nil)
+		return
+	}
+
+	removeShareRes, err := client.RemoveShare(ctx, &collaborationv1beta1.RemoveShareRequest{
+		Ref: &collaborationv1beta1.ShareReference{
+			Spec: &collaborationv1beta1.ShareReference_Id{
+				Id: s.Id,
+			},
+		},
+	})
 	if err != nil {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error removing grant", err)
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error removing space member", err)
 		return
 	}
 	if removeShareRes.Status.Code != rpc.Code_CODE_OK {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error removing grant", err)
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error removing space member", nil)
 		return
 	}
 
 	response.WriteOCSSuccess(w, r, nil)
 }
 
-func (h *Handler) getStorageProviderClient(p *registry.ProviderInfo) (provider.ProviderAPIClient, error) {
-	c, err := pool.GetStorageProviderServiceClient(p.Address)
-	if err != nil {
-		err = errors.Wrap(err, "shares spaces: error getting a storage provider client")
-		return nil, err
-	}
-
-	return c, nil
-}
-
-func (h *Handler) findProvider(ctx context.Context, ref *provider.Reference) (*registry.ProviderInfo, error) {
-	c, err := pool.GetStorageRegistryClient(h.storageRegistryAddr)
-	if err != nil {
-		return nil, errors.Wrap(err, "shares spaces: error getting storage registry client")
-	}
-
-	filters := map[string]string{}
-	if ref.Path != "" {
-		filters["path"] = ref.Path
-	}
-	if ref.ResourceId != nil {
-		filters["storage_id"] = ref.ResourceId.StorageId
-		filters["space_id"] = ref.ResourceId.SpaceId
-		filters["opaque_id"] = ref.ResourceId.OpaqueId
-	}
-
-	listReq := &registry.ListStorageProvidersRequest{
-		Opaque: &types.Opaque{},
-	}
-	sdk.EncodeOpaqueMap(listReq.Opaque, filters)
-
-	res, err := c.ListStorageProviders(ctx, listReq)
-
-	if err != nil {
-		return nil, errors.Wrap(err, "shares spaces: error calling ListStorageProviders")
-	}
-
-	if res.Status.Code != rpc.Code_CODE_OK {
-		switch res.Status.Code {
-		case rpc.Code_CODE_NOT_FOUND:
-			return nil, errtypes.NotFound("shares spaces: storage provider not found for reference:" + ref.String())
-		case rpc.Code_CODE_PERMISSION_DENIED:
-			return nil, errtypes.PermissionDenied("shares spaces: " + res.Status.Message + " for " + ref.String() + " with code " + res.Status.Code.String())
-		case rpc.Code_CODE_INVALID_ARGUMENT, rpc.Code_CODE_FAILED_PRECONDITION, rpc.Code_CODE_OUT_OF_RANGE:
-			return nil, errtypes.BadRequest("shares spaces: " + res.Status.Message + " for " + ref.String() + " with code " + res.Status.Code.String())
-		case rpc.Code_CODE_UNIMPLEMENTED:
-			return nil, errtypes.NotSupported("shares spaces: " + res.Status.Message + " for " + ref.String() + " with code " + res.Status.Code.String())
-		default:
-			return nil, status.NewErrorFromCode(res.Status.Code, "shares spaces")
-		}
-	}
-
-	if len(res.Providers) < 1 {
-		return nil, errtypes.NotFound("shares spaces: no provider found")
-	}
-
-	return res.Providers[0], nil
-}
-
-func isSpaceManagerRemaining(grants []*provider.Grant, grantee *provider.Grantee) bool {
-	for _, g := range grants {
-		// RemoveGrant is currently the way to check for the manager role
-		// If it is not set than the current grant is not for a manager and
-		// we can just continue with the next one.
-		if g.Permissions.RemoveGrant && !isEqualGrantee(g.Grantee, grantee) {
+func isSpaceManagerRemainingInShares(shares []*collaborationv1beta1.Share, grantee *provider.Grantee) bool {
+	for _, s := range shares {
+		if s.GetPermissions().GetPermissions().GetRemoveGrant() && !isEqualGrantee(s.Grantee, grantee) {
 			return true
 		}
 	}
 	return false
 }
 
-func granteeExists(grants []*provider.Grant, grantee *provider.Grantee) bool {
-	for _, g := range grants {
-		if isEqualGrantee(g.Grantee, grantee) {
-			return true
+func findShareByGrantee(shares []*collaborationv1beta1.Share, grantee *provider.Grantee) *collaborationv1beta1.Share {
+	for _, s := range shares {
+		if isEqualGrantee(s.Grantee, grantee) {
+			return s
 		}
 	}
-	return false
+	return nil
 }
 
 func isEqualGrantee(a, b *provider.Grantee) bool {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -34,6 +34,7 @@ import (
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/permission"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/opencloud-eu/reva/v2/pkg/share"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 )
 
@@ -330,7 +331,7 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 	log := appctx.GetLogger(ctx)
 
 	lsUserSharesRequest := collaboration.ListSharesRequest{
-		Filters: filters,
+		Filters: append(filters, share.SpaceRootFilter(false)),
 	}
 
 	ocsDataPayload := make([]*conversions.ShareData, 0)

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -123,6 +123,13 @@ func (s *svc) routerInit(log *zerolog.Logger) error {
 					r.Delete("/", sharesHandler.RejectReceivedShare)
 					r.Put("/", sharesHandler.UpdateReceivedShare)
 				})
+				r.Route("/pending", func(r chi.Router) {
+					r.Post("/", func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusMethodNotAllowed)
+					})
+					r.Delete("/", sharesHandler.ReceivedShareNotFound)
+					r.Put("/", sharesHandler.ReceivedShareNotFound)
+				})
 				r.Route("/remote_shares", func(r chi.Router) {
 					r.Get("/", sharesHandler.ListFederatedShares)
 					r.Get("/{shareid}", sharesHandler.GetFederatedShare)

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -296,16 +296,6 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 	user := ctxpkg.ContextMustGetUser(ctx)
 	ts := utils.TSNow()
 
-	// do not allow share to myself or the owner if share is for a user
-	// TODO: should this not already be caught at the gw level?
-	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
-		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		err := errtypes.BadRequest("jsoncs3: owner/creator and grantee are the same")
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	}
-
 	// check if share already exists.
 	key := &collaboration.ShareKey{
 		// Owner:      md.Owner, owner no longer matters as it belongs to the space

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -498,16 +498,9 @@ func (m *Manager) Unshare(ctx context.Context, ref *collaboration.ShareReference
 		return err
 	}
 
-	user := ctxpkg.ContextMustGetUser(ctx)
-
 	s, err := m.get(ctx, ref)
 	if err != nil {
 		return err
-	}
-	// TODO allow manager to unshare shares in a space created by other users
-	if !share.IsCreatedByUser(s, user) {
-		// TODO why not permission denied?
-		return errtypes.NotFound(ref.String())
 	}
 
 	return m.removeShare(ctx, s, false)

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -467,18 +467,6 @@ var _ = Describe("Jsoncs3", func() {
 		})
 
 		Describe("UnShare", func() {
-			It("does not remove shares of other users", func() {
-				err := m.Unshare(otherCtx, &collaboration.ShareReference{
-					Spec: &collaboration.ShareReference_Id{
-						Id: &collaboration.ShareId{
-							OpaqueId: share.Id.OpaqueId,
-						},
-					},
-				})
-
-				Expect(err).To(HaveOccurred())
-			})
-
 			It("removes an existing share", func() {
 				err := m.Unshare(ctx, &collaboration.ShareReference{
 					Spec: &collaboration.ShareReference_Id{

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -82,11 +82,6 @@ func (m *manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 		Nanos:   uint32(now % 1000000000),
 	}
 
-	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
-		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		return nil, errtypes.BadRequest("memory: owner/creator and grantee are the same")
-	}
-
 	// check if share already exists.
 	key := &collaboration.ShareKey{
 		Owner:      md.Owner,

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -136,6 +136,18 @@ func StateFilter(state collaboration.ShareState) *collaboration.Filter {
 	}
 }
 
+// SpaceRootFilter is an abstraction for filtering shares by whether the shared
+// resource is a space root. Pass true to include only space-root shares (space
+// membership), false to exclude them (file/folder shares only).
+func SpaceRootFilter(spaceRoot bool) *collaboration.Filter {
+	return &collaboration.Filter{
+		Type: collaboration.Filter_TYPE_SPACE_ROOT,
+		Term: &collaboration.Filter_SpaceRoot{
+			SpaceRoot: spaceRoot,
+		},
+	}
+}
+
 // IsCreatedByUser checks if the user is the owner or creator of the share.
 func IsCreatedByUser(share *collaboration.Share, user *userv1beta1.User) bool {
 	return utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator)
@@ -172,6 +184,9 @@ func MatchesFilter(share *collaboration.Share, state collaboration.ShareState, f
 		return share.ResourceId.SpaceId == filter.GetSpaceId()
 	case collaboration.Filter_TYPE_STATE:
 		return state == filter.GetState()
+	case collaboration.Filter_TYPE_SPACE_ROOT:
+		isSpaceRoot := share.ResourceId.SpaceId == share.ResourceId.OpaqueId
+		return isSpaceRoot == filter.GetSpaceRoot()
 	default:
 		return false
 	}

--- a/pkg/share/share_test.go
+++ b/pkg/share/share_test.go
@@ -142,6 +142,46 @@ func TestMatchesFilter(t *testing.T) {
 	}
 }
 
+func TestSpaceRootFilter(t *testing.T) {
+	// A space root share: SpaceId == OpaqueId
+	spaceRootShare := &collaboration.Share{
+		ResourceId: &provider.ResourceId{
+			StorageId: "storage",
+			SpaceId:   "spaceid",
+			OpaqueId:  "spaceid", // same as SpaceId -> space root
+		},
+	}
+
+	// A regular file/folder share: SpaceId != OpaqueId
+	fileShare := &collaboration.Share{
+		ResourceId: &provider.ResourceId{
+			StorageId: "storage",
+			SpaceId:   "spaceid",
+			OpaqueId:  "nodeid", // different from SpaceId -> not a space root
+		},
+	}
+
+	tests := []struct {
+		name        string
+		share       *collaboration.Share
+		filterValue bool
+		want        bool
+	}{
+		{"space root matches SpaceRootFilter(true)", spaceRootShare, true, true},
+		{"space root does not match SpaceRootFilter(false)", spaceRootShare, false, false},
+		{"file share matches SpaceRootFilter(false)", fileShare, false, true},
+		{"file share does not match SpaceRootFilter(true)", fileShare, true, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchesFilter(tc.share, NoState, SpaceRootFilter(tc.filterValue)); got != tc.want {
+				t.Errorf("MatchesFilter() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMatchesAnyFilter(t *testing.T) {
 	id := &provider.ResourceId{StorageId: "storage", OpaqueId: "opaque"}
 	share := &collaboration.Share{


### PR DESCRIPTION
This is the reva part for: https://github.com/opencloud-eu/opencloud/issues/2319

It requires a small adjustment to the CS3 APIs: https://github.com/rhafer/cs3apis/commit/3c8cce60d7ffa13f491a790cb8374cc556179516 (a PR will be created as soon as we have agreement on this)

What is missing before we can merge this:
- remove the `use_common_space_root_share_logic` switch from the gateway and make it the default behaviour. (That would remove a few more line on unneeded code
- figure out a migration so that existing setups will get their spacemembership migrated to the shareprovider