### PR TITLE
delete unused opaque property

### DIFF
--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -744,16 +744,6 @@ func (s *Service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 	}
 
 	ctx = ctxpkg.ContextSetLockID(ctx, req.LockId)
-
-	// check DeleteRequest for any known opaque properties.
-	// FIXME these should be part of the DeleteRequest object
-	if req.Opaque != nil {
-		if _, ok := req.Opaque.Map["deleting_shared_resource"]; ok {
-			// it is a binary key; its existence signals true. Although, do not assume.
-			ctx = appctx.WithDeletingSharedResource(ctx)
-		}
-	}
-
 	md, err := s.Storage.GetMD(ctx, req.Ref, []string{}, []string{"id", "status"})
 	if err != nil {
 		return &provider.DeleteResponse{

--- a/pkg/appctx/appctx.go
+++ b/pkg/appctx/appctx.go
@@ -27,16 +27,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// deletingSharedResource flags to a storage a shared resource is being deleted not by the owner.
-type deletingSharedResource struct{}
-
-func WithDeletingSharedResource(ctx context.Context) context.Context {
-	return context.WithValue(ctx, deletingSharedResource{}, struct{}{})
-}
-func DeletingSharedResourceFromContext(ctx context.Context) bool {
-	return ctx.Value(deletingSharedResource{}) != nil
-}
-
 // WithLogger returns a context with an associated logger.
 func WithLogger(ctx context.Context, l *zerolog.Logger) context.Context {
 	return l.WithContext(ctx)

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -40,7 +40,6 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 
-	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/events"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/blobstore"
@@ -589,11 +588,6 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) error {
 			t.log.Error().Err(err).Str("path", path).Msg("could not delete id from cache")
 		}
 	}()
-
-	if appctx.DeletingSharedResourceFromContext(ctx) {
-		src := filepath.Join(n.ParentPath(), n.Name)
-		return os.RemoveAll(src)
-	}
 
 	var sizeDiff int64
 	if n.IsDir(ctx) {

--- a/pkg/storage/pkg/decomposedfs/tree/tree.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree.go
@@ -429,11 +429,6 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	// remove entry from cache immediately to avoid inconsistencies
 	defer func() { _ = t.idCache.Delete(path) }()
 
-	if appctx.DeletingSharedResourceFromContext(ctx) {
-		src := filepath.Join(n.ParentPath(), n.Name)
-		return os.Remove(src)
-	}
-
 	// get the original path
 	origin, err := t.lookup.Path(ctx, n, node.NoCheck)
 	if err != nil {

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -445,11 +445,6 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	// remove entry from cache immediately to avoid inconsistencies
 	defer func() { _ = t.idCache.Delete(path) }()
 
-	if appctx.DeletingSharedResourceFromContext(ctx) {
-		src := filepath.Join(n.ParentPath(), n.Name)
-		return os.Remove(src)
-	}
-
 	// get the original path
 	origin, err := t.lookup.Path(ctx, n, node.NoCheck)
 	if err != nil {


### PR DESCRIPTION
`deleting_shared_resource` used to be set in the gateway storageproviders Delete(), but has long been gone. We can drop this code.