### PR TITLE
Fix nats ttl

### DIFF
--- a/pkg/events/raw/raw.go
+++ b/pkg/events/raw/raw.go
@@ -71,9 +71,8 @@ type RawStream struct {
 	c Config
 }
 
-func FromConfig(ctx context.Context, name string, cfg Config) (Stream, error) {
-	var s Stream
-	b := backoff.NewExponentialBackOff()
+func JetStream(ctx context.Context, name string, cfg Config) (jetstream.JetStream, error) {
+	var js jetstream.JetStream
 
 	connect := func() error {
 		var tlsConf *tls.Config
@@ -120,27 +119,32 @@ func FromConfig(ctx context.Context, name string, cfg Config) (Stream, error) {
 			return err
 		}
 
-		jsConn, err := jetstream.New(conn)
-		if err != nil {
-			return err
-		}
-
-		js, err := jsConn.Stream(ctx, events.MainQueueName)
-		if err != nil {
-			return err
-		}
-
-		s = &RawStream{
-			js: js,
-			c:  cfg,
-		}
-		return nil
+		js, err = jetstream.New(conn)
+		return err
 	}
-	err := backoff.Retry(connect, b)
+
+	err := backoff.Retry(connect, backoff.NewExponentialBackOff())
 	if err != nil {
-		return s, errors.Wrap(err, "could not connect to nats jetstream")
+		return nil, errors.Wrap(err, "could not connect to nats jetstream")
 	}
-	return s, nil
+	return js, nil
+}
+
+func FromConfig(ctx context.Context, name string, cfg Config) (Stream, error) {
+	jsConn, err := JetStream(ctx, name, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := jsConn.Stream(ctx, events.MainQueueName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RawStream{
+		js: js,
+		c:  cfg,
+	}, nil
 }
 
 func (s *RawStream) Consume(group string, evs ...events.Unmarshaller) (<-chan Event, error) {

--- a/pkg/events/stream/nats.go
+++ b/pkg/events/stream/nats.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -11,7 +12,9 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/go-micro/plugins/v4/events/natsjs"
+	"github.com/nats-io/nats.go/jetstream"
 	"github.com/opencloud-eu/reva/v2/pkg/events"
+	"github.com/opencloud-eu/reva/v2/pkg/events/raw"
 	"github.com/opencloud-eu/reva/v2/pkg/logger"
 )
 
@@ -65,7 +68,38 @@ func NatsFromConfig(connName string, disableDurability bool, cfg NatsConfig) (ev
 		opts = append(opts, natsjs.DisableDurableStreams())
 	}
 
-	return Nats(opts...)
+	s, err := Nats(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// apply a MaxAge to the main queue to prevent it from filling up
+	ctx := context.Background()
+	jsConn, err := raw.JetStream(ctx, connName, raw.Config{
+		Endpoint:             cfg.Endpoint,
+		Cluster:              cfg.Cluster,
+		TLSInsecure:          cfg.TLSInsecure,
+		TLSRootCACertificate: cfg.TLSRootCACertificate,
+		EnableTLS:            cfg.EnableTLS,
+		AuthUsername:         cfg.AuthUsername,
+		AuthPassword:         cfg.AuthPassword,
+	})
+	if err != nil {
+		return nil, err
+	}
+	streamCfg := jetstream.StreamConfig{
+		Name:   "main-queue",
+		MaxAge: 7 * 24 * time.Hour,
+	}
+	_, err = jsConn.CreateStream(ctx, streamCfg)
+	if err != nil {
+		// If the stream already exists, update its configuration
+		if err == jetstream.ErrStreamNameAlreadyInUse {
+			_, _ = jsConn.UpdateStream(ctx, streamCfg)
+		}
+	}
+
+	return s, nil
 }
 
 // nats returns a nats streaming client

--- a/pkg/storage/cache/kv.go
+++ b/pkg/storage/cache/kv.go
@@ -72,7 +72,7 @@ func NewNatsKeyValueFromJetStream(c Config, js jetstream.JetStream) (jetstream.K
 		if err != nil {
 			kvConfig := jetstream.KeyValueConfig{
 				Bucket: c.Database,
-				TTL:    0, // we don't do TTLs for this store
+				TTL:    c.TTL,
 			}
 			if c.DisablePersistence {
 				kvConfig.Storage = jetstream.MemoryStorage

--- a/pkg/storage/fs/posix/posix.go
+++ b/pkg/storage/fs/posix/posix.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/rs/zerolog"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
@@ -70,6 +71,7 @@ func NewDefault(m map[string]interface{}, stream events.Stream, log *zerolog.Log
 	}
 
 	o.IDCache.Database += "_v2" // Use a versioned bucket name to avoid conflicts with previous implementations
+	o.IDCache.TTL = 0           // Disable TTL for the ID cache, as the posix driver relies on it for caching file IDs and we don't want them to expire
 	kv, err := cache.NewNatsKeyValue(o.IDCache)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create nats key value store")
@@ -80,6 +82,7 @@ func NewDefault(m map[string]interface{}, stream events.Stream, log *zerolog.Log
 	}
 
 	o.IDCache.Database += "_history" // Use a versioned bucket name to avoid conflicts with previous implementations
+	o.IDCache.TTL = 24 * 60 * time.Minute
 	historyKv, err := cache.NewNatsKeyValue(o.IDCache)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create nats key value store")


### PR DESCRIPTION
Apply a MaxAge to the main queue to prevent it from filling up with old events.

Part of the fix for https://github.com/opencloud-eu/opencloud/issues/2681