### PR TITLE
fix(users): improve LDAP error handling

### DIFF
--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -182,9 +182,12 @@ func (s *service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (*use
 	user, err := s.usermgr.GetUser(ctx, req.UserId, req.SkipFetchingUserGroups)
 	if err != nil {
 		res := &userpb.GetUserResponse{}
-		if _, ok := err.(errtypes.NotFound); ok {
+		switch err.(type) {
+		case errtypes.NotFound:
 			res.Status = status.NewNotFound(ctx, "user not found")
-		} else {
+		case errtypes.Unavailable:
+			res.Status = status.NewUnavailable(ctx, "user provider temporarily unavailable")
+		default:
 			res.Status = status.NewInternal(ctx, "error getting user")
 		}
 		return res, nil
@@ -205,9 +208,12 @@ func (s *service) GetUserByClaim(ctx context.Context, req *userpb.GetUserByClaim
 	user, err := s.usermgr.GetUserByClaim(ctx, req.Claim, req.Value, tenantID, req.SkipFetchingUserGroups)
 	if err != nil {
 		res := &userpb.GetUserByClaimResponse{}
-		if _, ok := err.(errtypes.NotFound); ok {
+		switch err.(type) {
+		case errtypes.NotFound:
 			res.Status = status.NewNotFound(ctx, fmt.Sprintf("user not found %s %s", req.Claim, req.Value))
-		} else {
+		case errtypes.Unavailable:
+			res.Status = status.NewUnavailable(ctx, "user provider temporarily unavailable")
+		default:
 			res.Status = status.NewInternal(ctx, "error getting user by claim")
 		}
 		return res, nil

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -203,6 +203,15 @@ func (e TooEarly) Error() string { return "error: too early: " + string(e) }
 // IsTooEarly implements the IsTooEarly interface.
 func (e TooEarly) IsTooEarly() {}
 
+// Unavailable is the error to use when a backend service (e.g. LDAP, database) is
+// temporarily unreachable. Callers should treat this as a transient failure and retry.
+type Unavailable string
+
+func (e Unavailable) Error() string { return "error: unavailable: " + string(e) }
+
+// IsUnavailable implements the IsUnavailable interface.
+func (e Unavailable) IsUnavailable() {}
+
 // IsNotFound is the interface to implement
 // to specify that a resource is not found.
 type IsNotFound interface {
@@ -293,6 +302,12 @@ type IsTooEarly interface {
 	IsTooEarly()
 }
 
+// IsUnavailable is the interface to implement to specify that a backend service is
+// temporarily unavailable and the caller should retry.
+type IsUnavailable interface {
+	IsUnavailable()
+}
+
 // NewErrtypeFromStatus maps a rpc status to an errtype
 func NewErrtypeFromStatus(status *rpc.Status) error {
 	switch status.Code {
@@ -329,6 +344,8 @@ func NewErrtypeFromStatus(status *rpc.Status) error {
 		return BadRequest(status.Message)
 	case rpc.Code_CODE_TOO_EARLY:
 		return TooEarly(status.Message)
+	case rpc.Code_CODE_UNAVAILABLE:
+		return Unavailable(status.Message)
 	default:
 		return InternalError(status.Message)
 	}
@@ -363,6 +380,8 @@ func NewErrtypeFromHTTPStatusCode(code int, message string) error {
 		return PartialContent(message)
 	case http.StatusTooEarly:
 		return TooEarly(message)
+	case http.StatusServiceUnavailable:
+		return Unavailable(message)
 	case StatusChecksumMismatch:
 		return ChecksumMismatch(message)
 	default:
@@ -399,6 +418,8 @@ func NewHTTPStatusCodeFromErrtype(err error) int {
 		return http.StatusPartialContent
 	case TooEarly:
 		return http.StatusTooEarly
+	case Unavailable:
+		return http.StatusServiceUnavailable
 	case ChecksumMismatch:
 		return StatusChecksumMismatch
 	default:

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -68,6 +68,15 @@ func NewInternal(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
+// NewUnavailable returns a Status with CODE_UNAVAILABLE.
+func NewUnavailable(ctx context.Context, msg string) *rpc.Status {
+	return &rpc.Status{
+		Code:    rpc.Code_CODE_UNAVAILABLE,
+		Message: msg,
+		Trace:   getTrace(ctx),
+	}
+}
+
 // NewUnauthenticated returns a Status with CODE_UNAUTHENTICATED.
 func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status {
 	return &rpc.Status{
@@ -191,6 +200,10 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewUnimplemented(ctx, err, msg+":"+err.Error())
 	case errtypes.BadRequest:
 		return NewInvalid(ctx, msg+":"+err.Error())
+	case errtypes.Unavailable:
+		return NewUnavailable(ctx, msg+": "+err.Error())
+	case errtypes.IsUnavailable:
+		return NewUnavailable(ctx, msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -266,15 +266,10 @@ func (i *Identity) GetLDAPUserByFilter(ctx context.Context, lc ldap.Client, filt
 	res, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Debug().Str("backend", "ldap").Err(err).Str("userfilter", filter).Msg("Error looking up user by filter")
-		var errmsg string
-		if lerr, ok := err.(*ldap.Error); ok {
-			if lerr.ResultCode == ldap.LDAPResultSizeLimitExceeded {
-				errmsg = fmt.Sprintf("too many results searching for user '%s'", filter)
-			}
-		}
-		span.SetAttributes(attribute.String("ldap.error", errmsg))
-		span.SetStatus(codes.Error, errmsg)
-		return nil, errtypes.NotFound(errmsg)
+		classified := classifySearchError(err, fmt.Sprintf("too many results searching for user '%s'", filter))
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	if len(res.Entries) == 0 {
 		return nil, errtypes.NotFound(filter)
@@ -306,9 +301,10 @@ func (i *Identity) GetLDAPUserByDN(ctx context.Context, lc ldap.Client, dn strin
 	res, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Debug().Str("backend", "ldap").Err(err).Str("dn", dn).Msg("Error looking up user by DN")
-		span.SetAttributes(attribute.String("ldap.error", err.Error()))
-		span.SetStatus(codes.Error, "")
-		return nil, errtypes.NotFound(dn)
+		classified := classifySearchError(err, "")
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	span.SetStatus(codes.Ok, "")
 	if len(res.Entries) == 0 {
@@ -337,9 +333,10 @@ func (i *Identity) GetLDAPUsers(ctx context.Context, lc ldap.Client, query, tena
 	sr, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Debug().Str("backend", "ldap").Err(err).Str("filter", filter).Msg("Error searching users")
-		span.SetAttributes(attribute.String("ldap.error", err.Error()))
-		span.SetStatus(codes.Error, "")
-		return nil, errtypes.NotFound(query)
+		classified := classifySearchError(err, "")
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 
 	span.SetAttributes(attribute.Int("ldap.result_count", len(sr.Entries)))
@@ -376,7 +373,8 @@ func (i *Identity) IsLDAPUserInDisabledGroup(ctx context.Context, lc ldap.Client
 	sr, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Error().Str("backend", "ldap").Err(err).Str("filter", filter).Msg("Error looking up error group")
-		// Err on the side of caution.
+		// Err on the side of caution: treat search failures (including network
+		// errors) as if the user is in the disabled group.
 		span.SetAttributes(attribute.String("ldap.error", err.Error()))
 		span.SetStatus(codes.Error, "")
 		return true
@@ -423,10 +421,10 @@ func (i *Identity) GetLDAPUserGroups(ctx context.Context, lc ldap.Client, userEn
 			// not having any groups in LDAP
 			return []string{}, nil
 		}
-
-		span.SetAttributes(attribute.String("ldap.error", err.Error()))
-		span.SetStatus(codes.Error, "")
-		return []string{}, err
+		classified := classifySearchError(err, "")
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	span.SetStatus(codes.Ok, "")
 	span.SetAttributes(attribute.Int("ldap.result_count", len(sr.Entries)))
@@ -504,15 +502,10 @@ func (i *Identity) GetLDAPGroupByFilter(ctx context.Context, lc ldap.Client, fil
 	res, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Debug().Str("backend", "ldap").Err(err).Str("filter", filter).Msg("Error looking up group by filter")
-		var errmsg string
-		if lerr, ok := err.(*ldap.Error); ok {
-			if lerr.ResultCode == ldap.LDAPResultSizeLimitExceeded {
-				errmsg = fmt.Sprintf("too many results searching for group '%s'", filter)
-			}
-		}
-		span.SetAttributes(attribute.String("ldap.error", errmsg))
-		span.SetStatus(codes.Error, "")
-		return nil, errtypes.NotFound(errmsg)
+		classified := classifySearchError(err, fmt.Sprintf("too many results searching for group '%s'", filter))
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	if len(res.Entries) == 0 {
 		return nil, errtypes.NotFound(filter)
@@ -543,10 +536,11 @@ func (i *Identity) GetLDAPGroups(ctx context.Context, lc ldap.Client, query stri
 	setLDAPSearchSpanAttributes(span, searchRequest)
 	sr, err := lc.Search(searchRequest)
 	if err != nil {
-		span.SetAttributes(attribute.String("ldap.error", err.Error()))
-		span.SetStatus(codes.Error, "")
 		log.Debug().Str("backend", "ldap").Err(err).Str("query", query).Msg("Error search for groups")
-		return nil, errtypes.NotFound(query)
+		classified := classifySearchError(err, "")
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	span.SetStatus(codes.Ok, "")
 	return sr.Entries, nil
@@ -919,15 +913,10 @@ func (i *Identity) GetLDAPTenantByFilter(ctx context.Context, lc ldap.Client, fi
 	res, err := lc.Search(searchRequest)
 	if err != nil {
 		log.Debug().Str("backend", "ldap").Err(err).Str("tenantfilter", filter).Msg("Error looking up tenant by filter")
-		var errmsg string
-		if lerr, ok := err.(*ldap.Error); ok {
-			if lerr.ResultCode == ldap.LDAPResultSizeLimitExceeded {
-				errmsg = fmt.Sprintf("too many results searching for tenant '%s'", filter)
-			}
-		}
-		span.SetAttributes(attribute.String("ldap.error", errmsg))
-		span.SetStatus(codes.Error, errmsg)
-		return nil, errtypes.NotFound(errmsg)
+		classified := classifySearchError(err, fmt.Sprintf("too many results searching for tenant '%s'", filter))
+		span.SetAttributes(attribute.String("ldap.error", classified.Error()))
+		span.SetStatus(codes.Error, classified.Error())
+		return nil, classified
 	}
 	if len(res.Entries) == 0 {
 		return nil, errtypes.NotFound(filter)
@@ -978,6 +967,24 @@ func (i *Identity) getTenantAttributeFilter(attribute, value string) (string, er
 		attribute,
 		escapedValue,
 	), nil
+}
+
+// classifySearchError maps a raw error from lc.Search to the appropriate
+// errtypes value:
+//   - ldap.ErrorNetwork                → errtypes.Unavailable (transient; caller should retry)
+//   - ldap.LDAPResultSizeLimitExceeded → errtypes.NotFound(sizeExceededMsg)
+//   - anything else                    → errtypes.NotFound("") (preserving prior behaviour)
+//
+// The sizeExceededMsg is only used for the SizeLimitExceeded case; pass an
+// empty string if the caller does not need a custom message for that case.
+func classifySearchError(err error, sizeExceededMsg string) error {
+	if ldap.IsErrorWithCode(err, ldap.ErrorNetwork) {
+		return errtypes.Unavailable("ldap server unreachable: " + err.Error())
+	}
+	if sizeExceededMsg != "" && ldap.IsErrorWithCode(err, ldap.LDAPResultSizeLimitExceeded) {
+		return errtypes.NotFound(sizeExceededMsg)
+	}
+	return errtypes.NotFound("")
 }
 
 func setLDAPSearchSpanAttributes(span trace.Span, request *ldap.SearchRequest) {


### PR DESCRIPTION
Set a proper "unavailable" status that the caller can handle when the LDAP lookup failed because the LDAP server is unavailable instead of always returning "not found".