### PR TITLE
extract Dirstore from tree

### DIFF
--- a/pkg/storage/pkg/decomposedfs/dirstore/dirstore.go
+++ b/pkg/storage/pkg/decomposedfs/dirstore/dirstore.go
@@ -1,0 +1,45 @@
+// Package dirstore defines the interface for directory entry storage in decomposedfs.
+//
+// Decomposedfs represents a hierarchical filesystem where each node (file or directory)
+// is identified by a UUID. Directory entries map human-readable names to node IDs,
+// analogous to POSIX directory entries mapping filenames to inodes.
+//
+// Implementations must be safe for concurrent use.
+package dirstore
+
+import "context"
+
+// DirEntry represents a single entry in a directory.
+// It maps a human-readable name to the ID of the child node.
+type DirEntry struct {
+	// Name is the human-readable name of the child node as it appears in the directory.
+	Name string
+	// NodeID is the UUID of the child node within the space.
+	NodeID string
+}
+
+// DirStore abstracts the storage of directory entries.
+//
+// All operations are scoped to a space identified by spaceID. Within a space,
+// directories are identified by their node UUID (parentID), and entries within
+// a directory are identified by their human-readable name.
+type DirStore interface {
+	// Link creates a directory entry mapping name to childID under parentID in the given space.
+	// If an entry for name already exists and points to a different node, Link returns
+	// errtypes.AlreadyExists. If the entry already points to childID, Link is a no-op.
+	Link(ctx context.Context, spaceID, parentID, name, childID string) error
+
+	// Unlink removes the directory entry for name under parentID in the given space.
+	// If the entry does not exist, Unlink is a no-op.
+	Unlink(ctx context.Context, spaceID, parentID, name string) error
+
+	// Move renames a directory entry within or across parent directories in the given space.
+	// If the source entry does not exist, Move returns an error.
+	// If the destination entry already exists, it is overwritten.
+	Move(ctx context.Context, spaceID, oldParentID, oldName, newParentID, newName string) error
+
+	// List returns all directory entries under parentID in the given space.
+	// The order of entries is undefined.
+	// If the directory does not exist or is empty, List returns an empty slice and no error.
+	List(ctx context.Context, spaceID, parentID string) ([]DirEntry, error)
+}

--- a/pkg/storage/pkg/decomposedfs/dirstore/filesystem/dirstore.go
+++ b/pkg/storage/pkg/decomposedfs/dirstore/filesystem/dirstore.go
@@ -1,0 +1,151 @@
+package filesystem
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/dirstore"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/lookup"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
+	"github.com/pkg/errors"
+	"go-micro.dev/v4/store"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/opencloud-eu/reva/v2/pkg/storage/utils/decomposedfs/dirstore/filesystem")
+}
+
+// DirStore implements tree.DirStore using the local filesystem with symlinks.
+type DirStore struct {
+	root    string
+	idCache store.Store
+}
+
+// New returns a new filesystem DirStore.
+func New(root string, cache store.Store) *DirStore {
+	return &DirStore{root: root, idCache: cache}
+}
+
+// parentPath returns the directory path for a given parentID node.
+func (d *DirStore) parentPath(spaceID, parentID string) string {
+	return filepath.Join(d.root, "spaces", lookup.Pathify(spaceID, 1, 2), "nodes", lookup.Pathify(parentID, 4, 2))
+}
+
+// Link creates a symlink named `name` in the parent directory pointing to the child node.
+func (d *DirStore) Link(ctx context.Context, spaceID, parentID, name, childID string) error {
+	_, span := tracer.Start(ctx, "Link")
+	defer span.End()
+	relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(childID, 4, 2))
+	childNameLink := filepath.Join(d.parentPath(spaceID, parentID), name)
+	if err := os.Symlink(relativeNodePath, childNameLink); err != nil {
+		if !errors.Is(err, fs.ErrExist) {
+			return errors.Wrap(err, "filesystem dirstore: could not symlink child entry")
+		}
+		existing, rerr := os.Readlink(childNameLink)
+		if rerr != nil {
+			return errors.Wrap(rerr, "filesystem dirstore: could not read existing symlink")
+		}
+		if existing == relativeNodePath {
+			return nil // idempotent, same target
+		}
+		return errtypes.AlreadyExists(name)
+	}
+	return nil
+}
+
+// Unlink removes the symlink named `name` from the parent directory.
+func (d *DirStore) Unlink(ctx context.Context, spaceID, parentID, name string) error {
+	_, span := tracer.Start(ctx, "Unlink")
+	defer span.End()
+	childNameLink := filepath.Join(d.parentPath(spaceID, parentID), name)
+
+	// remove entry from cache immediately to avoid inconsistencies
+	defer func() { _ = d.idCache.Delete(childNameLink) }()
+
+	if err := os.Remove(childNameLink); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return errors.Wrap(err, "filesystem dirstore: could not remove symlink child entry")
+	}
+	return nil
+}
+
+// Move renames a directory entry, handling both same-parent renames and cross-parent moves.
+func (d *DirStore) Move(ctx context.Context, spaceID, oldParentID, oldName, newParentID, newName string) error {
+	_, span := tracer.Start(ctx, "Move")
+	defer span.End()
+	src := filepath.Join(d.parentPath(spaceID, oldParentID), oldName)
+	dst := filepath.Join(d.parentPath(spaceID, newParentID), newName)
+
+	// remove cache entry in any case to avoid inconsistencies
+	defer func() { _ = d.idCache.Delete(src) }()
+
+	if err := os.Rename(src, dst); err != nil {
+		return errors.Wrap(err, "filesystem dirstore: could not move child entry")
+	}
+	return nil
+}
+
+// List reads the directory entries for parentID by reading symlinks.
+func (d *DirStore) List(ctx context.Context, spaceID, parentID string) ([]dirstore.DirEntry, error) {
+	_, span := tracer.Start(ctx, "List")
+	defer span.End()
+	dir := d.parentPath(spaceID, parentID)
+	f, err := os.Open(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "filesystem dirstore: error opening directory")
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(0)
+	if err != nil {
+		return nil, errors.Wrap(err, "filesystem dirstore: error reading directory")
+	}
+
+	entries := make([]dirstore.DirEntry, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+
+		nodeID := d.getNodeIDFromCache(ctx, path)
+		if nodeID == "" {
+			nodeID, err = node.ReadChildNodeFromLink(ctx, path)
+			if err != nil {
+				return nil, errors.Wrapf(err, "filesystem dirstore: could not read symlink %s", path)
+			}
+			d.storeNodeIDInCache(ctx, path, nodeID)
+		}
+
+		entries = append(entries, dirstore.DirEntry{
+			Name:   name,
+			NodeID: nodeID,
+		})
+	}
+	return entries, nil
+}
+
+func (d *DirStore) getNodeIDFromCache(ctx context.Context, path string) string {
+	_, span := tracer.Start(ctx, "getNodeIDFromCache")
+	defer span.End()
+	recs, err := d.idCache.Read(path)
+	if err == nil && len(recs) > 0 {
+		return string(recs[0].Value)
+	}
+	return ""
+}
+
+func (d *DirStore) storeNodeIDInCache(ctx context.Context, path string, nodeID string) error {
+	_, span := tracer.Start(ctx, "storeNodeIDInCache")
+	defer span.End()
+	return d.idCache.Write(&store.Record{
+		Key:   path,
+		Value: []byte(nodeID),
+	})
+}

--- a/pkg/storage/pkg/decomposedfs/dirstore/nats/dirstore.go
+++ b/pkg/storage/pkg/decomposedfs/dirstore/nats/dirstore.go
@@ -1,0 +1,174 @@
+package nats
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/dirstore"
+	"github.com/pkg/errors"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+const (
+	walStateCommitted = "committed"
+	walStatePending   = "pending"
+)
+
+type walEntry struct {
+	Op          string `msgpack:"op"`
+	SpaceID     string `msgpack:"space_id"`
+	OldParentID string `msgpack:"old_parent_id"`
+	OldName     string `msgpack:"old_name"`
+	NewParentID string `msgpack:"new_parent_id"`
+	NewName     string `msgpack:"new_name"`
+	ChildID     string `msgpack:"child_id"`
+	State       string `msgpack:"state"`
+	CreatedAt   int64  `msgpack:"created_at"`
+}
+
+// DirStore implements tree.DirStore using NATS KV.
+type DirStore struct {
+	kv  jetstream.KeyValue // directory entries: {spaceID}.{parentID}.{name} -> childID
+	wal jetstream.KeyValue // wal entries:       wal.{txid} -> msgpack(walEntry)
+}
+
+// New returns a new NATS DirStore.
+func New(kv jetstream.KeyValue, wal jetstream.KeyValue) *DirStore {
+	return &DirStore{kv: kv, wal: wal}
+}
+
+// Recover replays any pending WAL entries. Call once on startup before serving requests.
+func (d *DirStore) Recover(ctx context.Context) error {
+	watcher, err := d.wal.Watch(ctx, "wal.*", jetstream.IgnoreDeletes())
+	if err != nil {
+		return errors.Wrap(err, "nats dirstore: could not watch wal")
+	}
+	defer watcher.Stop()
+
+	for entry := range watcher.Updates() {
+		if entry == nil {
+			break
+		}
+		var w walEntry
+		if err := msgpack.Unmarshal(entry.Value(), &w); err != nil {
+			return errors.Wrapf(err, "nats dirstore: could not unmarshal wal entry %s", entry.Key())
+		}
+		if w.State == walStateCommitted {
+			continue
+		}
+		// pending — complete the move
+		if err := d.applyMove(ctx, w); err != nil {
+			return errors.Wrapf(err, "nats dirstore: could not recover wal entry %s", entry.Key())
+		}
+		if err := d.wal.Delete(ctx, entry.Key()); err != nil {
+			return errors.Wrapf(err, "nats dirstore: could not delete wal entry %s", entry.Key())
+		}
+	}
+	return nil
+}
+
+// Link creates a directory entry mapping name → childID under spaceID+parentID.
+func (d *DirStore) Link(_ context.Context, spaceID, parentID, name, childID string) error {
+	_, err := d.kv.Put(context.Background(), d.key(spaceID, parentID, name), []byte(childID))
+	if err != nil {
+		return errors.Wrap(err, "nats dirstore: could not link child entry")
+	}
+	return nil
+}
+
+// Unlink removes the directory entry for name under spaceID+parentID.
+func (d *DirStore) Unlink(_ context.Context, spaceID, parentID, name string) error {
+	err := d.kv.Delete(context.Background(), d.key(spaceID, parentID, name))
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return errors.Wrap(err, "nats dirstore: could not unlink child entry")
+	}
+	return nil
+}
+
+// Move atomically renames a directory entry within or across parents using a WAL.
+func (d *DirStore) Move(ctx context.Context, spaceID, oldParentID, oldName, newParentID, newName string) error {
+	// read child id from source
+	entry, err := d.kv.Get(ctx, d.key(spaceID, oldParentID, oldName))
+	if err != nil {
+		return errors.Wrap(err, "nats dirstore: could not get source entry")
+	}
+	childID := string(entry.Value())
+
+	w := walEntry{
+		Op:          "move",
+		SpaceID:     spaceID,
+		OldParentID: oldParentID,
+		OldName:     oldName,
+		NewParentID: newParentID,
+		NewName:     newName,
+		ChildID:     childID,
+		State:       walStatePending,
+		CreatedAt:   time.Now().UnixNano(),
+	}
+
+	// write WAL entry
+	txid := uuid.New().String()
+	walKey := "wal." + txid
+	b, err := msgpack.Marshal(w)
+	if err != nil {
+		return errors.Wrap(err, "nats dirstore: could not marshal wal entry")
+	}
+	if _, err := d.wal.Put(ctx, walKey, b); err != nil {
+		return errors.Wrap(err, "nats dirstore: could not write wal entry")
+	}
+
+	// apply the move
+	if err := d.applyMove(ctx, w); err != nil {
+		return errors.Wrap(err, "nats dirstore: could not apply move")
+	}
+
+	// delete WAL entry — move is complete
+	if err := d.wal.Delete(ctx, walKey); err != nil {
+		return errors.Wrap(err, "nats dirstore: could not delete wal entry")
+	}
+
+	return nil
+}
+
+// List returns all directory entries under spaceID+parentID.
+func (d *DirStore) List(ctx context.Context, spaceID, parentID string) ([]dirstore.DirEntry, error) {
+	watcher, err := d.kv.Watch(ctx, d.prefix(spaceID, parentID)+"*", jetstream.IgnoreDeletes())
+	if err != nil {
+		return nil, errors.Wrap(err, "nats dirstore: could not create watcher")
+	}
+	defer watcher.Stop()
+
+	var entries []dirstore.DirEntry
+	for entry := range watcher.Updates() {
+		if entry == nil {
+			break
+		}
+		name := strings.TrimPrefix(entry.Key(), d.prefix(spaceID, parentID))
+		entries = append(entries, dirstore.DirEntry{
+			Name:   name,
+			NodeID: string(entry.Value()),
+		})
+	}
+	return entries, nil
+}
+
+func (d *DirStore) applyMove(ctx context.Context, w walEntry) error {
+	if _, err := d.kv.Put(ctx, d.key(w.SpaceID, w.NewParentID, w.NewName), []byte(w.ChildID)); err != nil {
+		return errors.Wrap(err, "nats dirstore: could not put destination entry")
+	}
+	if err := d.kv.Delete(ctx, d.key(w.SpaceID, w.OldParentID, w.OldName)); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return errors.Wrap(err, "nats dirstore: could not delete source entry")
+	}
+	return nil
+}
+
+func (d *DirStore) key(spaceID, parentID, name string) string {
+	return d.prefix(spaceID, parentID) + name
+}
+
+func (d *DirStore) prefix(spaceID, parentID string) string {
+	return spaceID + "." + parentID + "."
+}

--- a/pkg/storage/pkg/decomposedfs/tree/tree.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree.go
@@ -34,6 +34,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/dirstore"
+	fsdirstore "github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/dirstore/filesystem"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/lookup"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
@@ -62,10 +64,9 @@ type Tree struct {
 	blobstore   node.Blobstore
 	propagator  propagator.Propagator
 	permissions permissions.Permissions
+	dirStore    dirstore.DirStore
 
 	options *options.Options
-
-	idCache store.Store
 }
 
 // PermissionCheckFunc defined a function used to check resource permissions
@@ -78,7 +79,7 @@ func New(lu node.PathLookup, bs node.Blobstore, o *options.Options, p permission
 		blobstore:   bs,
 		options:     o,
 		permissions: p,
-		idCache:     cache,
+		dirStore:    fsdirstore.New(o.Root, cache),
 		propagator:  propagator.New(lu, o, log),
 	}
 }
@@ -162,19 +163,8 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node, markprocessing bool,
 	}
 
 	// link child name to parent if it is new
-	childNameLink := filepath.Join(n.ParentPath(), n.Name)
-	var link string
-	link, err = os.Readlink(childNameLink)
-	if err == nil && link != "../"+n.ID {
-		if err = os.Remove(childNameLink); err != nil {
-			return errors.Wrap(err, "Decomposedfs: could not remove symlink child entry")
-		}
-	}
-	if errors.Is(err, fs.ErrNotExist) || link != "../"+n.ID {
-		relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
-		if err = os.Symlink(relativeNodePath, childNameLink); err != nil {
-			return errors.Wrap(err, "Decomposedfs: could not symlink child entry")
-		}
+	if err = t.dirStore.Link(ctx, n.SpaceID, n.ParentID, n.Name, n.ID); err != nil {
+		return errors.Wrap(err, "Decomposedfs: could not link child entry")
 	}
 
 	return t.Propagate(ctx, n, 0)
@@ -200,24 +190,9 @@ func (t *Tree) CreateDir(ctx context.Context, n *node.Node) (err error) {
 	}
 
 	// make child appear in listings
-	relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
-	ctx, subspan := tracer.Start(ctx, "os.Symlink")
-	err = os.Symlink(relativeNodePath, filepath.Join(n.ParentPath(), n.Name))
-	subspan.End()
+	err = t.dirStore.Link(ctx, n.SpaceID, n.ParentID, n.Name, n.ID)
 	if err != nil {
-		// no better way to check unfortunately
-		if !strings.Contains(err.Error(), "file exists") {
-			return
-		}
-
-		// try to remove the node
-		ctx, subspan = tracer.Start(ctx, "os.RemoveAll")
-		e := os.RemoveAll(n.InternalPath())
-		subspan.End()
-		if e != nil {
-			appctx.GetLogger(ctx).Debug().Err(e).Msg("cannot delete node")
-		}
-		return errtypes.AlreadyExists(err.Error())
+		return
 	}
 	return t.Propagate(ctx, n, 0)
 }
@@ -243,23 +218,12 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		}
 	}
 
-	// remove cache entry in any case to avoid inconsistencies
-	defer func() { _ = t.idCache.Delete(filepath.Join(oldNode.ParentPath(), oldNode.Name)) }()
-
 	// Always target the old node ID for xattr updates.
 	// The new node id is empty if the target does not exist
 	// and we need to overwrite the new one when overwriting an existing path.
 	// are we just renaming (parent stays the same)?
 	if oldNode.ParentID == newNode.ParentID {
-
-		// parentPath := t.lookup.InternalPath(oldNode.SpaceID, oldNode.ParentID)
-		parentPath := oldNode.ParentPath()
-
-		// rename child
-		err = os.Rename(
-			filepath.Join(parentPath, oldNode.Name),
-			filepath.Join(parentPath, newNode.Name),
-		)
+		err = t.dirStore.Move(ctx, oldNode.SpaceID, oldNode.ParentID, oldNode.Name, newNode.ParentID, newNode.Name)
 		if err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not rename child")
 		}
@@ -273,13 +237,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 	}
 
 	// we are moving the node to a new parent, any target has been removed
-	// bring old node to the new parent
-
-	// rename child
-	err = os.Rename(
-		filepath.Join(oldNode.ParentPath(), oldNode.Name),
-		filepath.Join(newNode.ParentPath(), newNode.Name),
-	)
+	err = t.dirStore.Move(ctx, oldNode.SpaceID, oldNode.ParentID, oldNode.Name, newNode.ParentID, newNode.Name)
 	if err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not move child")
 	}
@@ -323,31 +281,21 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, error) {
 	ctx, span := tracer.Start(ctx, "ListFolder")
 	defer span.End()
-	dir := n.InternalPath()
 
-	_, subspan := tracer.Start(ctx, "os.Open")
-	f, err := os.Open(dir)
-	subspan.End()
+	entries, err := t.dirStore.List(ctx, n.SpaceID, n.ID)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, errtypes.NotFound(dir)
-		}
-		return nil, errors.Wrap(err, "tree: error listing "+dir)
+		return nil, errors.Wrap(err, "tree: error listing "+n.SpaceID+"!"+n.ID)
 	}
-	defer f.Close()
 
-	_, subspan = tracer.Start(ctx, "f.Readdirnames")
-	names, err := f.Readdirnames(0)
-	subspan.End()
-	if err != nil {
-		return nil, err
+	if len(entries) == 0 {
+		return []*node.Node{}, nil
 	}
 
 	numWorkers := t.options.MaxConcurrency
-	if len(names) < numWorkers {
-		numWorkers = len(names)
+	if len(entries) < numWorkers {
+		numWorkers = len(entries)
 	}
-	work := make(chan string)
+	work := make(chan dirstore.DirEntry)
 	results := make(chan *node.Node)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -355,9 +303,9 @@ func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, erro
 	// Distribute work
 	g.Go(func() error {
 		defer close(work)
-		for _, name := range names {
+		for _, entry := range entries {
 			select {
-			case work <- name:
+			case work <- entry:
 			case <-ctx.Done():
 				return ctx.Err()
 			}
@@ -368,22 +316,8 @@ func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, erro
 	// Spawn workers that'll concurrently work the queue
 	for i := 0; i < numWorkers; i++ {
 		g.Go(func() error {
-			var err error
-			for name := range work {
-				path := filepath.Join(dir, name)
-				nodeID := getNodeIDFromCache(ctx, path, t.idCache)
-				if nodeID == "" {
-					nodeID, err = node.ReadChildNodeFromLink(ctx, path)
-					if err != nil {
-						return err
-					}
-					err = storeNodeIDInCache(ctx, path, nodeID, t.idCache)
-					if err != nil {
-						return err
-					}
-				}
-
-				child, err := node.ReadNode(ctx, t.lookup, n.SpaceID, nodeID, "", false, n.SpaceRoot, true)
+			for entry := range work {
+				child, err := node.ReadNode(ctx, t.lookup, n.SpaceID, entry.NodeID, "", false, n.SpaceRoot, true)
 				if err != nil {
 					return err
 				}
@@ -425,9 +359,6 @@ func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, erro
 func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	_, span := tracer.Start(ctx, "Delete")
 	defer span.End()
-	path := filepath.Join(n.ParentPath(), n.Name)
-	// remove entry from cache immediately to avoid inconsistencies
-	defer func() { _ = t.idCache.Delete(path) }()
 
 	// get the original path
 	origin, err := t.lookup.Path(ctx, n, node.NoCheck)
@@ -502,11 +433,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	_ = os.Remove(t.lookup.MetadataBackend().LockfilePath(n))
 
 	// finally remove the entry from the parent dir
-	if err = os.Remove(path); err != nil {
-		// To roll back changes
-		// TODO revert the rename
-		// TODO remove symlink
-		// Roll back changes
+	if err = t.dirStore.Unlink(ctx, n.SpaceID, n.ParentID, n.Name); err != nil {
 		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
 		return
 	}
@@ -556,7 +483,7 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		restoreNode := node.NewBaseNode(targetNode.SpaceID, originalId, t.lookup)
 
 		// add the entry for the parent dir
-		err = os.Symlink("../../../../../"+lookup.Pathify(originalId, 4, 2), filepath.Join(targetNode.ParentPath(), targetNode.Name))
+		err = t.dirStore.Link(ctx, targetNode.SpaceID, targetNode.ParentID, targetNode.Name, originalId)
 		if err != nil {
 			return nil, err
 		}
@@ -679,23 +606,13 @@ func (t *Tree) InitNewNode(ctx context.Context, n *node.Node, fsize uint64) (met
 	}
 
 	// link child name to parent if it is new
-	childNameLink := filepath.Join(n.ParentPath(), n.Name)
-	relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
-	log := appctx.GetLogger(ctx).With().Str("childNameLink", childNameLink).Str("relativeNodePath", relativeNodePath).Logger()
-	log.Info().Msg("initNewNode: creating symlink")
-
-	_, subspan = tracer.Start(ctx, "os.Symlink")
-	err = os.Symlink(relativeNodePath, childNameLink)
-	subspan.End()
+	err = t.dirStore.Link(ctx, n.SpaceID, n.ParentID, n.Name, n.ID)
 	if err != nil {
-		log.Info().Err(err).Msg("initNewNode: symlink failed")
-		if errors.Is(err, fs.ErrExist) {
-			log.Info().Err(err).Msg("initNewNode: symlink already exists")
+		if errors.Is(err, errtypes.AlreadyExists("")) {
 			return unlock, errtypes.AlreadyExists(n.Name)
 		}
-		return unlock, errors.Wrap(err, "Decomposedfs: could not symlink child entry")
+		return unlock, errors.Wrap(err, "Decomposedfs: could not link child entry")
 	}
-	log.Info().Msg("initNewNode: symlink created")
 
 	return unlock, nil
 }
@@ -933,23 +850,4 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceID, key, path string) (
 	}
 
 	return
-}
-
-func getNodeIDFromCache(ctx context.Context, path string, cache store.Store) string {
-	_, span := tracer.Start(ctx, "getNodeIDFromCache")
-	defer span.End()
-	recs, err := cache.Read(path)
-	if err == nil && len(recs) > 0 {
-		return string(recs[0].Value)
-	}
-	return ""
-}
-
-func storeNodeIDInCache(ctx context.Context, path string, nodeID string, cache store.Store) error {
-	_, span := tracer.Start(ctx, "storeNodeIDInCache")
-	defer span.End()
-	return cache.Write(&store.Record{
-		Key:   path,
-		Value: []byte(nodeID),
-	})
 }


### PR DESCRIPTION
This is WIP, but I am creating a PR because there are other implementations for nats based metadata persistence.

The first commit just extracts a dirstore package from the tree to persist parent -> child relationship in the filesystem or (the second commit) in nats. Other implementations are certainly possible and this is in an early stage. And AFAICT there are more places that touch the disk, so I assume the interface will grow to cover more cases.

In any case, the nats implamantation uses a WAL to implement move, since nats cannot change two keys in a transaction. 

Every parent -> child relationship is modeled as an individual key. This allows listing a directory with a watch on a drefix for the dir + the `*` wildcard. This approach prevents having to deal with the default 1MB limitation on nats values.
