### PR TITLE
ldap: Set a default request timeout

### DIFF
--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -68,7 +68,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func getAuthManager(manager string, m map[string]map[string]interface{}) (auth.Manager, *plugin.RevaPlugin, error) {
+func getAuthManager(manager string, m map[string]map[string]any, logger *zerolog.Logger) (auth.Manager, *plugin.RevaPlugin, error) {
 	if manager == "" {
 		return nil, nil, errtypes.InternalError("authsvc: driver not configured for auth manager")
 	}
@@ -86,7 +86,7 @@ func getAuthManager(manager string, m map[string]map[string]interface{}) (auth.M
 		return authManager, p, nil
 	} else if _, ok := err.(errtypes.NotFound); ok {
 		if f, ok := registry.NewFuncs[manager]; ok {
-			authmgr, err := f(m[manager])
+			authmgr, err := f(m[manager], logger)
 			return authmgr, nil, err
 		}
 	} else {
@@ -96,13 +96,13 @@ func getAuthManager(manager string, m map[string]map[string]interface{}) (auth.M
 }
 
 // New returns a new AuthProviderServiceServer.
-func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Service, error) {
+func New(m map[string]interface{}, ss *grpc.Server, logger *zerolog.Logger) (rgrpc.Service, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 
-	authManager, plug, err := getAuthManager(c.AuthManager, c.AuthManagers)
+	authManager, plug, err := getAuthManager(c.AuthManager, c.AuthManagers, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/grpc/services/groupprovider/groupprovider.go
+++ b/internal/grpc/services/groupprovider/groupprovider.go
@@ -60,22 +60,22 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func getDriver(c *config) (group.Manager, error) {
+func getDriver(c *config, logger *zerolog.Logger) (group.Manager, error) {
 	if f, ok := registry.NewFuncs[c.Driver]; ok {
-		return f(c.Drivers[c.Driver])
+		return f(c.Drivers[c.Driver], logger)
 	}
 
 	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for group manager", c.Driver))
 }
 
 // New returns a new GroupProviderServiceServer.
-func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Service, error) {
+func New(m map[string]any, ss *grpc.Server, logger *zerolog.Logger) (rgrpc.Service, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 
-	groupManager, err := getDriver(c)
+	groupManager, err := getDriver(c, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -84,7 +84,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
+func getDriver(c *config, logger *zerolog.Logger) (user.Manager, *plugin.RevaPlugin, error) {
 	p, err := plugin.Load("userprovider", c.Driver)
 	if err == nil {
 		manager, ok := p.Plugin.(user.Manager)
@@ -100,7 +100,7 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 	} else if _, ok := err.(errtypes.NotFound); ok {
 		// plugin not found, fetch the driver from the in-memory registry
 		if f, ok := userRegistry.NewFuncs[c.Driver]; ok {
-			mgr, err := f(c.Drivers[c.Driver])
+			mgr, err := f(c.Drivers[c.Driver], logger)
 			return mgr, nil, err
 		}
 	} else {
@@ -109,25 +109,25 @@ func getDriver(c *config) (user.Manager, *plugin.RevaPlugin, error) {
 	return nil, nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for user manager", c.Driver))
 }
 
-func getTenantManager(c *config) (tenant.Manager, error) {
+func getTenantManager(c *config, logger *zerolog.Logger) (tenant.Manager, error) {
 	if f, ok := tenantRegistry.NewFuncs[c.TenantDriver]; ok {
-		mgr, err := f(c.TenantDrivers[c.TenantDriver])
+		mgr, err := f(c.TenantDrivers[c.TenantDriver], logger)
 		return mgr, err
 	}
 	return nil, errtypes.NotFound(fmt.Sprintf("driver %s not found for tenant manager", c.TenantDriver))
 }
 
 // New returns a new UserProviderServiceServer.
-func New(m map[string]interface{}, ss *grpc.Server, _ *zerolog.Logger) (rgrpc.Service, error) {
+func New(m map[string]interface{}, ss *grpc.Server, logger *zerolog.Logger) (rgrpc.Service, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
-	userManager, plug, err := getDriver(c)
+	userManager, plug, err := getDriver(c, logger)
 	if err != nil {
 		return nil, err
 	}
-	tenantManager, err := getTenantManager(c)
+	tenantManager, err := getTenantManager(c, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -42,7 +43,7 @@ type manager struct {
 }
 
 // New returns a new auth Manager.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, logger *zerolog.Logger) (auth.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {

--- a/pkg/auth/manager/demo/demo.go
+++ b/pkg/auth/manager/demo/demo.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/auth/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/auth/scope"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -44,7 +45,7 @@ type Credentials struct {
 }
 
 // New returns a new auth Manager.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	// m not used
 	mgr := &manager{}
 	err := mgr.Configure(m)

--- a/pkg/auth/manager/demo/demo_test.go
+++ b/pkg/auth/manager/demo/demo_test.go
@@ -27,7 +27,7 @@ var ctx = context.Background()
 
 func TestUserManager(t *testing.T) {
 	// get manager
-	manager, _ := New(nil)
+	manager, _ := New(nil, nil)
 
 	// Authenticate - positive test
 	_, _, err := manager.Authenticate(ctx, "einstein", "relativity")

--- a/pkg/auth/manager/impersonator/impersonator.go
+++ b/pkg/auth/manager/impersonator/impersonator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/auth"
 	"github.com/opencloud-eu/reva/v2/pkg/auth/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/auth/scope"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -36,7 +37,7 @@ func init() {
 type mgr struct{}
 
 // New returns an auth manager implementation that allows to authenticate with any credentials.
-func New(c map[string]interface{}) (auth.Manager, error) {
+func New(c map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	return &mgr{}, nil
 }
 

--- a/pkg/auth/manager/impersonator/impersonator_test.go
+++ b/pkg/auth/manager/impersonator/impersonator_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestImpersonator(t *testing.T) {
 	ctx := context.Background()
-	i, _ := New(nil)
+	i, _ := New(nil, nil)
 	u, _, err := i.Authenticate(ctx, "admin", "pwd")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/auth/scope"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -78,7 +79,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a new auth Manager.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {

--- a/pkg/auth/manager/json/json_test.go
+++ b/pkg/auth/manager/json/json_test.go
@@ -60,7 +60,7 @@ func TestGetManagerWithInvalidUser(t *testing.T) {
 				"users": tt.user,
 			}
 
-			manager, err := New(input)
+			manager, err := New(input, nil)
 
 			assert.Empty(t, manager)
 			assert.EqualError(t, err, tt.expectedError)
@@ -117,7 +117,7 @@ func TestGetManagerWithJSONObject(t *testing.T) {
 				"users": tmpFile.Name(),
 			}
 
-			manager, err := New(input)
+			manager, err := New(input, nil)
 
 			if tt.expectManager {
 				assert.Equal(t, nil, err)
@@ -180,7 +180,7 @@ func TestGetAuthenticatedManager(t *testing.T) {
 	input := map[string]interface{}{
 		"users": tempFile.Name(),
 	}
-	manager, _ := New(input)
+	manager, _ := New(input, nil)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -39,6 +39,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	ldapIdentity "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -72,13 +73,13 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns an auth manager implementation that connects to a LDAP server to validate the user.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, logger *zerolog.Logger) (auth.Manager, error) {
 	manager := &mgr{}
 	err := manager.Configure(m)
 	if err != nil {
 		return nil, err
 	}
-	manager.ldapClient, err = utils.GetLDAPClientWithReconnect(&manager.c.LDAPConn)
+	manager.ldapClient, err = utils.GetLDAPClientWithReconnect(&manager.c.LDAPConn, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 // 'machine' is an authentication method used to impersonate users.
@@ -60,7 +61,7 @@ func (m *manager) Configure(conf map[string]interface{}) error {
 }
 
 // New creates a new manager for the 'machine' authentication
-func New(conf map[string]interface{}) (auth.Manager, error) {
+func New(conf map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	m := &manager{}
 	err := m.Configure(conf)
 	if err != nil {

--- a/pkg/auth/manager/ocmshares/ocmshares.go
+++ b/pkg/auth/manager/ocmshares/ocmshares.go
@@ -39,6 +39,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/opencloud-eu/reva/v2/pkg/utils/cfg"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -59,7 +60,7 @@ func (c *config) ApplyDefaults() {
 }
 
 // New creates a new ocmshares authentication manager.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	var mgr manager
 	if err := mgr.Configure(m); err != nil {
 		return nil, err

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -44,6 +44,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp"
 	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 )
 
@@ -102,7 +103,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns an auth manager implementation that verifies the oidc token and obtains the user claims.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	manager := &mgr{}
 	err := manager.Configure(m)
 	if err != nil {

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -36,6 +36,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -60,7 +61,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a new auth Manager.
-func New(m map[string]interface{}) (auth.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {

--- a/pkg/auth/manager/registry/registry.go
+++ b/pkg/auth/manager/registry/registry.go
@@ -20,11 +20,12 @@ package registry
 
 import (
 	"github.com/opencloud-eu/reva/v2/pkg/auth"
+	"github.com/rs/zerolog"
 )
 
 // NewFunc is the function that auth implementations
 // should register to at init time.
-type NewFunc func(map[string]interface{}) (auth.Manager, error)
+type NewFunc func(map[string]any, *zerolog.Logger) (auth.Manager, error)
 
 // NewFuncs is a map containing all the registered auth managers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/auth/manager/serviceaccounts/serviceaccounts.go
+++ b/pkg/auth/manager/serviceaccounts/serviceaccounts.go
@@ -5,6 +5,7 @@ import (
 
 	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/rs/zerolog"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/opencloud-eu/reva/v2/pkg/auth"
@@ -46,7 +47,7 @@ func (m *manager) Configure(config map[string]interface{}) error {
 }
 
 // New creates a new manager for the 'service' authentication
-func New(conf map[string]interface{}) (auth.Manager, error) {
+func New(conf map[string]any, _ *zerolog.Logger) (auth.Manager, error) {
 	m := &manager{}
 	err := m.Configure(conf)
 	if err != nil {

--- a/pkg/conversions/main.go
+++ b/pkg/conversions/main.go
@@ -30,9 +30,7 @@ import (
 
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/mime"
-	"github.com/opencloud-eu/reva/v2/pkg/publicshare"
 	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
-	"github.com/opencloud-eu/reva/v2/pkg/user"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
@@ -42,8 +40,6 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	publicsharemgr "github.com/opencloud-eu/reva/v2/pkg/publicshare/manager/registry"
-	usermgr "github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
 )
 
 const (
@@ -411,24 +407,6 @@ func LocalGroupIDToString(groupID *grouppb.GroupId) string {
 		return ""
 	}
 	return groupID.OpaqueId
-}
-
-// GetUserManager returns a connection to a user share manager
-func GetUserManager(manager string, m map[string]map[string]interface{}) (user.Manager, error) {
-	if f, ok := usermgr.NewFuncs[manager]; ok {
-		return f(m[manager])
-	}
-
-	return nil, fmt.Errorf("driver %s not found for user manager", manager)
-}
-
-// GetPublicShareManager returns a connection to a public share manager
-func GetPublicShareManager(manager string, m map[string]map[string]interface{}) (publicshare.Manager, error) {
-	if f, ok := publicsharemgr.NewFuncs[manager]; ok {
-		return f(m[manager])
-	}
-
-	return nil, fmt.Errorf("driver %s not found for public shares manager", manager)
 }
 
 // timestamp is assumed to be UTC ... just human readable ...

--- a/pkg/group/manager/json/json.go
+++ b/pkg/group/manager/json/json.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/group"
 	"github.com/opencloud-eu/reva/v2/pkg/group/manager/registry"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -65,7 +66,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a group manager implementation that reads a json file to provide group metadata.
-func New(m map[string]interface{}) (group.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (group.Manager, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/group/manager/json/json_test.go
+++ b/pkg/group/manager/json/json_test.go
@@ -61,7 +61,7 @@ func TestUserManager(t *testing.T) {
 	input := map[string]interface{}{
 		"groups": file.Name(),
 	}
-	_, err = New(input)
+	_, err = New(input, nil)
 	if err == nil {
 		t.Fatalf("no error (but we expected one) while get manager")
 	}
@@ -89,7 +89,7 @@ func TestUserManager(t *testing.T) {
 	input = map[string]interface{}{
 		"groups": file.Name(),
 	}
-	manager, _ := New(input)
+	manager, _ := New(input, nil)
 
 	// setup test data
 	gid := &grouppb.GroupId{OpaqueId: "sailing-lovers"}

--- a/pkg/group/manager/ldap/ldap.go
+++ b/pkg/group/manager/ldap/ldap.go
@@ -36,6 +36,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/sharedconf"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	ldapIdentity "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -70,7 +71,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a group manager implementation that connects to a LDAP server to provide group metadata.
-func New(m map[string]interface{}) (group.Manager, error) {
+func New(m map[string]any, logger *zerolog.Logger) (group.Manager, error) {
 	if sharedconf.MultiTenantEnabled() {
 		return nil, errtypes.NotSupported("ldap group manager does not support multi-tenancy")
 	}
@@ -81,7 +82,7 @@ func New(m map[string]interface{}) (group.Manager, error) {
 		return nil, err
 	}
 
-	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn)
+	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/group/manager/null/null.go
+++ b/pkg/group/manager/null/null.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/group"
 	"github.com/opencloud-eu/reva/v2/pkg/group/manager/registry"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -37,7 +38,7 @@ type manager struct {
 }
 
 // New returns a group manager implementation that return NOT FOUND or empty result set for every call
-func New(m map[string]interface{}) (group.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (group.Manager, error) {
 	return &manager{}, nil
 }
 

--- a/pkg/group/manager/registry/registry.go
+++ b/pkg/group/manager/registry/registry.go
@@ -18,11 +18,14 @@
 
 package registry
 
-import "github.com/opencloud-eu/reva/v2/pkg/group"
+import (
+	"github.com/opencloud-eu/reva/v2/pkg/group"
+	"github.com/rs/zerolog"
+)
 
 // NewFunc is the function that group managers
 // should register at init time.
-type NewFunc func(map[string]interface{}) (group.Manager, error)
+type NewFunc func(map[string]any, *zerolog.Logger) (group.Manager, error)
 
 // NewFuncs is a map containing all the registered group managers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/tenant/manager/ldap/ldap.go
+++ b/pkg/tenant/manager/ldap/ldap.go
@@ -32,6 +32,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	ldapIdentity "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -60,14 +61,14 @@ type manager struct {
 }
 
 // New returns a new user manager.
-func New(m map[string]interface{}) (tenant.Manager, error) {
+func New(m map[string]any, logger *zerolog.Logger) (tenant.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {
 		return nil, err
 	}
 
-	mgr.ldap, err = utils.GetLDAPClientWithReconnect(&mgr.conf.LDAPConn)
+	mgr.ldap, err = utils.GetLDAPClientWithReconnect(&mgr.conf.LDAPConn, logger)
 
 	return mgr, err
 }

--- a/pkg/tenant/manager/memory/memory.go
+++ b/pkg/tenant/manager/memory/memory.go
@@ -27,6 +27,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/tenant"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -57,7 +58,7 @@ type manager struct {
 }
 
 // New returns a new tenant manager.
-func New(m map[string]interface{}) (tenant.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (tenant.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	return mgr, err

--- a/pkg/tenant/manager/null/null.go
+++ b/pkg/tenant/manager/null/null.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant"
 	"github.com/opencloud-eu/reva/v2/pkg/tenant/manager/registry"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -36,7 +37,7 @@ type manager struct {
 }
 
 // New returns a tenant manager implementation that return NOT FOUND or empty result set for every call
-func New(m map[string]interface{}) (tenant.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (tenant.Manager, error) {
 	return &manager{}, nil
 }
 

--- a/pkg/tenant/manager/registry/registry.go
+++ b/pkg/tenant/manager/registry/registry.go
@@ -20,11 +20,12 @@ package registry
 
 import (
 	"github.com/opencloud-eu/reva/v2/pkg/tenant"
+	"github.com/rs/zerolog"
 )
 
 // NewFunc is the function that tenant managers
 // should register at init time.
-type NewFunc func(map[string]interface{}) (tenant.Manager, error)
+type NewFunc func(map[string]any, *zerolog.Logger) (tenant.Manager, error)
 
 // NewFuncs is a map containing all the registered user managers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/user/manager/demo/demo.go
+++ b/pkg/user/manager/demo/demo.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/user"
 	"github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -40,7 +41,7 @@ type manager struct {
 }
 
 // New returns a new user manager.
-func New(m map[string]interface{}) (user.Manager, error) {
+func New(m map[string]interface{}, _ *zerolog.Logger) (user.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {

--- a/pkg/user/manager/demo/demo_test.go
+++ b/pkg/user/manager/demo/demo_test.go
@@ -34,7 +34,7 @@ var ctx = context.Background()
 
 func TestUserManager(t *testing.T) {
 	// get manager
-	manager, _ := New(nil)
+	manager, _ := New(nil, nil)
 
 	// setup test data
 	uidEinstein := &userpb.UserId{

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -25,14 +25,14 @@ import (
 	"strconv"
 	"strings"
 
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/mitchellh/mapstructure"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/user"
 	"github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/proto"
-
-	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 )
 
 func init() {
@@ -65,7 +65,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a user manager implementation that reads a json file to provide user metadata.
-func New(m map[string]interface{}) (user.Manager, error) {
+func New(m map[string]interface{}, _ *zerolog.Logger) (user.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -58,7 +58,7 @@ func TestUserManager(t *testing.T) {
 	input := map[string]interface{}{
 		"users": file.Name(),
 	}
-	_, err = New(input)
+	_, err = New(input, nil)
 	if err == nil {
 		t.Fatalf("no error (but we expected one) while get manager")
 	}
@@ -86,7 +86,7 @@ func TestUserManager(t *testing.T) {
 	input = map[string]interface{}{
 		"users": file.Name(),
 	}
-	manager, _ := New(input)
+	manager, _ := New(input, nil)
 
 	// setup test data
 	uidEinstein := &userpb.UserId{Idp: "localhost", OpaqueId: "einstein", Type: userpb.UserType_USER_TYPE_PRIMARY}

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -34,6 +34,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	ldapIdentity "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -68,14 +69,18 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a user manager implementation that connects to a LDAP server to provide user metadata.
-func New(m map[string]interface{}) (user.Manager, error) {
+func New(m map[string]any, logger *zerolog.Logger) (user.Manager, error) {
+	if logger == nil {
+		nop := zerolog.Nop()
+		logger = &nop
+	}
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	if err != nil {
 		return nil, err
 	}
 
-	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn)
+	mgr.ldapClient, err = utils.GetLDAPClientWithReconnect(&mgr.c.LDAPConn, logger)
 	return mgr, err
 }
 

--- a/pkg/user/manager/ldap/ldap_test.go
+++ b/pkg/user/manager/ldap/ldap_test.go
@@ -26,17 +26,17 @@ import (
 
 func TestUserManager(t *testing.T) {
 	// negative test for parseConfig
-	_, err := New(map[string]interface{}{"uri": 42})
+	_, err := New(map[string]any{"uri": 42}, nil)
 	if err == nil {
 		t.Fatal("expected error but got none")
 	}
 	defaults := ldapIdentity.New()
-	internal := map[string]interface{}{
+	internal := map[string]any{
 		"mail": "email",
 		"dn":   "dn",
 	}
 
-	con := map[string]interface{}{
+	con := map[string]any{
 		"user_schema": internal,
 	}
 
@@ -61,7 +61,7 @@ func TestUserManager(t *testing.T) {
 	}
 
 	// positive tests for New
-	_, err = New(map[string]interface{}{})
+	_, err = New(map[string]any{}, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/user/manager/memory/memory.go
+++ b/pkg/user/manager/memory/memory.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/user"
 	"github.com/opencloud-eu/reva/v2/pkg/user/manager/registry"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -68,7 +69,7 @@ type manager struct {
 }
 
 // New returns a new user manager.
-func New(m map[string]interface{}) (user.Manager, error) {
+func New(m map[string]any, _ *zerolog.Logger) (user.Manager, error) {
 	mgr := &manager{}
 	err := mgr.Configure(m)
 	return mgr, err

--- a/pkg/user/manager/memory/memory_test.go
+++ b/pkg/user/manager/memory/memory_test.go
@@ -31,10 +31,10 @@ var ctx = context.Background()
 
 func TestUserManager(t *testing.T) {
 	// get manager
-	manager, _ := New(map[string]interface{}{
-		"users": map[string]interface{}{
-			"4c510ada-c86b-4815-8820-42cdf82c3d51": map[string]interface{}{
-				"id": map[string]interface{}{
+	manager, _ := New(map[string]any{
+		"users": map[string]any{
+			"4c510ada-c86b-4815-8820-42cdf82c3d51": map[string]any{
+				"id": map[string]any{
 					"opaqueId": "4c510ada-c86b-4815-8820-42cdf82c3d51",
 					"idp":      "http://localhost:9998",
 					"type":     1, // user.UserType_USER_TYPE_PRIMARY
@@ -47,7 +47,7 @@ func TestUserManager(t *testing.T) {
 				"groups":       []string{"sailing-lovers", "violin-haters", "physics-lovers"},
 			},
 		},
-	})
+	}, nil)
 
 	// setup test data
 	uidEinstein := &userpb.UserId{Idp: "http://localhost:9998", OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51", Type: userpb.UserType_USER_TYPE_PRIMARY}

--- a/pkg/user/manager/registry/registry.go
+++ b/pkg/user/manager/registry/registry.go
@@ -20,11 +20,12 @@ package registry
 
 import (
 	"github.com/opencloud-eu/reva/v2/pkg/user"
+	"github.com/rs/zerolog"
 )
 
 // NewFunc is the function that user managers
 // should register at init time.
-type NewFunc func(map[string]interface{}) (user.Manager, error)
+type NewFunc func(map[string]any, *zerolog.Logger) (user.Manager, error)
 
 // NewFuncs is a map containing all the registered user managers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/utils/ldap.go
+++ b/pkg/utils/ldap.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
-	"github.com/opencloud-eu/reva/v2/pkg/logger"
 	ldapReconnect "github.com/opencloud-eu/reva/v2/pkg/utils/ldap"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 // LDAPConn holds the basic parameter for setting up an
@@ -44,10 +44,14 @@ type LDAPConn struct {
 // GetLDAPClientWithReconnect initializes a long-lived LDAP connection that
 // automatically reconnects on connection errors. It allows to set TLS options
 // e.g. to add trusted Certificates or disable Certificate verification
-func GetLDAPClientWithReconnect(c *LDAPConn) (ldap.Client, error) {
+func GetLDAPClientWithReconnect(c *LDAPConn, logger *zerolog.Logger) (ldap.Client, error) {
 	var tlsConf *tls.Config
+	if logger == nil {
+		nop := zerolog.Nop()
+		logger = &nop
+	}
 	if c.Insecure {
-		logger.New().Warn().Msg("SSL Certificate verification is disabled. This is strongly discouraged for production environments.")
+		logger.Warn().Msg("SSL Certificate verification is disabled. This is strongly discouraged for production environments.")
 		tlsConf = &tls.Config{
 			//nolint:gosec // We need the ability to run with "insecure" (dev/testing)
 			InsecureSkipVerify: true,
@@ -73,6 +77,8 @@ func GetLDAPClientWithReconnect(c *LDAPConn) (ldap.Client, error) {
 			TLSConfig:    tlsConf,
 		},
 	)
+
+	conn.SetLogger(logger)
 	return conn, nil
 }
 

--- a/pkg/utils/ldap/reconnect.go
+++ b/pkg/utils/ldap/reconnect.go
@@ -221,6 +221,7 @@ func (c *ConnWithReconnect) ldapConnect(config Config) (*ldap.Conn, error) {
 		return nil, err
 	}
 	c.logger.Debug().Msg("LDAP Connected")
+	l.SetTimeout(30 * time.Second)
 	if config.BindDN != "" {
 		c.logger.Debug().Msgf("Binding as %s", config.BindDN)
 		err = l.Bind(config.BindDN, config.BindPassword)


### PR DESCRIPTION
By default the go-ldap Client only has a network timeout set when
establishing the connection. That timeout is not used when sending
requests on an already established connection. This can lead to
problems when an already established LDAP connections closed uncleanly
(e.g. by a rough load-balancer/firewall)

This changes configures a default network timeout of 30 seconds for all
outgoing request. When the client runs into this time the reconnect
logic will try to establish a new connection and retry the request.

Related: https://github.com/opencloud-eu/internal/issues/278

Note to reviewer: The actual change is in the last commit. The other changes a mostly for being able to get useful debug logging out the of the LDAP client.