### PR TITLE
fix(sharing/jsoncs3): Reject Write Requests while migration is running

### DIFF
--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -234,11 +234,25 @@ func (s *svc) CreateStorageSpace(ctx context.Context, req *provider.CreateStorag
 	//       here is happeing so that that grant is also visible when listing permission (shares) on the spaceroot.
 	if req.GetType() != "personal" && createRes.GetStatus().GetCode() == rpc.Code_CODE_OK {
 		rollbackFn := func() {
-			dsRes, dsErr := s.DeleteStorageSpace(ctx, &provider.DeleteStorageSpaceRequest{
+			// Deleting a space needs to DeleteRequests, one to disable the Space ...
+			dr := &provider.DeleteStorageSpaceRequest{
 				Id: createRes.GetStorageSpace().GetId(),
-			})
+			}
+			dsRes, dsErr := s.DeleteStorageSpace(ctx, dr)
 			if dsErr != nil || dsRes.GetStatus().GetCode() != rpc.Code_CODE_OK {
-				log.Error().Err(dsErr).Interface("status", dsRes.GetStatus()).Interface("space_id", createRes.GetStorageSpace().GetId()).Msg("failed to delete space during rollback")
+				log.Error().Err(dsErr).Interface("status", dsRes.GetStatus()).Interface("space_id", createRes.GetStorageSpace().GetId()).Msg("failed to disable space during rollback")
+				// if disabling fails we won't be able to purge it either so give up here
+				return
+			}
+			// ... and other one to finally purge it
+			dr.Opaque = &typesv1beta1.Opaque{
+				Map: map[string]*typesv1beta1.OpaqueEntry{
+					"purge": {},
+				},
+			}
+			dsRes, dsErr = s.DeleteStorageSpace(ctx, dr)
+			if dsErr != nil || dsRes.GetStatus().GetCode() != rpc.Code_CODE_OK {
+				log.Error().Err(dsErr).Interface("status", dsRes.GetStatus()).Interface("space_id", createRes.GetStorageSpace().GetId()).Msg("failed to purge space during rollback")
 			}
 		}
 

--- a/internal/grpc/services/gateway/storageprovider_test.go
+++ b/internal/grpc/services/gateway/storageprovider_test.go
@@ -219,13 +219,18 @@ var _ = Describe("CreateStorageSpace", func() {
 				DeleteStorageSpace(mock.Anything, mock.Anything, mock.Anything).
 				Return(&provider.DeleteStorageSpaceResponse{
 					Status: status.NewOK(ctx),
+				}, nil).Twice()
+
+			collaborationMock.EXPECT().
+				ListShares(mock.Anything, mock.Anything).
+				Return(&collaborationv1beta1.ListSharesResponse{
+					Status: status.NewOK(ctx),
 				}, nil).Once()
 
 			resp, err := s.CreateStorageSpace(ctx, req)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_INTERNAL))
-			spacesMock.AssertNumberOfCalls(GinkgoT(), "DeleteStorageSpace", 1)
 		})
 
 		It("rolls back the space and returns an error when CreateShare returns a non-OK status", func() {
@@ -239,6 +244,12 @@ var _ = Describe("CreateStorageSpace", func() {
 				DeleteStorageSpace(mock.Anything, mock.Anything, mock.Anything).
 				Return(&provider.DeleteStorageSpaceResponse{
 					Status: status.NewOK(ctx),
+				}, nil).Twice()
+
+			collaborationMock.EXPECT().
+				ListShares(mock.Anything, mock.Anything).
+				Return(&collaborationv1beta1.ListSharesResponse{
+					Status: status.NewOK(ctx),
 				}, nil).Once()
 
 			resp, err := s.CreateStorageSpace(ctx, req)
@@ -247,7 +258,6 @@ var _ = Describe("CreateStorageSpace", func() {
 			Expect(resp.GetStatus().GetCode()).To(Equal(rpcv1beta1.Code_CODE_INTERNAL))
 			// The status message should be propagated from the share response.
 			Expect(resp.GetStatus().GetMessage()).To(ContainSubstring("share store full"))
-			spacesMock.AssertNumberOfCalls(GinkgoT(), "DeleteStorageSpace", 1)
 		})
 
 		It("still returns an error even if the rollback DeleteStorageSpace also fails", func() {

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -328,21 +328,13 @@ func (m *Manager) waitForInit(ctx context.Context) error {
 	}
 }
 
-// waitForMigrations blocks until both storage initialization and all data
-// migrations have completed on this instance, or until ctx is cancelled.
-// It is a strict superset of waitForInit and should be used by write operations
-// to ensure no writes race with an in-progress migration.
-func (m *Manager) waitForMigrations(ctx context.Context) error {
-	select {
-	case <-m.ready:
-	case <-ctx.Done():
-		return errors.Wrap(ctx.Err(), "share manager not yet initialized")
-	}
+// migrationsRunning returns true if migrations have not yet completed on this instance.
+func (m *Manager) migrationsRunning() bool {
 	select {
 	case <-m.migrationsDone:
-		return nil
-	case <-ctx.Done():
-		return errors.Wrap(ctx.Err(), "share manager migrations not yet complete")
+		return false
+	default:
+		return true
 	}
 }
 
@@ -396,10 +388,13 @@ func (m *Manager) ProcessEvents(ch <-chan events.Event) {
 func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Share")
 	defer span.End()
-	if err := m.waitForMigrations(ctx); err != nil {
+	if err := m.waitForInit(ctx); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
+	}
+	if m.migrationsRunning() {
+		return nil, errtypes.Aborted("share manager is currently migrating, please retry")
 	}
 
 	user := ctxpkg.ContextMustGetUser(ctx)
@@ -603,8 +598,11 @@ func (m *Manager) Unshare(ctx context.Context, ref *collaboration.ShareReference
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Unshare")
 	defer span.End()
 
-	if err := m.waitForMigrations(ctx); err != nil {
+	if err := m.waitForInit(ctx); err != nil {
 		return err
+	}
+	if m.migrationsRunning() {
+		return errtypes.Aborted("share manager is currently migrating, please retry")
 	}
 
 	s, err := m.get(ctx, ref)
@@ -620,8 +618,11 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "UpdateShare")
 	defer span.End()
 
-	if err := m.waitForMigrations(ctx); err != nil {
+	if err := m.waitForInit(ctx); err != nil {
 		return nil, err
+	}
+	if m.migrationsRunning() {
+		return nil, errtypes.Aborted("share manager is currently migrating, please retry")
 	}
 
 	var toUpdate *collaboration.Share
@@ -1165,8 +1166,11 @@ func (m *Manager) UpdateReceivedShare(ctx context.Context, receivedShare *collab
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "UpdateReceivedShare")
 	defer span.End()
 
-	if err := m.waitForMigrations(ctx); err != nil {
+	if err := m.waitForInit(ctx); err != nil {
 		return nil, err
+	}
+	if m.migrationsRunning() {
+		return nil, errtypes.Aborted("share manager is currently migrating, please retry")
 	}
 
 	rs, err := m.getReceived(ctx, &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: receivedShare.Share.Id}})
@@ -1330,7 +1334,10 @@ func (m *Manager) removeShare(ctx context.Context, s *collaboration.Share, skipS
 func (m *Manager) CleanupStaleShares(ctx context.Context) {
 	log := appctx.GetLogger(ctx)
 
-	if err := m.waitForMigrations(ctx); err != nil {
+	if err := m.waitForInit(ctx); err != nil {
+		return
+	}
+	if m.migrationsRunning() {
 		return
 	}
 

--- a/pkg/share/manager/jsoncs3/migrations/migration.go
+++ b/pkg/share/manager/jsoncs3/migrations/migration.go
@@ -144,7 +144,7 @@ func New(logger zerolog.Logger,
 // indefinitely until ctx is cancelled. A lock whose timestamp is older than
 // lockTTL is considered stale and will be taken over.
 func (m *Migrations) acquireLock(ctx context.Context) (string, error) {
-	m.logger.Debug().Str("instance", m.instanceID).Msg("acquiring migration lock")
+	m.logger.Info().Str("instance", m.instanceID).Msg("acquiring migration lock")
 	for {
 		// Fast path: create the lock file only if it does not exist yet.
 		data, err := json.Marshal(lockData{Timestamp: time.Now(), InstanceID: m.instanceID})
@@ -157,7 +157,7 @@ func (m *Migrations) acquireLock(ctx context.Context) (string, error) {
 			IfNoneMatch: []string{"*"},
 		})
 		if err == nil {
-			m.logger.Debug().Str("instance", m.instanceID).Msg("migration lock acquired")
+			m.logger.Info().Str("instance", m.instanceID).Msg("migration lock acquired")
 			return res.Etag, nil
 		}
 
@@ -179,7 +179,7 @@ func (m *Migrations) acquireLock(ctx context.Context) (string, error) {
 			if _, ok := err.(errtypes.IsNotFound); ok {
 				// Lock was released between our upload attempt and the download;
 				// retry acquiring it immediately.
-				m.logger.Debug().Str("instance", m.instanceID).Msg("migration lock vanished during read; retrying")
+				m.logger.Info().Str("instance", m.instanceID).Msg("migration lock vanished during read; retrying")
 				continue
 			}
 			return "", err
@@ -192,7 +192,7 @@ func (m *Migrations) acquireLock(ctx context.Context) (string, error) {
 		}
 
 		if stale {
-			m.logger.Debug().
+			m.logger.Info().
 				Str("instance", m.instanceID).
 				Str("held_by", existing.InstanceID).
 				Time("lock_timestamp", existing.Timestamp).
@@ -209,15 +209,15 @@ func (m *Migrations) acquireLock(ctx context.Context) (string, error) {
 				IfMatchEtag: dl.Etag,
 			})
 			if err == nil {
-				m.logger.Debug().Str("instance", m.instanceID).Msg("migration lock acquired via stale takeover")
+				m.logger.Info().Str("instance", m.instanceID).Msg("migration lock acquired via stale takeover")
 				return res.Etag, nil
 			}
 			// Another instance took the stale lock before us; loop and retry.
-			m.logger.Debug().Str("instance", m.instanceID).Err(err).Msg("stale lock takeover lost race; retrying")
+			m.logger.Info().Str("instance", m.instanceID).Err(err).Msg("stale lock takeover lost race; retrying")
 			continue
 		}
 
-		m.logger.Debug().
+		m.logger.Info().
 			Str("instance", m.instanceID).
 			Str("held_by", existing.InstanceID).
 			Time("lock_timestamp", existing.Timestamp).


### PR DESCRIPTION
Instead of blocking on incoming requests, just send an error to avoid the clients hanging for the duration of the migration.

Also fixes the rollback, when share creation fails during space creation and improves logging.
