### PR TITLE
Revert "Fall back to disk if ids aren't available from the cache"

### DIFF
--- a/pkg/storage/fs/posix/lookup/lookup.go
+++ b/pkg/storage/fs/posix/lookup/lookup.go
@@ -122,14 +122,6 @@ func (lu *Lookup) IDsForPath(ctx context.Context, path string) (string, string, 
 	// IDsForPath returns the space and opaque id for the given path
 	spaceID, nodeID, err := lu.IDCache.GetByPath(ctx, path)
 	if err != nil {
-		if _, ok := err.(errtypes.NotFound); !ok {
-			lu.log.Error().Err(err).Str("path", path).Msg("error looking up path in cache")
-		}
-		// fallback to disk
-		sID, nID, _, _, mErr := lu.metadataBackend.IdentifyPath(ctx, path)
-		if mErr == nil && nID != "" {
-			return sID, nID, nil
-		}
 		return "", "", err
 	}
 	return spaceID, nodeID, nil


### PR DESCRIPTION
Falling back to disk to retrieve the file ids can lead to undesirable side effects in other parts of the application which also rely on NATS to be available. Let's be honest and fail fast if NATS is unavailable instead.

This reverts commit 2de23a9ca218d25581d12e8a8ea4268d523e11a2.

Fixes opencloud-eu/opencloud#2793