### PR TITLE
Fix race condition

### DIFF
--- a/pkg/storage/fs/posix/ignore/ignore.go
+++ b/pkg/storage/fs/posix/ignore/ignore.go
@@ -42,6 +42,10 @@ func (i *Ignorer) IsIndex(path string) bool {
 	return strings.HasPrefix(path, filepath.Join(i.options.Root, "indexes"))
 }
 
+func (i *Ignorer) IsChanges(path string) bool {
+	return strings.HasPrefix(path, filepath.Join(i.options.Root, "changes"))
+}
+
 func (i *Ignorer) IsTemporary(path string) bool {
 	if filepath.IsAbs(path) {
 		tmpDirPattern := filepath.Join(i.options.Root, "*", "*", blobstore.TMPDir)
@@ -72,7 +76,7 @@ func (i *Ignorer) IsSpaceRoot(path string) bool {
 }
 
 func (i *Ignorer) IsInternal(path string) bool {
-	return i.IsIndex(path) || strings.Contains(path, lookup.MetadataDir) || i.IsTemporary(path)
+	return i.IsIndex(path) || strings.Contains(path, lookup.MetadataDir) || i.IsTemporary(path) || i.IsChanges(path)
 }
 
 func IsLockFile(path string) bool {

--- a/pkg/storage/fs/posix/lookup/lookup.go
+++ b/pkg/storage/fs/posix/lookup/lookup.go
@@ -432,7 +432,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, src, target me
 		return errors.New("lockpath does not match filepath")
 	}
 
-	attrs, err := lu.metadataBackend.All(ctx, src)
+	attrs, err := lu.metadataBackend.AllWithLockedSource(ctx, src, lockedSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/posix/posix.go
+++ b/pkg/storage/fs/posix/posix.go
@@ -100,6 +100,9 @@ func New(o *options.Options, stream events.Stream, cache, historyCache *idcache.
 	if o.IDCache.Store != "nats-js-kv" {
 		return nil, fmt.Errorf("the posix driver requires a nats-js-kv cache")
 	}
+	if o.FileMetadataCache.Store == "noop" {
+		return nil, fmt.Errorf("the posix driver requires a file metadata cache")
+	}
 
 	var err error
 	if log == nil {

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -183,6 +183,10 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 			"cache_store":    "nats-js-kv",
 			"cache_database": "ids-storage-users",
 		},
+		"filemetadata_cache": map[string]interface{}{
+			"cache_store":    "nats-js-kv",
+			"cache_database": "filemetadata-storage-users",
+		},
 	}
 	// make it possible to override single config values
 	maps.Copy(defaultConfig, config)

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -49,6 +49,10 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 )
 
+var (
+	_errSkipAlreadyKnown = errors.New("skip already known item")
+)
+
 type ScanDebouncer struct {
 	after      time.Duration
 	f          func(item scanItem)
@@ -168,8 +172,19 @@ func (t *Tree) workScanQueue() {
 
 				err := t.assimilate(item)
 				if err != nil {
+					if errors.Is(err, _errSkipAlreadyKnown) {
+						log.Trace().Err(err).Str("path", item.Path).Msg("skip already known item")
+						continue
+					}
 					log.Error().Err(err).Str("path", item.Path).Msg("failed to assimilate item")
 					continue
+				}
+
+				if item.RefreshParent {
+					err = t.WarmupIDCache(filepath.Dir(item.Path), true, true)
+					if err != nil {
+						log.Error().Err(err).Str("path", item.Path).Msg("failed to warmup id cache")
+					}
 				}
 
 				if item.Recurse {
@@ -195,17 +210,16 @@ func (t *Tree) Scan(path string, action watcher.EventAction, isDir bool) error {
 			//   -> scan parent directory recursively to update tree size and catch nodes that weren't covered by an event
 			AssimilationCounter.WithLabelValues(_labelFile, _labelAdded).Inc()
 			if !t.scanDebouncer.Pending(filepath.Dir(path)) {
+				// Use RefreshParent instead of scanning the parent recursively so that it can be skipped if
+				// the current state is already known (based on the mtime on disk vs. metadata)
 				t.scanDebouncer.Debounce(scanItem{
-					Path: path,
+					Path:          path,
+					RefreshParent: true,
 				})
 			}
 			if err := t.setDirty(filepath.Dir(path), true); err != nil {
 				t.log.Error().Err(err).Str("path", path).Bool("isDir", isDir).Msg("failed to mark directory as dirty")
 			}
-			t.scanDebouncer.Debounce(scanItem{
-				Path:    filepath.Dir(path),
-				Recurse: true,
-			})
 		} else {
 			// 2. New directory
 			//  -> scan directory
@@ -467,7 +481,7 @@ func (t *Tree) assimilate(item scanItem) error {
 		// compare metadata mtime with actual mtime. if it matches AND the path hasn't changed (move operation)
 		// we can skip the assimilation because the file was handled by us
 		if previousPath == item.Path && mtime.Equal(fi.ModTime()) {
-			return nil
+			return _errSkipAlreadyKnown
 		}
 
 		// was it moved or copied/restored with a clashing id?

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -753,6 +753,7 @@ assimilate:
 		n = node.New(spaceID, id, parentID, filepath.Base(path), fi.Size(), blobID, provider.ResourceType_RESOURCE_TYPE_FILE, nil, t.lookup)
 		n.SpaceRoot = &node.Node{
 			BaseNode: *node.NewBaseNode(spaceID, spaceID, t.lookup),
+			Exists:   true,
 		}
 
 		prevBlobSize, err := previousAttribs.Int64(prefixes.BlobsizeAttr)
@@ -765,7 +766,10 @@ assimilate:
 	}
 	attributes.SetTime(prefixes.MTimeAttr, fi.ModTime())
 
-	n.SpaceRoot = &node.Node{BaseNode: *node.NewBaseNode(spaceID, spaceID, t.lookup)}
+	n.SpaceRoot = &node.Node{
+		BaseNode: *node.NewBaseNode(spaceID, spaceID, t.lookup),
+		Exists:   true,
+	}
 
 	if !fi.IsDir() && t.options.EnableFSRevisions {
 		go func() {

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -923,15 +923,17 @@ func (t *Tree) WarmupIDCache(root string, assimilate, onlyDirty bool) error {
 				dir = filepath.Clean(filepath.Dir(dir))
 				sizes[dir] += info.Size()
 			}
-		} else if onlyDirty {
-			dirty, err := t.isDirty(path)
-			if err != nil {
-				return err
-			}
-			if !dirty {
-				return filepath.SkipDir
-			}
+		} else {
 			sizes[path] += 0 // Make sure to set the size to 0 for empty directories
+			if onlyDirty {
+				dirty, err := t.isDirty(path)
+				if err != nil {
+					return err
+				}
+				if !dirty {
+					return filepath.SkipDir
+				}
+			}
 		}
 
 		nodeSpaceID, id, _, _, err := t.lookup.MetadataBackend().IdentifyPath(context.Background(), path)

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -751,7 +751,9 @@ assimilate:
 		attributes.SetInt64(prefixes.BlobsizeAttr, fi.Size())
 		attributes.SetInt64(prefixes.TypeAttr, int64(provider.ResourceType_RESOURCE_TYPE_FILE))
 		n = node.New(spaceID, id, parentID, filepath.Base(path), fi.Size(), blobID, provider.ResourceType_RESOURCE_TYPE_FILE, nil, t.lookup)
-		n.SpaceRoot = &node.Node{BaseNode: node.BaseNode{SpaceID: spaceID, ID: spaceID}}
+		n.SpaceRoot = &node.Node{
+			BaseNode: *node.NewBaseNode(spaceID, spaceID, t.lookup),
+		}
 
 		prevBlobSize, err := previousAttribs.Int64(prefixes.BlobsizeAttr)
 		if err != nil || prevBlobSize < 0 {
@@ -763,7 +765,7 @@ assimilate:
 	}
 	attributes.SetTime(prefixes.MTimeAttr, fi.ModTime())
 
-	n.SpaceRoot = &node.Node{BaseNode: node.BaseNode{SpaceID: spaceID, ID: spaceID}}
+	n.SpaceRoot = &node.Node{BaseNode: *node.NewBaseNode(spaceID, spaceID, t.lookup)}
 
 	if !fi.IsDir() && t.options.EnableFSRevisions {
 		go func() {

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -451,7 +451,11 @@ func (t *Tree) assimilate(item scanItem) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to lock item for assimilation")
 		}
+		locked := true
 		defer func() {
+			if !locked {
+				return
+			}
 			_ = unlock()
 		}()
 
@@ -473,6 +477,11 @@ func (t *Tree) assimilate(item scanItem) error {
 				// this id clashes with an existing item -> clear metadata and re-assimilate
 				t.log.Debug().Str("path", item.Path).Msg("ID clash detected, purging metadata and re-assimilating")
 
+				err := unlock()
+				if err != nil {
+					t.log.Error().Err(err).Str("path", item.Path).Msg("could not unlock item for assimilation")
+				}
+				locked = false
 				if err := t.lookup.MetadataBackend().Purge(context.Background(), assimilationNode); err != nil {
 					t.log.Error().Err(err).Str("path", item.Path).Msg("could not purge metadata")
 				}
@@ -646,6 +655,8 @@ func (t *Tree) assimilate(item scanItem) error {
 	return nil
 }
 
+// updateFile updates the metadata of the given file and returns the new file info and attributes
+// The according file is supposed to be locked for assimilation already when calling this function
 func (t *Tree) updateFile(path, id, spaceID string, fi fs.FileInfo) (fs.FileInfo, node.Attributes, error) {
 	retries := 1
 	parentID := ""
@@ -690,7 +701,7 @@ assimilate:
 		}
 	}
 
-	attrs, err := t.lookup.MetadataBackend().All(context.Background(), bn)
+	attrs, err := t.lookup.MetadataBackend().AllWithLockedSource(context.Background(), bn, nil)
 	if err != nil && !metadata.IsAttrUnset(err) {
 		return nil, nil, errors.Wrap(err, "failed to get item attribs")
 	}

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -901,8 +901,7 @@ func (t *Tree) WarmupIDCache(root string, assimilate, onlyDirty bool) error {
 		if t.Ignorer.IsInternal(path) ||
 			ignore.IsLockFile(path) ||
 			ignore.IsTrash(path) ||
-			t.Ignorer.IsUpload(path) ||
-			t.Ignorer.IsIndex(path) {
+			t.Ignorer.IsUpload(path) {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -77,8 +77,9 @@ type IDResolver interface {
 }
 
 type scanItem struct {
-	Path    string
-	Recurse bool
+	Path          string
+	Recurse       bool
+	RefreshParent bool
 }
 
 // Tree manages a hierarchical tree

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -445,10 +445,12 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		_, subspan = tracer.Start(ctx, "propagate size changes")
 		err = t.Propagate(ctx, oldNode, -sizeDiff)
 		if err != nil {
+			// log error but continue anyway. The move itself was successful and the treesize will self-heal during the next fs scan
 			t.log.Error().Err(err).Str("path", oldNode.InternalPath()).Msg("could not propagate size changes for old node")
 		}
 		err = t.Propagate(ctx, newNode, sizeDiff)
 		if err != nil {
+			// log error but continue anyway. The move itself was successful and the treesize will self-heal during the next fs scan
 			t.log.Error().Err(err).Str("path", newNode.InternalPath()).Msg("could not propagate size changes for new node")
 		}
 		subspan.End()

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -423,38 +423,49 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 
 	subspan.End()
 
-	_, subspan = tracer.Start(ctx, "warmup id cache for moved subtree")
-	// update id cache for the moved subtree.
-	if oldNode.IsDir(ctx) {
-		err = t.WarmupIDCache(filepath.Join(newNode.ParentPath(), newNode.Name), false, false)
+	// A pure rename within the same parent must not change treesize accounting.
+	if oldNode.ParentID == newNode.ParentID {
+		err = t.Propagate(ctx, newNode, 0)
 		if err != nil {
-			return err
+			t.log.Error().Err(err).Str("path", newNode.InternalPath()).Msg("could not propagate size changes for renamed node")
 		}
-	}
-	subspan.End()
-
-	// the size diff is the current treesize or blobsize of the old/source node
-	var sizeDiff int64
-	if oldNode.IsDir(ctx) {
-		treeSize, err := oldNode.GetTreeSize(ctx)
-		if err != nil {
-			return err
-		}
-		sizeDiff = int64(treeSize)
 	} else {
-		sizeDiff = oldNode.Blobsize
+		// the size diff is the current treesize or blobsize of the old/source node
+		var sizeDiff int64
+		if oldNode.IsDir(ctx) {
+			treeSize, err := oldNode.GetTreeSize(ctx)
+			if err != nil {
+				return err
+			}
+			sizeDiff = int64(treeSize)
+		} else {
+			sizeDiff = oldNode.Blobsize
+		}
+
+		_, subspan = tracer.Start(ctx, "propagate size changes")
+		err = t.Propagate(ctx, oldNode, -sizeDiff)
+		if err != nil {
+			t.log.Error().Err(err).Str("path", oldNode.InternalPath()).Msg("could not propagate size changes for old node")
+		}
+		err = t.Propagate(ctx, newNode, sizeDiff)
+		if err != nil {
+			t.log.Error().Err(err).Str("path", newNode.InternalPath()).Msg("could not propagate size changes for new node")
+		}
+		subspan.End()
 	}
 
-	_, subspan = tracer.Start(ctx, "propagate size changes")
-	err = t.Propagate(ctx, oldNode, -sizeDiff)
-	if err != nil {
-		return errors.Wrap(err, "posixfs: Move: could not propagate old node")
-	}
-	err = t.Propagate(ctx, newNode, sizeDiff)
-	if err != nil {
-		return errors.Wrap(err, "posixfs: Move: could not propagate new node")
-	}
-	subspan.End()
+	go func() {
+		_, subspan = tracer.Start(ctx, "warmup id cache for moved subtree")
+		// update id cache for the moved subtree.
+		if oldNode.IsDir(ctx) {
+			err = t.WarmupIDCache(filepath.Join(newNode.ParentPath(), newNode.Name), false, false)
+			if err != nil {
+				t.log.Error().Err(err).Str("path", filepath.Join(newNode.ParentPath(), newNode.Name)).Msg("failed to warmup id cache for moved subtree")
+			}
+		}
+		subspan.End()
+	}()
+
 	return nil
 }
 

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -710,6 +710,20 @@ func (t *Tree) InitNewNode(ctx context.Context, n *node.Node, fsize uint64) (met
 		}
 		return unlock, err
 	}
+
+	// Set known mtime from filesystem to metadata to preven re-assimilation
+	fi, err := h.Stat()
+	if err != nil {
+		return nil, err
+	}
+	mtime := fi.ModTime()
+	err = n.SetXattrsWithContext(ctx, map[string][]byte{
+		prefixes.MTimeAttr: []byte(mtime.UTC().Format(time.RFC3339Nano)),
+	}, false)
+	if err != nil {
+		t.log.Error().Err(err).Str("path", n.InternalPath()).Msg("could not set mtime attribute on new node")
+	}
+
 	_ = h.Close()
 
 	if _, err := node.CheckQuota(ctx, n.SpaceRoot, false, 0, fsize); err != nil {

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -456,17 +456,17 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		subspan.End()
 	}
 
-	go func() {
-		_, subspan = tracer.Start(ctx, "warmup id cache for moved subtree")
-		// update id cache for the moved subtree.
-		if oldNode.IsDir(ctx) {
+	if oldNode.IsDir(ctx) {
+		go func() {
+			_, subspan = tracer.Start(ctx, "warmup id cache for moved subtree")
+			// update id cache for the moved subtree.
 			err = t.WarmupIDCache(filepath.Join(newNode.ParentPath(), newNode.Name), false, false)
 			if err != nil {
 				t.log.Error().Err(err).Str("path", filepath.Join(newNode.ParentPath(), newNode.Name)).Msg("failed to warmup id cache for moved subtree")
 			}
-		}
-		subspan.End()
-	}()
+			subspan.End()
+		}()
+	}
 
 	return nil
 }

--- a/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -351,7 +351,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, ta
 		return errors.New("lockpath does not match filepath")
 	}
 
-	attrs, err := lu.metadataBackend.All(ctx, sourceNode)
+	attrs, err := lu.metadataBackend.AllWithLockedSource(ctx, sourceNode, lockedSource)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -351,7 +351,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, ta
 		return errors.New("lockpath does not match filepath")
 	}
 
-	attrs, err := lu.metadataBackend.AllWithLockedSource(ctx, sourceNode, lockedSource)
+	attrs, err := lu.metadataBackend.All(ctx, sourceNode)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -107,47 +107,51 @@ func (b HybridBackend) GetInt64(ctx context.Context, n MetadataNode, key string)
 	return v, nil
 }
 
-func (b HybridBackend) list(ctx context.Context, n MetadataNode, acquireLock bool) (attribs []string, err error) {
+func (b HybridBackend) list(ctx context.Context, n MetadataNode) (attribs []string, err error) {
 	filePath := n.InternalPath()
 
 	if len(filePath) == 0 {
 		return nil, &xattr.Error{Op: "HybridBackend.list", Path: n.InternalPath(), Err: syscall.ENOENT} // attribute not found
 	}
 
-	attrs, err := xattr.List(filePath)
-	if err == nil {
-		return attrs, nil
-	}
-
-	// listing xattrs failed, try again, either with lock or without
-	if acquireLock {
-		unlock, err := b.Lock(n)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = unlock() }()
-
-	}
 	return xattr.List(filePath)
 }
 
 // All reads all extended attributes for a node, protected by a
 // shared file lock
 func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return b.getAll(ctx, n, false, false, true)
-}
-
-func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipCache, skipOffloaded, acquireLock bool) (map[string][]byte, error) {
 	attribs := map[string][]byte{}
 
-	if !skipCache {
-		err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
-		if err == nil {
-			return attribs, err
-		}
+	err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
+	if err == nil {
+		return attribs, err
 	}
 
-	attrNames, err := b.list(ctx, n, acquireLock)
+	unlock, err := b.Lock(n)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = unlock() }()
+
+	return b.getAll(ctx, n, false, false)
+}
+
+// AllWithLockedSource reads all extended attributes from the given reader.
+// The path argument is used for storing the data in the cache
+func (b HybridBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {
+	attribs := map[string][]byte{}
+
+	err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
+	if err == nil {
+		return attribs, err
+	}
+
+	return b.getAll(ctx, n, false, false)
+}
+
+func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipCache, skipOffloaded bool) (map[string][]byte, error) {
+	attribs := map[string][]byte{}
+	attrNames, err := b.list(ctx, n)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +247,7 @@ func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 				mdSize += len(attribs[key]) + len(key)
 			}
 		}
-		existingAttribs, err := b.getAll(ctx, n, true, true, false)
+		existingAttribs, err := b.getAll(ctx, n, true, true)
 		if err != nil {
 			return err
 		}
@@ -316,7 +320,7 @@ func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 	}
 
 	// Update the cache with the new values
-	_, err = b.getAll(ctx, n, true, false, false)
+	_, err = b.getAll(ctx, n, true, false)
 	return err
 }
 
@@ -327,7 +331,7 @@ func (b HybridBackend) offloadMetadata(ctx context.Context, n MetadataNode) erro
 	var xerr error
 
 	// collect attributes to move
-	existingAttribs, err := b.getAll(ctx, n, true, true, false)
+	existingAttribs, err := b.getAll(ctx, n, true, true)
 	if err != nil {
 		return err
 	}
@@ -440,7 +444,7 @@ func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, a
 	}
 
 	// Update the cache with the new values
-	_, err := b.getAll(ctx, n, true, false, false)
+	_, err := b.getAll(ctx, n, true, false)
 	return err
 }
 
@@ -452,7 +456,13 @@ func (b HybridBackend) Purge(ctx context.Context, n MetadataNode) error {
 	path := n.InternalPath()
 	_, err := os.Stat(path)
 	if err == nil {
-		attribs, err := b.getAll(ctx, n, true, false, true)
+		unlock, err := b.Lock(n)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = unlock() }()
+
+		attribs, err := b.getAll(ctx, n, true, false)
 		if err == nil {
 			for attr := range attribs {
 				if strings.HasPrefix(attr, prefixes.OcPrefix) {
@@ -515,12 +525,6 @@ func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
 	}, nil
-}
-
-// AllWithLockedSource reads all extended attributes from the given reader.
-// The path argument is used for storing the data in the cache
-func (b HybridBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {
-	return b.All(ctx, n)
 }
 
 func (b HybridBackend) cacheKey(n MetadataNode) string {

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -365,6 +365,7 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 
 	n, err := ReadNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck)
 	if err != nil {
+		_ = unlock()
 		return nil, nil, err
 	}
 	if !n.Exists {

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -351,6 +351,30 @@ func (n *Node) SpaceOwnerOrManager(ctx context.Context) *userpb.UserId {
 	return nil
 }
 
+func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, metadata.UnlockFunc, error) {
+	ctx, span := tracer.Start(ctx, "LockAndReadNode")
+	defer span.End()
+
+	_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
+	bn := NewBaseNode(spaceID, nodeID, lu)
+	unlock, err := lu.MetadataBackend().Lock(bn)
+	subspan.End()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n, err := ReadNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !n.Exists {
+		_ = unlock()
+		return n, nil, errtypes.NotFound(filepath.Join(n.ParentID, n.Name))
+	}
+
+	return n, unlock, nil
+}
+
 // ReadNode creates a new instance from an id and checks if it exists
 func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, error) {
 	ctx, span := tracer.Start(ctx, "ReadNode")

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -92,7 +92,6 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 	attrs := node.Attributes{}
 
 	// lock parent before reading treesize or tree time
-
 	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, n.SpaceID, n.ParentID, "", false, n.SpaceRoot, false)
 	if err != nil {
 		return nil, true, err
@@ -143,10 +142,21 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 
 	// size accounting
 	if p.treeSizeAccounting && sizeDiff != 0 {
-		var newSize uint64
+		var (
+			newSize  uint64
+			treeSize uint64
+		)
 
 		// read treesize
-		treeSize, err := n.GetTreeSize(ctx)
+		if n.ID == n.SpaceID {
+			allAttrs, readErr := p.lookup.MetadataBackend().All(ctx, n)
+			if readErr == nil {
+				treeSize, readErr = node.Attributes(allAttrs).UInt64(prefixes.TreesizeAttr)
+			}
+			err = readErr
+		} else {
+			treeSize, err = n.GetTreeSize(ctx)
+		}
 		switch {
 		case metadata.IsAttrUnset(err):
 			// fallback to calculating the treesize

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -149,6 +149,9 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 
 		// read treesize
 		if n.ID == n.SpaceID {
+			// Don't rely on node metadata for space root treesize. Space root nodes frequently get cached
+			// and passed around and might not be up to date
+			// Instead read all attributes directly from the backend and get the treesize from there.
 			allAttrs, readErr := p.lookup.MetadataBackend().All(ctx, n)
 			if readErr == nil {
 				treeSize, readErr = node.Attributes(allAttrs).UInt64(prefixes.TreesizeAttr)

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -93,23 +93,11 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 
 	// lock parent before reading treesize or tree time
 
-	_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
-	parentNode := node.NewBaseNode(n.SpaceID, n.ParentID, p.lookup)
-	unlock, err := p.lookup.MetadataBackend().Lock(parentNode)
-	subspan.End()
+	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, n.SpaceID, n.ParentID, "", false, n.SpaceRoot, false)
 	if err != nil {
-		log.Error().Err(err).
-			Str("parent filename", parentNode.InternalPath()).
-			Msg("Propagation failed. Could not open metadata for parent with lock.")
 		return nil, true, err
 	}
 	defer func() { _ = unlock() }()
-
-	if n, err = n.Parent(ctx); err != nil {
-		log.Error().Err(err).
-			Msg("Propagation failed. Could not read parent node.")
-		return n, true, err
-	}
 
 	if !n.HasPropagation(ctx) {
 		log.Debug().Str("attr", prefixes.PropagationAttr).Msg("propagation attribute not set or unreadable, not propagating")

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -316,14 +316,16 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 		_ = lockedNode.Close()
 	}()
 
-	isProcessing := revisionNode.IsProcessing(ctx)
-	var procssingID string
-	if isProcessing {
-		procssingID, _ = revisionNode.ProcessingID(ctx)
+	attribs, err := revisionNode.XattrsWithReader(ctx, lockedNode)
+	if err != nil {
+		return err
 	}
+	status := attribs.String(prefixes.StatusPrefix)
+	isProcessing := strings.HasPrefix(status, node.ProcessingStatus)
+	processingID := strings.TrimPrefix(status, node.ProcessingStatus)
 
 	// another upload on this node is in progress or has finished since we started
-	if !isProcessing || procssingID != session.ID() {
+	if !isProcessing || processingID != session.ID() {
 		versionID := revisionNode.ID + node.RevisionIDDelimiter + session.MTime().UTC().Format(time.RFC3339Nano)
 		// There should be a revision node (created by the other upload that finished before us), read it and upload our blob there.
 		existingRevisionNode, err := node.ReadNode(ctx, session.store.lu, session.SpaceID(), versionID, "", false, spaceRoot, false)

--- a/tests/oc-integration-tests/ci/storage-users-posix.toml
+++ b/tests/oc-integration-tests/ci/storage-users-posix.toml
@@ -32,7 +32,7 @@ generalspacepath_template = "projects/{{.SpaceId}}"
 watch_fs = true
 
 [grpc.services.storageprovider.drivers.posix.filemetadatacache]
-cache_store = "noop"
+cache_store = "memory"
 
 [grpc.services.storageprovider.drivers.posix.idcache]
 cache_store = "nats-js-kv"
@@ -59,4 +59,4 @@ cache_store = "nats-js-kv"
 cache_nodes = [ "nats:4222" ]
 
 [http.services.dataprovider.drivers.posix.filemetadatacache]
-cache_store = "noop"
+cache_store = "memory"


### PR DESCRIPTION
Acquire the metadata lock directly in `getAll()` instead of delegating it to
`list()`. This ensures the lock is held while reading all xattrs and pushing
to the cache, preventing a race condition where a concurrent `SetMultiple()`
could cause stale, partially-written metadata to overwrite the cache.

(hopefully) fixes opencloud-eu/opencloud#2821