### PR TITLE
fix(ocdav): create the file on LOCK of a non-existent path

### DIFF
--- a/internal/http/services/owncloud/ocdav/errors/error.go
+++ b/internal/http/services/owncloud/ocdav/errors/error.go
@@ -159,6 +159,8 @@ var (
 	ErrLocked = errors.New("webdav: locked")
 	// ErrNoSuchLock is returned by a LockSystem's Refresh and Unlock methods.
 	ErrNoSuchLock = errors.New("webdav: no such lock")
+	// ErrNotFound is returned when a resource does not exist.
+	ErrNotFound = errors.New("webdav: not found")
 	// ErrNotImplemented is returned when hitting not implemented code paths
 	ErrNotImplemented = errors.New("webdav: not implemented")
 	// ErrTokenNotFound is returned when a token is not found
@@ -206,6 +208,8 @@ func NewErrFromStatus(s *rpc.Status) error {
 		return ErrForbidden
 	case rpc.Code_CODE_LOCKED, rpc.Code_CODE_FAILED_PRECONDITION:
 		return ErrLocked
+	case rpc.Code_CODE_NOT_FOUND:
+		return ErrNotFound
 	case rpc.Code_CODE_UNIMPLEMENTED:
 		return ErrNotImplemented
 	default:

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -546,20 +546,26 @@ func (s *svc) lockReference(ctx context.Context, w http.ResponseWriter, r *http.
 		ld.OwnerXML = li.Owner.InnerXML // TODO optional, should be a URL
 		ld.ZeroDepth = depth == 0
 
-		//TODO: @jfd the code tries to create a lock for a file that may not even exist,
-		//      should we do that in the decomposedfs as well? the node does not exist
-		//      this actually is a name based lock ... ugh
 		token, err = s.LockSystem.Create(ctx, now, ld)
-
-		//
 		if err != nil {
 			switch {
-			case errors.Is(err, ocdavErrors.ErrLocked):
-				return http.StatusLocked, err
-			case errors.Is(err, ocdavErrors.ErrForbidden):
-				return http.StatusForbidden, err
+			case errors.Is(err, ocdavErrors.ErrNotFound):
+				// RFC 4918 section 7.3: a LOCK request on an unmapped URL
+				// creates an empty locked resource. Create the resource, then
+				// retry the lock against the now-existing node.
+				resourceCreated, status, cerr := s.createEmptyResource(ctx, ref)
+				if cerr != nil {
+					return status, cerr
+				}
+				// Report 201 only when the resource was actually created; a
+				// concurrent create leaves an existing resource to lock (200).
+				created = resourceCreated
+				if token, err = s.LockSystem.Create(ctx, now, ld); err != nil {
+					sublog.Error().Err(err).Msg("could not lock resource after creating it")
+					return lockCreateErrToStatus(err), err
+				}
 			default:
-				return http.StatusInternalServerError, err
+				return lockCreateErrToStatus(err), err
 			}
 		}
 
@@ -571,19 +577,9 @@ func (s *svc) lockReference(ctx context.Context, w http.ResponseWriter, r *http.
 			}
 		}()
 
-		// Create the resource if it didn't previously exist.
-		// TODO use sdk to stat?
-		/*
-			if _, err := s.FileSystem.Stat(ctx, reqPath); err != nil {
-				f, err := s.FileSystem.OpenFile(ctx, reqPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
-				if err != nil {
-					// TODO: detect missing intermediate dirs and return http.StatusConflict?
-					return http.StatusInternalServerError, err
-				}
-				f.Close()
-				created = true
-			}
-		*/
+		// The resource is created (if it did not previously exist) in the
+		// ErrNotFound branch above, mirroring sabre/dav per RFC 4918 section 7.3.
+
 		// http://www.webdav.org/specs/rfc4918.html#HEADER_Lock-Token says that the
 		// Lock-Token value is a Coded-URL. We add angle brackets.
 		w.Header().Set("Lock-Token", "<"+token+">")
@@ -601,6 +597,59 @@ func (s *svc) lockReference(ctx context.Context, w http.ResponseWriter, r *http.
 		sublog.Err(err).Int("bytes_written", n).Msg("error writing response")
 	}
 	return 0, nil
+}
+
+// lockCreateErrToStatus maps a LockSystem.Create error to the HTTP status the
+// LOCK handler returns. ErrNotFound is handled separately by the caller (it
+// creates the resource and retries), so it falls through to 500 here.
+func lockCreateErrToStatus(err error) int {
+	switch {
+	case errors.Is(err, ocdavErrors.ErrLocked):
+		return http.StatusLocked
+	case errors.Is(err, ocdavErrors.ErrForbidden):
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// createEmptyResource creates a 0-byte file at ref so that a LOCK on an
+// unmapped URL can succeed, as required by RFC 4918 section 7.3. It mirrors
+// the empty-file path of handlePut, which uses TouchFile for a zero-length
+// upload. The first return value reports whether the resource was actually
+// created (CODE_OK); on a concurrent create (CODE_ALREADY_EXISTS) it is false
+// so the caller locks the existing resource and returns 200 rather than 201.
+// On failure it returns an (http status, error) pair the LOCK handler can
+// return directly. Server-side failures (500) are logged, mirroring handlePut.
+func (s *svc) createEmptyResource(ctx context.Context, ref *provider.Reference) (bool, int, error) {
+	client, err := s.gatewaySelector.Next()
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Msg("error selecting next gateway client for lock")
+		return false, http.StatusInternalServerError, err
+	}
+
+	res, err := client.TouchFile(ctx, &provider.TouchFileRequest{Ref: ref})
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Interface("ref", ref).Msg("error sending grpc touch file request on lock")
+		return false, http.StatusInternalServerError, err
+	}
+
+	switch res.GetStatus().GetCode() {
+	case rpc.Code_CODE_OK:
+		return true, 0, nil
+	case rpc.Code_CODE_ALREADY_EXISTS:
+		// The resource appeared concurrently. Lock the existing one (200).
+		return false, 0, nil
+	case rpc.Code_CODE_NOT_FOUND:
+		// A missing intermediate collection. RFC 4918 section 9.10.6 maps this
+		// to 409 Conflict, not 500.
+		return false, http.StatusConflict, ocdavErrors.NewErrFromStatus(res.GetStatus())
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		return false, http.StatusForbidden, ocdavErrors.NewErrFromStatus(res.GetStatus())
+	default:
+		appctx.GetLogger(ctx).Error().Interface("status", res.GetStatus()).Interface("ref", ref).Msg("error touching file on lock")
+		return false, http.StatusInternalServerError, ocdavErrors.NewErrFromStatus(res.GetStatus())
+	}
 }
 
 func writeLockInfo(w io.Writer, token string, ld LockDetails) (int, error) {

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -600,6 +600,175 @@ var _ = Describe("ocdav", func() {
 
 		})
 
+		Describe("LOCK", func() {
+
+			const lockBody = `<?xml version="1.0" encoding="utf-8"?>
+<d:lockinfo xmlns:d="DAV:"><d:lockscope><d:exclusive/></d:lockscope><d:locktype><d:write/></d:locktype><d:owner><d:href>principal</d:href></d:owner></d:lockinfo>`
+
+			BeforeEach(func() {
+				rr = httptest.NewRecorder()
+			})
+
+			When("locking an existing resource", func() {
+				It("returns 200 OK with a lock token", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/existing.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewOK(ctx),
+					}, nil).Once()
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+					Expect(rr.Header().Get("Lock-Token")).ToNot(BeEmpty())
+					Expect(rr.Body.String()).To(ContainSubstring("<d:lockdiscovery>"))
+				})
+			})
+
+			When("locking a not-yet-existing resource", func() {
+				// RFC 4918 section 7.3: a LOCK on an unmapped URL creates an
+				// empty locked resource and returns 201 Created.
+				It("creates an empty resource and returns 201 Created", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/newfile.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					// the first lock attempt fails: the node does not exist yet
+					firstLock := client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+
+					// the handler creates the empty resource at the SAME reference
+					// the failed lock targeted ...
+					touch := client.On("TouchFile", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.TouchFileRequest) bool {
+						return utils.ResourceEqual(req.Ref, &cs3storageprovider.Reference{
+							ResourceId: userspace.Root,
+							Path:       "./newfile.txt",
+						})
+					})).Return(&cs3storageprovider.TouchFileResponse{
+						Status: status.NewOK(ctx),
+					}, nil).Once().NotBefore(firstLock)
+
+					// ... then retries the lock, which now succeeds
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewOK(ctx),
+					}, nil).Once().NotBefore(touch)
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusCreated))
+					Expect(rr.Header().Get("Lock-Token")).ToNot(BeEmpty())
+					Expect(rr.Body.String()).To(ContainSubstring("<d:lockdiscovery>"))
+					// the retry must have happened: SetLock called twice, TouchFile once
+					client.AssertNumberOfCalls(GinkgoT(), "SetLock", 2)
+					client.AssertNumberOfCalls(GinkgoT(), "TouchFile", 1)
+				})
+			})
+
+			When("the resource appears concurrently between the failed lock and the create", func() {
+				// TouchFile reports ALREADY_EXISTS: the resource was not created
+				// here, so the handler locks the existing one and returns 200, not 201.
+				It("returns 200 OK, not 201", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/raced.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					firstLock := client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+					touch := client.On("TouchFile", mock.Anything, mock.Anything).Return(&cs3storageprovider.TouchFileResponse{
+						Status: status.NewAlreadyExists(ctx, errors.New("already exists"), "already exists"),
+					}, nil).Once().NotBefore(firstLock)
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewOK(ctx),
+					}, nil).Once().NotBefore(touch)
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusOK))
+					Expect(rr.Header().Get("Lock-Token")).ToNot(BeEmpty())
+				})
+			})
+
+			When("the user may not create the resource", func() {
+				// createEmptyResource maps CODE_PERMISSION_DENIED to 403.
+				It("returns 403 Forbidden", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/forbidden.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+					client.On("TouchFile", mock.Anything, mock.Anything).Return(&cs3storageprovider.TouchFileResponse{
+						Status: status.NewPermissionDenied(ctx, errors.New("permission denied"), "permission denied"),
+					}, nil).Once()
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusForbidden))
+				})
+			})
+
+			When("the resource gets locked by someone else between create and retry", func() {
+				// TouchFile succeeds but the retried lock hits an existing lock.
+				It("returns 423 Locked", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/contended.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					firstLock := client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+					touch := client.On("TouchFile", mock.Anything, mock.Anything).Return(&cs3storageprovider.TouchFileResponse{
+						Status: status.NewOK(ctx),
+					}, nil).Once().NotBefore(firstLock)
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewLocked(ctx, "locked"),
+					}, nil).Once().NotBefore(touch)
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusLocked))
+				})
+			})
+
+			When("creating the resource fails on the storage", func() {
+				// A transport error on TouchFile maps to 500.
+				It("returns 500 Internal Server Error", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/broken.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+					client.On("TouchFile", mock.Anything, mock.Anything).Return(nil, errors.New("grpc transport error")).Once()
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusInternalServerError))
+				})
+			})
+
+			When("locking a not-yet-existing resource whose parent collection is missing", func() {
+				// RFC 4918 section 9.10.6: a missing intermediate collection
+				// maps to 409 Conflict, not 500.
+				It("returns 409 Conflict", func() {
+					req, err = http.NewRequest("LOCK", "/dav/spaces/provider-1$userspace!root/missing/newfile.txt", strings.NewReader(lockBody))
+					Expect(err).ToNot(HaveOccurred())
+					req = req.WithContext(ctx)
+
+					client.On("SetLock", mock.Anything, mock.Anything).Return(&cs3storageprovider.SetLockResponse{
+						Status: status.NewNotFound(ctx, "not found"),
+					}, nil).Once()
+					client.On("TouchFile", mock.Anything, mock.Anything).Return(&cs3storageprovider.TouchFileResponse{
+						Status: status.NewNotFound(ctx, "parent not found"),
+					}, nil).Once()
+
+					handler.Handler().ServeHTTP(rr, req)
+					Expect(rr).To(HaveHTTPStatus(http.StatusConflict))
+				})
+			})
+
+		})
+
 		Describe("MOVE", func() {
 
 			BeforeEach(func() {


### PR DESCRIPTION
## Description

A WebDAV `LOCK` on a path that does not exist yet returns `500 Internal Server Error` instead of creating an empty locked resource ([RFC 4918 section 7.3](https://www.rfc-editor.org/rfc/rfc4918#section-7.3)) and returning `201 Created` ([section 9.10.6](https://www.rfc-editor.org/rfc/rfc4918#section-9.10.6)).

Root cause: `NewErrFromStatus` has no `CODE_NOT_FOUND` case, so a `NotFound` from the storage provider reaches the LOCK handler as an untyped error and falls through the handler's error switch to `default -> 500`. The lock-null create path that section 7.3 requires existed only as a commented-out TODO, left over from the original locking work.

The fix has three parts:

1. `errors.NewErrFromStatus` maps `rpc.Code_CODE_NOT_FOUND` to a new `ErrNotFound` sentinel, so the handler can detect it.
2. The LOCK handler catches `ErrNotFound`, creates an empty resource, retries the lock against the now-existing node, and returns `201`. If the path already exists (a concurrent create), the handler locks the existing resource and returns `200` instead. sabre/dav (the library behind ownCloud 10 and Nextcloud) does the same: it catches `NotFound`, creates the file (RFC 4918 section 7.3), and returns `201`.
3. The empty resource is created with the gateway `TouchFile` RPC, the same call `handlePut` uses for a zero-length upload. A missing intermediate collection maps to `409 Conflict` ([RFC 4918 section 9.10.6](https://www.rfc-editor.org/rfc/rfc4918#section-9.10.6)) and a permission failure to `403`, instead of `500`. The handler logs server-side failures during the create, matching `handlePut`.

The fix sits in the ocdav layer, which keeps it storage-driver independent (both Decomposedfs and PosixFS benefit) and leaves `SetLock` unchanged. The alternative is to create the node inside `Decomposedfs.SetLock`, but that adds a side effect to the storage call and still has to report "created" back to ocdav for the `201`. The ocdav layer is the lower-risk of the two; the storage-layer variant is available if reviewers prefer it.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/2861

## Motivation and Context

Lock-before-write clients cannot create files. davfs2 with the default `use_locks 1` is the common case: a new file fails with `Input/output error`, while reading and editing existing files work. The root-cause trace and reproduction are in https://github.com/opencloud-eu/opencloud/issues/2861.

## How Has This Been Tested?

- test environment: reva `main`, Go 1.26, local
- `go build ./internal/http/services/owncloud/ocdav/...`
- `go vet ./internal/http/services/owncloud/ocdav/`
- `go test ./internal/http/services/owncloud/ocdav/...` (full suite passes)
- `golangci-lint run ./internal/http/services/owncloud/ocdav/...` (0 issues, v2.10.1)
- new specs (7): LOCK on an existing resource returns `200`; on a not-yet-existing resource returns `201` and creates it at the locked reference; on a concurrent create returns `200`; a missing parent collection returns `409`; a create the user may not perform returns `403`; the resource locked by another client during the retry returns `423`; a storage error during the create returns `500`
- end to end: a davfs2 mount with the default config can create files after the fix; before it, `touch newfile` fails with `Input/output error`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added (the behat suite has no lock-on-unmapped-URL scenario; this PR covers it at the unit level. A behat scenario can follow in the opencloud repo.)
- [ ] Documentation added (n/a — reva generates the changelog from the PR title + `Type:*` label via ready-release-go; no fragment needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
