### PR TITLE
fix(ocdav): encode oc:downloadURL path so filenames with "%" round-trip

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@
 - Thomas Boerger <thomas@webhippie.de>
 - Miroslav Bauer <bauer@cesnet.cz>
 - Daniel Mueller <daniel.mueller@uni-muenster.de>
+- Michael Stingl <mail@michaelstingl.com>

--- a/internal/http/services/owncloud/ocdav/propfind/downloadurl_internal_test.go
+++ b/internal/http/services/owncloud/ocdav/propfind/downloadurl_internal_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package propfind
+
+import (
+	"context"
+
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+)
+
+// Regression test for https://github.com/opencloud-eu/opencloud/issues/2852:
+// downloadURL must percent-encode the path so a filename with a literal "%"
+// or "#" round-trips. (Rationale at the call site in propfind.go.)
+var _ = Describe("downloadURL", func() {
+	// net.EncodePath runs before the branch switch and is shared by all
+	// branches. The public, non-password-protected branch is the deterministic
+	// observation point: it returns publicURL+baseURI+encodedPath without a
+	// signer. This is not a claim that public links are affected; the
+	// user-facing impact is on the signed personal/space URLs.
+	const (
+		publicURL = "https://cloud.example"
+		baseURI   = "/remote.php/dav/public-files/tok"
+	)
+
+	DescribeTable("percent-encodes reserved characters in the name",
+		func(path, wantTail string) {
+			got := downloadURL(context.Background(), zerolog.Nop(), true, path, &link.PublicShare{}, publicURL, baseURI, nil)
+			Expect(got).To(Equal(publicURL + baseURI + wantTail))
+		},
+		Entry("percent followed by hex digits in name", "/dir/firstword%20secondword.pdf", "/dir/firstword%2520secondword.pdf"),
+		Entry("percent not followed by hex in name", "/dir/50%off.pdf", "/dir/50%25off.pdf"),
+		Entry("hash in name", "/dir/a#b.pdf", "/dir/a%23b.pdf"),
+		Entry("plain space in name", "/dir/foo bar.pdf", "/dir/foo%20bar.pdf"),
+	)
+})

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1736,12 +1736,11 @@ func hasPreview(md *provider.ResourceInfo, appendToOK func(p ...prop.PropertyXML
 }
 
 func downloadURL(ctx context.Context, log zerolog.Logger, isPublic bool, path string, ls *link.PublicShare, publicURL string, baseURI string, urlSigner signedurl.Signer) string {
-	parts := strings.Split(path, "/")
-	encodedPath, err := url.JoinPath("/", parts...)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to encode the path for the download URL")
-		return ""
-	}
+	// Encode the path with net.EncodePath, the same encoder the resource href
+	// uses, so a filename with a literal "%" or "#" round-trips. url.JoinPath
+	// treats a literal "%" as an escape, so such names 404.
+	// See https://github.com/opencloud-eu/opencloud/issues/2852.
+	encodedPath := net.EncodePath(path)
 
 	switch {
 	case isPublic:


### PR DESCRIPTION
## Description

PROPFIND builds the `oc:downloadURL` property with `url.JoinPath`, which treats a literal `%` in a filename as an escape. A name like `firstword%20secondword.pdf` is read as `firstword secondword.pdf`, so the web "Download" button requests the wrong path and the download returns 404 from personal/space storage. The sibling `href` in the same response uses `net.EncodePath` and stays correct, so PROPFIND already emits a correct `href` next to an under-encoded `oc:downloadURL`.

The fix uses `net.EncodePath(path)`, the encoder the `href` already uses, in `downloadURL` (`internal/http/services/owncloud/ocdav/propfind/propfind.go`). `url.JoinPath` was introduced here to keep a literal `#` working (see https://github.com/opencloud-eu/reva/pull/415); `net.EncodePath` covers both `#` -> `%23` and `%` -> `%25`, so it keeps that behavior while letting names with reserved characters round-trip. The GET handler and the proxy are unchanged; only the URL this property emits was wrong.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/2852

## Motivation and Context

A file whose name contains a literal `%` cannot be downloaded from personal or space storage via the web UI, although it lists and opens normally. Public links are unaffected: the public-files handler resolves the file by share token and emits no `oc:downloadURL`.

## How Has This Been Tested?

- test environment: reva `main`, Go 1.26, local
- `go build`, `go vet`, `go test ./...propfind/...` and `.../net/...`, and the pinned `golangci-lint` v2.10.1 (`make lint`): all pass, 0 lint issues
- the fix, unit: new ginkgo `DescribeTable` for `downloadURL` asserts a literal `%` encodes to `%25` (whether or not followed by hex digits), `#` to `%23`, a plain space to `%20`
- the fix, over HTTP: on a local revad stack, patched vs unpatched, PROPFIND of a public link to a file named `firstword%20secondword.pdf` emits an `oc:downloadURL` ending `...firstword%2520secondword.pdf` with the fix and `...firstword%20secondword.pdf` without it

## Screenshots (if appropriate):

n/a. Server-side URL-encoding fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added (the behat suite has no download-of-a-name-with-reserved-characters scenario; this PR covers it at the unit level. A behat scenario can follow in the opencloud repo.)
- [ ] Documentation added (n/a — reva generates the changelog from the PR title + `Type:*` label via ready-release-go; no fragment needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
