### PR TITLE
fix(ocdav): return 400 with a body when a TUS upload creation has an invalid name

### DIFF
--- a/.woodpecker.env
+++ b/.woodpecker.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=a370bce5b934b51a299d18e17be3a203ae931f1e
+APITESTS_COMMITID=a3951098c6915e4579bbb4897edd590b66aca074
 APITESTS_BRANCH=main
 APITESTS_REPO_GIT_URL=https://github.com/opencloud-eu/opencloud

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -107,7 +107,9 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 	if err := ValidateName(filename(meta["filename"]), s.nameValidators); err != nil {
-		w.WriteHeader(http.StatusPreconditionFailed)
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, err.Error(), "", "")
+		errors.HandleWebdavError(&log, w, b, err)
 		return
 	}
 

--- a/internal/http/services/owncloud/ocdav/tus_internal_test.go
+++ b/internal/http/services/owncloud/ocdav/tus_internal_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package ocdav
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+
+	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/config"
+	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/net"
+)
+
+// Regression test for https://github.com/opencloud-eu/opencloud/issues/2803:
+// a TUS create whose Upload-Metadata filename fails name validation returns
+// 400 Bad Request with the validation error in the body, like the other write
+// handlers (PUT, MOVE, COPY, MKCOL), instead of a bare 412 with no body. Name
+// validation runs before the gateway is contacted, so the branch is exercised
+// without a backend.
+var _ = Describe("handleTusPost", func() {
+	var s *svc
+
+	BeforeEach(func() {
+		c := &config.Config{}
+		c.Init() // applies the default invalid_chars, which include the backslash
+		s = &svc{nameValidators: ValidatorsFromConfig(c)}
+	})
+
+	It("rejects an invalid name with 400 and the reason in the body", func() {
+		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		r.Header.Set(net.HeaderTusResumable, "1.0.0")
+		r.Header.Set(net.HeaderUploadLength, "8")
+		rec := httptest.NewRecorder()
+
+		meta := map[string]string{"filename": `IM\000024`}
+		s.handleTusPost(context.Background(), rec, r, meta, &provider.Reference{}, zerolog.Nop())
+
+		res := rec.Result()
+		defer res.Body.Close()
+		Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+
+		body, err := io.ReadAll(res.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(ContainSubstring("must not contain"))
+	})
+})


### PR DESCRIPTION
## Description

Align the TUS upload-creation handler (`tus.go`) with the other write handlers: on a name-validation failure, return `400 Bad Request` with the reason in the body instead of a bare `412`.

> [!WARNING]
> This changes a status the OpenCloud acceptance suite pins, so it needs a matching update to the OpenCloud acceptance tests; until then `api-integration` fails. The scenario [`coreApiWebdavUploadTUS/uploadFile.feature`](https://github.com/opencloud-eu/opencloud/blob/31340e30fbb6f71e4e67c7b1c76e0bcfbca243be/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature#L151) "upload a file with invalid-name" asserts `412`; moving it to `400` is the only change needed there, since its other checks (no `Location`, file not created) stay valid. The same applies to the missing-length scenario in [`lowLevelCreationExtension.feature`](https://github.com/opencloud-eu/opencloud/blob/31340e30fbb6f71e4e67c7b1c76e0bcfbca243be/tests/acceptance/features/coreApiWebdavUploadTUS/lowLevelCreationExtension.feature#L28) if that branch is aligned too.

## Related Issue

- Fixes https://github.com/opencloud-eu/reva/issues/654
- User-facing report: https://github.com/opencloud-eu/opencloud/issues/2803

## Motivation and Context

With a bare 412 and no body, clients cannot show the user why an upload was rejected. The linked issue has the details.

## How Has This Been Tested?

- `go build`, `go vet`, `go test -race` of the `ocdav` package, and the pinned `golangci-lint` v2.10.1 (`GOOS=linux GOARCH=amd64`): all pass, 0 lint issues
- unit: a new whitebox ginkgo spec drives `handleTusPost` with a backslash filename and asserts `400` plus the reason in the body; red on the unpatched handler (412), green with the fix
- over HTTP on a local revad stack, patched vs unpatched: the create returns `412` with an empty body unpatched and `400` with `name validation failed: must not contain \` patched, while a clean name returns `201` in both

## Screenshots (if appropriate):

n/a. Server-side status and response-body change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added (the existing [`coreApiWebdavUploadTUS/uploadFile.feature`](https://github.com/opencloud-eu/opencloud/blob/31340e30fbb6f71e4e67c7b1c76e0bcfbca243be/tests/acceptance/features/coreApiWebdavUploadTUS/uploadFile.feature#L151) scenario pins the old `412` and needs a matching update in OpenCloud to move it to `400`)
- [ ] Documentation added (n/a — reva generates the changelog from the PR title + `Type:*` label via ready-release-go; no fragment needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
