### PR TITLE
🎉 Release 2.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.46.2](https://github.com/opencloud-eu/reva/releases/tag/v2.46.2) - 2026-06-02
+
+### ❤️ Thanks to all contributors! ❤️
+
+@dragonchaser
+
+
+
 ## [2.46.1](https://github.com/opencloud-eu/reva/releases/tag/v2.46.1) - 2026-06-01
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.46.2` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.46.2](https://github.com/opencloud-eu/reva/releases/tag/v2.46.2) - 2026-06-02

