### PR TITLE
feat(archiver): name the archive after the resource

### DIFF
--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
+	"strings"
 	"time"
 
 	"regexp"
@@ -34,6 +36,7 @@ import (
 	"github.com/gdexlab/go-render/render"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/opencloud-eu/reva/v2/internal/http/services/archiver/manager"
+	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp"
@@ -200,6 +203,56 @@ func (s *svc) allAllowed(paths []string) error {
 }
 */
 
+// resourceName resolves the name of a single resource so the archive can be named after it instead
+// of the generic "download". It returns an empty string on any failure, so the caller keeps the
+// default name. The name is sanitized via sanitizeArchiveName.
+func (s *svc) resourceName(ctx context.Context, id *provider.ResourceId) string {
+	gatewayClient, err := s.gatewaySelector.Next()
+	if err != nil {
+		s.log.Debug().Err(err).Msg("archiver: could not select gateway to resolve the archive name, using the default")
+		return ""
+	}
+
+	res, err := gatewayClient.Stat(ctx, &provider.StatRequest{
+		Ref: &provider.Reference{ResourceId: id},
+	})
+	if err != nil {
+		s.log.Debug().Err(err).Msg("archiver: stat failed while resolving the archive name, using the default")
+		return ""
+	}
+	if code := res.GetStatus().GetCode(); code != rpc.Code_CODE_OK {
+		s.log.Debug().Str("code", code.String()).Msg("archiver: stat returned non-OK while resolving the archive name, using the default")
+		return ""
+	}
+
+	name := res.GetInfo().GetName()
+	if name == "" {
+		name = path.Base(res.GetInfo().GetPath())
+	}
+	return sanitizeArchiveName(name)
+}
+
+// sanitizeArchiveName removes characters that would break the Content-Disposition header (CR, LF,
+// double quote) or let the name act as a path (slash, backslash), plus all control characters
+// (C0, DEL and C1). It returns an empty string if nothing usable is left.
+func sanitizeArchiveName(name string) string {
+	name = strings.Map(func(r rune) rune {
+		switch {
+		case r == '"', r == '\\', r == '/':
+			return -1
+		case r < 0x20 || (r >= 0x7f && r <= 0x9f):
+			return -1
+		default:
+			return r
+		}
+	}, name)
+	name = strings.TrimSpace(name)
+	if name == "." || name == ".." {
+		return ""
+	}
+	return name
+}
+
 func (s *svc) writeHTTPError(rw http.ResponseWriter, err error) {
 	s.log.Error().Msg(err.Error())
 
@@ -251,7 +304,17 @@ func (s *svc) Handler() http.Handler {
 			return
 		}
 
+		// Name the archive after the resource when a single one was requested, instead of the
+		// generic "download". The name must be resolved here, before the body is streamed: the
+		// Content-Disposition header below is written before CreateZip/CreateTar run, so the name
+		// the walker resolves while building the archive would come too late.
+		// See https://github.com/opencloud-eu/reva/issues/308
 		archName := s.config.Name
+		if len(resources) == 1 {
+			if name := s.resourceName(ctx, resources[0]); name != "" {
+				archName = name
+			}
+		}
 		if format == "tar" {
 			archName += ".tar"
 		} else {
@@ -260,7 +323,7 @@ func (s *svc) Handler() http.Handler {
 
 		s.log.Debug().Msg("Requested the following resources to archive: " + render.Render(resources))
 
-		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", archName))
+		rw.Header().Set(net.HeaderContentDisposistion, net.ContentDispositionAttachment(archName))
 		rw.Header().Set("Content-Transfer-Encoding", "binary")
 
 		// create the archive

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -206,11 +206,11 @@ func (s *svc) allAllowed(paths []string) error {
 // resourceName resolves the name of a single resource so the archive can be named after it instead
 // of the generic "download". It returns an empty string on any failure, so the caller keeps the
 // default name. The name is sanitized via sanitizeArchiveName.
-func (s *svc) resourceName(ctx context.Context, id *provider.ResourceId) string {
+func (s *svc) resourceName(ctx context.Context, id *provider.ResourceId) (string, error) {
 	gatewayClient, err := s.gatewaySelector.Next()
 	if err != nil {
 		s.log.Debug().Err(err).Msg("archiver: could not select gateway to resolve the archive name, using the default")
-		return ""
+		return "", err
 	}
 
 	res, err := gatewayClient.Stat(ctx, &provider.StatRequest{
@@ -218,18 +218,18 @@ func (s *svc) resourceName(ctx context.Context, id *provider.ResourceId) string 
 	})
 	if err != nil {
 		s.log.Debug().Err(err).Msg("archiver: stat failed while resolving the archive name, using the default")
-		return ""
+		return "", err
 	}
 	if code := res.GetStatus().GetCode(); code != rpc.Code_CODE_OK {
 		s.log.Debug().Str("code", code.String()).Msg("archiver: stat returned non-OK while resolving the archive name, using the default")
-		return ""
+		return "", fmt.Errorf("stat returned non-OK code %s", code.String())
 	}
 
 	name := res.GetInfo().GetName()
 	if name == "" {
 		name = path.Base(res.GetInfo().GetPath())
 	}
-	return sanitizeArchiveName(name)
+	return sanitizeArchiveName(name), nil
 }
 
 // sanitizeArchiveName removes characters that would break the Content-Disposition header (CR, LF,
@@ -311,8 +311,11 @@ func (s *svc) Handler() http.Handler {
 		// See https://github.com/opencloud-eu/reva/issues/308
 		archName := s.config.Name
 		if len(resources) == 1 {
-			if name := s.resourceName(ctx, resources[0]); name != "" {
+			if name, err := s.resourceName(ctx, resources[0]); name != "" && err == nil {
 				archName = name
+			} else {
+				s.log.Debug().Err(err).Msg("could not resolve the archive name, using the default")
+				archName = "download"
 			}
 		}
 		if format == "tar" {

--- a/internal/http/services/archiver/handler_internal_test.go
+++ b/internal/http/services/archiver/handler_internal_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package archiver
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/net"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	cs3mocks "github.com/opencloud-eu/reva/v2/tests/cs3mocks/mocks"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSanitizeArchiveName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "Documents", "Documents"},
+		{"spaces and umlauts kept", "Pröbe Ördner 308", "Pröbe Ördner 308"},
+		{"double quote removed", `a"b`, "ab"},
+		{"slashes removed", "a/b\\c", "abc"},
+		{"crlf removed", "line\r\nbreak", "linebreak"},
+		{"control chars removed", "a\x00\x07b", "ab"},
+		{"del removed (0x7f, lower bound of the c1 strip)", "a\x7fb", "ab"},
+		{"surrounding space trimmed", "  spaced  ", "spaced"},
+		{"dot only", ".", ""},
+		{"dotdot only", "..", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeArchiveName(tc.in); got != tc.want {
+				t.Errorf("sanitizeArchiveName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeSelector is a minimal pool.Selectable returning a fixed gateway client (or error),
+// so resourceName can be tested without the real gateway pool.
+type fakeSelector struct {
+	client gateway.GatewayAPIClient
+	err    error
+}
+
+func (f fakeSelector) Next(_ ...pool.Option) (gateway.GatewayAPIClient, error) {
+	return f.client, f.err
+}
+
+func TestResourceName(t *testing.T) {
+	ok := func(info *provider.ResourceInfo) *provider.StatResponse {
+		return &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_OK}, Info: info}
+	}
+
+	cases := []struct {
+		name    string
+		resp    *provider.StatResponse
+		statErr error
+		selErr  error
+		want    string
+	}{
+		{name: "ok uses name", resp: ok(&provider.ResourceInfo{Name: "Documents"}), want: "Documents"},
+		{name: "empty name falls back to path base", resp: ok(&provider.ResourceInfo{Path: "/space/Reports"}), want: "Reports"},
+		{name: "name is sanitized", resp: ok(&provider.ResourceInfo{Name: `a"b/c`}), want: "abc"},
+		{name: "name sanitizing to empty keeps default", resp: ok(&provider.ResourceInfo{Name: "/"}), want: ""},
+		{name: "empty name and path keep default", resp: ok(&provider.ResourceInfo{}), want: ""},
+		{name: "stat error keeps default", statErr: errors.New("boom"), want: ""},
+		{name: "non-OK status keeps default", resp: &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, want: ""},
+		{name: "selector error keeps default", selErr: errors.New("no gateway"), want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := cs3mocks.NewGatewayAPIClient(t)
+			if tc.selErr == nil {
+				gw.EXPECT().Stat(mock.Anything, mock.Anything).Return(tc.resp, tc.statErr).Once()
+			}
+			log := zerolog.Nop()
+			s := &svc{gatewaySelector: fakeSelector{client: gw, err: tc.selErr}, log: &log}
+
+			got := s.resourceName(context.Background(), &provider.ResourceId{OpaqueId: "x"})
+			if got != tc.want {
+				t.Errorf("resourceName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestArchiveNameContentDisposition(t *testing.T) {
+	// A name with umlauts survives sanitization and still encodes correctly:
+	// net.ContentDispositionAttachment emits both the RFC 6266 filename* form and the raw filename.
+	got := net.ContentDispositionAttachment(sanitizeArchiveName("Pröbe Ördner 308"))
+	if !strings.Contains(got, "filename*=UTF-8''") {
+		t.Errorf("expected RFC 6266 filename* form, got %q", got)
+	}
+	if !strings.Contains(got, `filename="Pröbe Ördner 308"`) {
+		t.Errorf("expected raw filename, got %q", got)
+	}
+}

--- a/internal/http/services/archiver/handler_internal_test.go
+++ b/internal/http/services/archiver/handler_internal_test.go
@@ -69,15 +69,16 @@ func TestResourceName(t *testing.T) {
 		statErr error
 		selErr  error
 		want    string
+		wantErr bool
 	}{
 		{name: "ok uses name", resp: ok(&provider.ResourceInfo{Name: "Documents"}), want: "Documents"},
 		{name: "empty name falls back to path base", resp: ok(&provider.ResourceInfo{Path: "/space/Reports"}), want: "Reports"},
 		{name: "name is sanitized", resp: ok(&provider.ResourceInfo{Name: `a"b/c`}), want: "abc"},
 		{name: "name sanitizing to empty keeps default", resp: ok(&provider.ResourceInfo{Name: "/"}), want: ""},
 		{name: "empty name and path keep default", resp: ok(&provider.ResourceInfo{}), want: ""},
-		{name: "stat error keeps default", statErr: errors.New("boom"), want: ""},
-		{name: "non-OK status keeps default", resp: &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, want: ""},
-		{name: "selector error keeps default", selErr: errors.New("no gateway"), want: ""},
+		{name: "stat error returns error", statErr: errors.New("boom"), wantErr: true},
+		{name: "non-OK status keeps default", resp: &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, want: "", wantErr: true},
+		{name: "selector error keeps default", selErr: errors.New("no gateway"), want: "", wantErr: true},
 	}
 
 	for _, tc := range cases {
@@ -89,7 +90,13 @@ func TestResourceName(t *testing.T) {
 			log := zerolog.Nop()
 			s := &svc{gatewaySelector: fakeSelector{client: gw, err: tc.selErr}, log: &log}
 
-			got := s.resourceName(context.Background(), &provider.ResourceId{OpaqueId: "x"})
+			got, err := s.resourceName(context.Background(), &provider.ResourceId{OpaqueId: "x"})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
 			if got != tc.want {
 				t.Errorf("resourceName() = %q, want %q", got, tc.want)
 			}


### PR DESCRIPTION
## Description

When an archive download targets a single resource, the handler resolves that resource's name, sanitizes it, and sets `Content-Disposition` with `net.ContentDispositionAttachment`, the same RFC 6266 `filename*` helper the single-file download uses, so the archive is named after the resource instead of the constant `download.zip` / `download.tar`. Multiple resources, or any failure to resolve the name, keep the `download` default.

The name is resolved in the handler, before the body is streamed: the `Content-Disposition` header is written before `CreateZip` / `CreateTar` build the archive, while the walker only resolves the root name during streaming, too late for the header. It is sanitized first (control characters, quotes and path separators removed), so a folder name cannot break the header or act as a path.

## Related Issue

- Fixes https://github.com/opencloud-eu/reva/issues/308

## Motivation and Context

All access contexts (personal space, project space, user share, public link) reach the same `/archiver` handler, so one server-side change covers them, and the web client takes the filename from `Content-Disposition`, so no web change is needed.

## How Has This Been Tested?

- test environment: reva `main` (rebased onto current main), Go, local; plus the OpenCloud single binary with a `go mod replace` to this branch
- `gofmt`, `go vet`, `go test -race ./internal/http/services/archiver/...`, and the pinned `golangci-lint` v2.10.1: all pass, 0 lint issues
- unit: `TestSanitizeArchiveName` (quotes, slashes, CR/LF, C0/DEL/C1 controls, dot/dotdot, umlauts kept), `TestResourceName` (name, path-base fallback, sanitize, sanitize-to-empty, stat error, non-OK status and selector error all fall back to the default), and `TestArchiveNameContentDisposition` (a name with umlauts encodes to both the RFC 6266 `filename*` and the raw `filename`)
- over HTTP (patched OpenCloud single binary): the `Content-Disposition` filename matches the folder for a personal-space folder (zip and tar), a multi-select download keeps `download.zip`, and a password-protected public link (a different principal) is named after the folder with the umlauts encoded per RFC 6266
- not covered locally: the behat archiver suite runs only after a maintainer approves the fork CI run; the local proof is the unit tests plus the patched-binary header checks above

## Screenshots (if appropriate):

n/a. Server-side `Content-Disposition` change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added (the behat suite has no archiver-filename scenario; this PR covers the logic at the unit level plus a patched-binary header check. A behat scenario can follow in the opencloud repo.)
- [ ] Documentation added (n/a: reva generates the changelog from the PR title + `Type:*` label via ready-release-go, no fragment needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
