### PR TITLE
Improve apptoken jsoncs3 update behavior

### DIFF
--- a/pkg/appauth/manager/jsoncs3/jsoncs3.go
+++ b/pkg/appauth/manager/jsoncs3/jsoncs3.go
@@ -2,9 +2,7 @@ package jsoncs3
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -21,12 +19,14 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/metadatacache"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-diceware/diceware"
 	"github.com/sethvargo/go-password/password"
 	"go.opentelemetry.io/otel/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 type PasswordGenerator interface {
@@ -40,9 +40,9 @@ func init() {
 type manager struct {
 	sync.RWMutex        // for lazy initialization
 	mds                 metadata.Storage
+	store               *metadatacache.Store[string, map[string]*apppb.AppPassword]
 	generator           PasswordGenerator
 	uTimeUpdateInterval time.Duration
-	updateRetryCount    int
 	initialized         bool
 }
 
@@ -58,8 +58,6 @@ type config struct {
 	UTimeUpdateInterval int `mapstructure:"utime_update_interval_seconds"`
 	UpdateRetryCount    int `mapstructure:"update_retry_count"`
 }
-
-type updaterFunc func(map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error)
 
 const tracerName = "jsoncs3"
 
@@ -127,11 +125,17 @@ func New(m map[string]any) (appauth.Manager, error) {
 }
 
 func NewWithOptions(mds metadata.Storage, generator PasswordGenerator, uTimeUpdateInterval time.Duration, updateRetries int) (*manager, error) {
+	store := metadatacache.New(metadatacache.Options[string, map[string]*apppb.AppPassword]{
+		Storage: mds,
+		Path:    func(userID string) string { return userID + ".json" },
+		Retries: updateRetries,
+		Init:    func() map[string]*apppb.AppPassword { return map[string]*apppb.AppPassword{} },
+	})
 	return &manager{
 		mds:                 mds,
+		store:               store,
 		generator:           generator,
 		uTimeUpdateInterval: uTimeUpdateInterval,
-		updateRetryCount:    updateRetries,
 	}, nil
 }
 
@@ -170,7 +174,7 @@ func (m *manager) GenerateAppPassword(ctx context.Context, scope map[string]*aut
 	cTime := &typespb.Timestamp{Seconds: uint64(time.Now().Unix())}
 
 	// For persisting we use the hashed password, since we don't
-	// want to store it in cleartext
+	// want to store it in cleartext.
 	appPass := &apppb.AppPassword{
 		Password:   tokenHashed,
 		TokenScope: scope,
@@ -183,21 +187,26 @@ func (m *manager) GenerateAppPassword(ctx context.Context, scope map[string]*aut
 
 	id := uuid.New().String()
 
-	err = m.updateWithRetry(ctx, m.updateRetryCount, true, userID, func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+	err = m.store.Update(ctx, userID.GetOpaqueId(), true, func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, bool, error) {
 		a[id] = appPass
-		return a, nil
+		return a, true, nil
 	})
-
 	if err != nil {
 		logger.Debug().Err(err).Msg("failed to store new app password")
 		return nil, err
 	}
 
-	// Here we need to resplace the hash with the cleartext password again since
-	// the requestor needs to know the cleartext value.
-	appPass.Password = token
-
-	return appPass, nil
+	// Return a fresh AppPassword with the cleartext token for the caller.
+	// Constructing from scratch avoids copying the proto struct (which contains a mutex).
+	return &apppb.AppPassword{
+		Password:   token,
+		TokenScope: scope,
+		Label:      label,
+		Expiration: expiration,
+		Ctime:      cTime,
+		Utime:      cTime,
+		User:       userID,
+	}, nil
 }
 
 // ListAppPasswords lists the application passwords created by a user.
@@ -216,23 +225,26 @@ func (m *manager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, e
 	} else {
 		return nil, errtypes.BadRequest("no user in context")
 	}
-	_, userAppPasswords, err := m.getUserAppPasswords(ctx, userID)
+
+	unlock := m.store.Lock(userID.GetOpaqueId())
+	defer unlock()
+
+	passwords, ok, err := m.store.Get(ctx, userID.GetOpaqueId())
 	if err != nil {
-		if _, ok := err.(errtypes.NotFound); ok {
-			return []*apppb.AppPassword{}, nil
-		}
-		log.Error().Err(err).Msg("getUserAppPasswords failed")
+		log.Error().Err(err).Msg("store.Get failed")
 		return nil, err
 	}
-
-	userAppPasswordSlice := make([]*apppb.AppPassword, 0, len(userAppPasswords))
-
-	for id, p := range userAppPasswords {
-		p.Password = id
-		userAppPasswordSlice = append(userAppPasswordSlice, p)
+	if !ok {
+		return []*apppb.AppPassword{}, nil
 	}
 
-	return userAppPasswordSlice, nil
+	result := make([]*apppb.AppPassword, 0, len(passwords))
+	for id, p := range passwords {
+		pw := proto.Clone(p).(*apppb.AppPassword)
+		pw.Password = id
+		result = append(result, pw)
+	}
+	return result, nil
 }
 
 // InvalidateAppPassword invalidates a generated password.
@@ -253,16 +265,16 @@ func (m *manager) InvalidateAppPassword(ctx context.Context, secretOrId string) 
 		return errtypes.BadRequest("no user in context")
 	}
 
-	updater := func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+	err := m.store.Update(ctx, userID.GetOpaqueId(), false, func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, bool, error) {
 		// Allow deleting a token using the ID inside the password property. This is needed because of
-		// some shortcomings of the CS3 APIs. On the API level tokens don't have IDs
+		// some shortcomings of the CS3 APIs. On the API level tokens don't have IDs;
 		// ListAppPasswords in this backend returns the ID as the password value.
 		if _, ok := a[secretOrId]; ok {
 			delete(a, secretOrId)
-			return a, nil
+			return a, true, nil
 		}
 
-		// Check if the supplied parameter matches any of the stored password tokens
+		// Check if the supplied parameter matches any of the stored password tokens.
 		for key, pw := range a {
 			ok, err := argon2id.ComparePasswordAndHash(secretOrId, pw.Password)
 			switch {
@@ -270,15 +282,13 @@ func (m *manager) InvalidateAppPassword(ctx context.Context, secretOrId string) 
 				log.Debug().Err(err).Msg("Error comparing password and hash")
 			case ok:
 				delete(a, key)
-				return a, nil
+				return a, true, nil
 			}
 		}
-		return a, errtypes.NotFound("password not found")
-	}
-
-	err := m.updateWithRetry(ctx, m.updateRetryCount, false, userID, updater)
+		return a, false, errtypes.NotFound("password not found")
+	})
 	if err != nil {
-		log.Error().Err(err).Msg("getUserAppPasswords failed")
+		log.Error().Err(err).Msg("store.Update failed")
 		return errtypes.NotFound("password not found")
 	}
 	return nil
@@ -295,13 +305,12 @@ func (m *manager) GetAppPassword(ctx context.Context, user *userpb.UserId, secre
 		return nil, err
 	}
 
-	errUpdateSkipped := errors.New("update skipped")
-
 	var (
 		matchedPw *apppb.AppPassword
 		matchedID string
 	)
-	updater := func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, error) {
+
+	err := m.store.Update(ctx, user.GetOpaqueId(), false, func(a map[string]*apppb.AppPassword) (map[string]*apppb.AppPassword, bool, error) {
 		matchedPw = nil
 		for id, pw := range a {
 			ok, err := argon2id.ComparePasswordAndHash(secret, pw.Password)
@@ -312,35 +321,31 @@ func (m *manager) GetAppPassword(ctx context.Context, user *userpb.UserId, secre
 				// password found
 				if pw.Expiration != nil && pw.Expiration.Seconds != 0 && uint64(time.Now().Unix()) > pw.Expiration.Seconds {
 					log.Debug().Str("AppPasswordId", id).Msg("password expired")
-					return nil, errtypes.NotFound("password not found")
+					return nil, false, errtypes.NotFound("password not found")
 				}
 
 				matchedPw = pw
 				matchedID = id
-				// password not expired
 				// Updating the Utime will cause an Upload for every single GetAppPassword request. We are limiting this to one
 				// update per 'uTimeUpdateInterval' (default 5 min) otherwise this backend will become unusable.
 				if time.Since(utils.TSToTime(pw.Utime)) > m.uTimeUpdateInterval {
 					a[id].Utime = utils.TSNow()
-					return a, nil
+					return a, true, nil
 				}
-				return a, errUpdateSkipped
+				return a, false, nil
 			}
 		}
+		return nil, false, errtypes.NotFound("password not found")
+	})
+	if err != nil {
 		return nil, errtypes.NotFound("password not found")
 	}
 
-	err := m.updateWithRetry(ctx, m.updateRetryCount, false, user, updater)
-	switch {
-	case err == nil:
-		fallthrough
-	case errors.Is(err, errUpdateSkipped):
-		// Don't return the hashed password, put the ID into the password field
-		matchedPw.Password = matchedID
-		return matchedPw, nil
-	}
-
-	return nil, errtypes.NotFound("password not found")
+	// Return a clone with the ID in the password field so the cached entry
+	// is not corrupted.
+	result := proto.Clone(matchedPw).(*apppb.AppPassword)
+	result.Password = matchedID
+	return result, nil
 }
 
 func (m *manager) initialize(ctx context.Context) error {
@@ -370,142 +375,6 @@ func (m *manager) initialize(ctx context.Context) error {
 	}
 	m.initialized = true
 	return nil
-}
-
-func (m *manager) updateWithRetry(ctx context.Context, retries int, createIfNotFound bool, userid *userpb.UserId, updater updaterFunc) error {
-	log := appctx.GetLogger(ctx)
-	_, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "initialize")
-	defer span.End()
-
-	retry := true
-	var (
-		etag             string
-		userAppPasswords map[string]*apppb.AppPassword
-		err              error
-	)
-
-	// retry for the specified number of times, then error out
-	for i := 0; i < retries && retry; i++ {
-		if i > 0 {
-			// if we're retrying, wait a bit before the next try
-			jitter := time.Duration(rand.Int63n(int64(100 * time.Millisecond)))
-			time.Sleep(jitter + 100*time.Millisecond)
-		}
-
-		etag, userAppPasswords, err = m.getUserAppPasswords(ctx, userid)
-		switch err.(type) {
-		case nil:
-			// empty
-		case errtypes.NotFound:
-			if createIfNotFound {
-				userAppPasswords = map[string]*apppb.AppPassword{}
-			} else {
-				log.Debug().Err(err).Msg("getUserAppPasswords failed (not found)")
-				span.RecordError(err)
-				span.SetStatus(codes.Error, "downloading app tokens failed")
-				return err
-			}
-		case errtypes.TooEarly:
-			// Ideally this should never happen as we disable asynchronous uploads for the metadata storage.
-			log.Debug().Err(err).Int("try", i).Msg("getUserAppPasswords failed (too early, retrying)")
-			retry = true
-			continue
-		default:
-			log.Debug().Err(err).Msg("getUserAppPasswords failed")
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "downloading app tokens failed")
-			return err
-		}
-
-		userAppPasswords, err = updater(userAppPasswords)
-		if err != nil {
-			return err
-		}
-
-		err = m.updateUserAppPassword(ctx, userid, userAppPasswords, etag)
-		switch err.(type) {
-		case nil:
-			retry = false
-		case errtypes.Aborted:
-			log.Debug().Err(err).Int("attempt", i).Msg("updateUserAppPassword failed (retrying)")
-			retry = true
-		default:
-			log.Debug().Err(err).Int("attempt", i).Msg("updateUserAppPassword failed (not retrying)")
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			return err
-		}
-	}
-	if retry {
-		log.Debug().Err(err).Msg("updateUserAppPassword failed")
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "updating app token failed")
-		return err
-	}
-	return nil
-}
-
-func (m *manager) updateUserAppPassword(ctx context.Context, userid *userpb.UserId, appPasswords map[string]*apppb.AppPassword, ifMatchEtag string) error {
-	log := appctx.GetLogger(ctx)
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "getUserAppPasswords")
-	jsonPath := userAppTokenJSONPath(userid)
-
-	pwBytes, err := json.Marshal(appPasswords)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return err
-	}
-
-	ur := metadata.UploadRequest{
-		Path:        jsonPath,
-		Content:     pwBytes,
-		IfMatchEtag: ifMatchEtag,
-	}
-
-	// If there is no etag, make sure to only upload if the file wasn't craeted yet
-	if ifMatchEtag == "" {
-		ur.IfNoneMatch = []string{"*"}
-	}
-	_, err = m.mds.Upload(ctx, ur)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		log.Debug().Err(err).Msg("failed to upload AppPasswword")
-		return err
-	}
-	return nil
-}
-
-func (m *manager) getUserAppPasswords(ctx context.Context, userid *userpb.UserId) (string, map[string]*apppb.AppPassword, error) {
-	log := appctx.GetLogger(ctx)
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "getUserAppPasswords")
-	jsonPath := userAppTokenJSONPath(userid)
-	dlreq := metadata.DownloadRequest{
-		Path: jsonPath,
-	}
-
-	var userAppPasswords = map[string]*apppb.AppPassword{}
-	dlres, err := m.mds.Download(ctx, dlreq)
-	switch err.(type) {
-	case nil:
-		err = json.Unmarshal(dlres.Content, &userAppPasswords)
-		if err != nil {
-			log.Error().Err(err).Msg("unmarshaling app tokens failed")
-			return "", nil, err
-		}
-	case errtypes.NotFound:
-		return "", nil, errtypes.NotFound("password not found")
-	default:
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "downloading app tokens failed")
-		return "", nil, err
-	}
-	return dlres.Etag, userAppPasswords, nil
-}
-
-func userAppTokenJSONPath(userID *userpb.UserId) string {
-	return userID.GetOpaqueId() + ".json"
 }
 
 type randomPassword struct {

--- a/pkg/metadatacache/store.go
+++ b/pkg/metadatacache/store.go
@@ -1,0 +1,328 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metadatacache provides a generic in-memory write-through cache
+// backed by a metadata.Storage.  Each key is protected by its own mutex so
+// concurrent updates to different keys never contend.  Persistence uses
+// etag-based Compare-And-Swap to detect cross-replica conflicts.
+package metadatacache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/opencloud-eu/reva/v2/pkg/appctx"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+const tracerName = "metadatacache"
+
+// entry holds the cached value and the etag last seen from storage.
+type entry[V any] struct {
+	value V
+	etag  string
+}
+
+// Options configures a Store.
+type Options[K comparable, V any] struct {
+	// Storage is the metadata backend (required).
+	Storage metadata.Storage
+
+	// Path maps a key to a storage path (required).
+	Path func(K) string
+
+	// Retries is the maximum number of attempts in Update before giving up.
+	// Defaults to 100 when zero.
+	Retries int
+
+	// Init returns a valid zero value for V.  Required when Update is called
+	// with createIfNotFound=true (e.g. to produce an initialised map rather
+	// than a nil map).
+	Init func() V
+}
+
+// Store is a generic in-memory write-through cache.  V must be
+// JSON-serialisable.  K must be comparable (map key) and must produce a
+// human-readable string via fmt.Sprint for log/trace attributes.
+type Store[K comparable, V any] struct {
+	opts    Options[K, V]
+	mu      sync.Map // K → *sync.Mutex  (per-key lock)
+	entries sync.Map // K → *entry[V]
+}
+
+// New returns a ready-to-use Store.
+func New[K comparable, V any](opts Options[K, V]) *Store[K, V] {
+	if opts.Retries <= 0 {
+		opts.Retries = 100
+	}
+	return &Store[K, V]{opts: opts}
+}
+
+// Lock acquires the per-key mutex and returns an unlock function.  The caller
+// must call the returned function exactly once (typically via defer).
+func (s *Store[K, V]) Lock(key K) func() {
+	v, _ := s.mu.LoadOrStore(key, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
+// IsCached reports whether key has a cached entry without consulting storage.
+// The caller must hold the per-key lock.
+func (s *Store[K, V]) IsCached(key K) bool {
+	_, ok := s.entries.Load(key)
+	return ok
+}
+
+// Get syncs from storage and returns the current value for key.
+// The caller must hold the per-key lock.
+// Returns (zero, false, nil) when the key does not exist in storage.
+func (s *Store[K, V]) Get(ctx context.Context, key K) (V, bool, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Get")
+	defer span.End()
+	span.SetAttributes(attribute.String("key", fmt.Sprint(key)))
+
+	if err := s.Sync(ctx, key); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		var zero V
+		return zero, false, err
+	}
+
+	if e, ok := s.entries.Load(key); ok {
+		span.SetStatus(codes.Ok, "")
+		return e.(*entry[V]).value, true, nil
+	}
+
+	span.SetStatus(codes.Ok, "not found")
+	var zero V
+	return zero, false, nil
+}
+
+// Set stores value for key in the in-memory cache without persisting to
+// storage.  The etag of the existing entry (if any) is preserved.
+// The caller must hold the per-key lock.
+func (s *Store[K, V]) Set(key K, v V) {
+	var etag string
+	if e, ok := s.entries.Load(key); ok {
+		etag = e.(*entry[V]).etag
+	}
+	s.entries.Store(key, &entry[V]{value: v, etag: etag})
+}
+
+// Sync downloads the current state of key from storage and updates the cache.
+// It is a no-op (returns nil) when the key does not exist in storage or when
+// the stored etag matches the cached etag (NotModified).
+// The caller must hold the per-key lock.
+func (s *Store[K, V]) Sync(ctx context.Context, key K) error {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Sync")
+	defer span.End()
+	span.SetAttributes(attribute.String("key", fmt.Sprint(key)))
+
+	var ifNoneMatch []string
+	if e, ok := s.entries.Load(key); ok {
+		ifNoneMatch = []string{e.(*entry[V]).etag}
+	}
+
+	dlres, err := s.opts.Storage.Download(ctx, metadata.DownloadRequest{
+		Path:        s.opts.Path(key),
+		IfNoneMatch: ifNoneMatch,
+	})
+	switch err.(type) {
+	case nil:
+		// fall through to unmarshal
+	case errtypes.NotFound:
+		span.SetStatus(codes.Ok, "not found")
+		return nil
+	case errtypes.NotModified:
+		span.SetStatus(codes.Ok, "not modified")
+		return nil
+	default:
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	var v V
+	if err := json.Unmarshal(dlres.Content, &v); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	s.entries.Store(key, &entry[V]{value: v, etag: dlres.Etag})
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
+// Persist writes the cached value for key to storage using etag-based CAS.
+// If the path's parent directory is non-trivial (not "." or "/"),
+// MakeDirIfNotExist is called first.
+// The caller must hold the per-key lock.
+func (s *Store[K, V]) Persist(ctx context.Context, key K) error {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Persist")
+	defer span.End()
+	span.SetAttributes(attribute.String("key", fmt.Sprint(key)))
+
+	e, ok := s.entries.Load(key)
+	if !ok {
+		span.SetStatus(codes.Ok, "nothing to persist")
+		return nil
+	}
+	ent := e.(*entry[V])
+
+	b, err := json.Marshal(ent.value)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	p := s.opts.Path(key)
+	if dir := path.Dir(p); dir != "." && dir != "/" {
+		if err := s.opts.Storage.MakeDirIfNotExist(ctx, dir); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	}
+
+	ur := metadata.UploadRequest{
+		Path:        p,
+		Content:     b,
+		IfMatchEtag: ent.etag,
+	}
+	if ent.etag == "" {
+		ur.IfNoneMatch = []string{"*"}
+	}
+
+	res, err := s.opts.Storage.Upload(ctx, ur)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	// Update the etag so subsequent operations use the latest value.
+	var newEtag string
+	if res != nil {
+		newEtag = res.Etag
+	}
+	s.entries.Store(key, &entry[V]{value: ent.value, etag: newEtag})
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
+// Update atomically reads, transforms, and (conditionally) persists the value
+// for key.  It acquires the per-key lock internally; callers must not hold it.
+//
+// fn receives the current value and returns (newValue, shouldPersist, error).
+// When shouldPersist is false the update is skipped entirely (useful for
+// read-modify-skip-write patterns like GetAppPassword's utime throttle).
+// When err is non-nil the update is abandoned immediately.
+//
+// createIfNotFound controls whether a missing key is initialised via
+// Options.Init (which must be set) or returned as errtypes.NotFound.
+//
+// Conflicts (Aborted, PreconditionFailed, AlreadyExists, TooEarly) are
+// retried up to Options.Retries times, re-syncing from storage before each
+// retry.
+func (s *Store[K, V]) Update(ctx context.Context, key K, createIfNotFound bool, fn func(V) (V, bool, error)) error {
+	log := appctx.GetLogger(ctx).With().
+		Str("hostname", os.Getenv("HOSTNAME")).
+		Str("key", fmt.Sprint(key)).Logger()
+
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Update")
+	defer span.End()
+	span.SetAttributes(attribute.String("key", fmt.Sprint(key)))
+
+	unlock := s.Lock(key)
+	defer unlock()
+
+	// Warm the cache on first access.
+	if !s.IsCached(key) {
+		if err := s.Sync(ctx, key); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < s.opts.Retries; attempt++ {
+		// Load the current value (or initialise if absent and allowed).
+		var v V
+		if e, ok := s.entries.Load(key); ok {
+			v = e.(*entry[V]).value
+		} else if createIfNotFound {
+			v = s.opts.Init()
+		} else {
+			span.SetStatus(codes.Error, "not found")
+			return errtypes.NotFound(fmt.Sprint(key))
+		}
+
+		newV, shouldPersist, err := fn(v)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+
+		if !shouldPersist {
+			span.SetStatus(codes.Ok, "persist skipped")
+			return nil
+		}
+
+		s.Set(key, newV)
+
+		lastErr = s.Persist(ctx, key)
+		switch lastErr.(type) {
+		case nil:
+			span.SetAttributes(attribute.Int("attempts", attempt+1))
+			span.SetStatus(codes.Ok, "")
+			return nil
+		case errtypes.Aborted:
+			log.Debug().Int("attempt", attempt).Msg("metadatacache: persist aborted (etag mismatch), retrying")
+		case errtypes.PreconditionFailed:
+			log.Debug().Int("attempt", attempt).Msg("metadatacache: persist precondition failed, retrying")
+		case errtypes.AlreadyExists:
+			log.Debug().Int("attempt", attempt).Msg("metadatacache: persist already exists, retrying")
+		case errtypes.TooEarly:
+			log.Debug().Int("attempt", attempt).Msg("metadatacache: persist too early (processing lock), retrying")
+		default:
+			span.RecordError(lastErr)
+			span.SetStatus(codes.Error, lastErr.Error())
+			return lastErr
+		}
+
+		// Re-sync before the next attempt (skip after the last attempt).
+		if attempt+1 < s.opts.Retries {
+			if syncErr := s.Sync(ctx, key); syncErr != nil {
+				span.RecordError(syncErr)
+				span.SetStatus(codes.Error, syncErr.Error())
+				return syncErr
+			}
+		}
+	}
+
+	span.RecordError(lastErr)
+	span.SetStatus(codes.Error, fmt.Sprintf("gave up after %d attempts: %s", s.opts.Retries, lastErr))
+	return fmt.Errorf("metadatacache: update of %v failed after %d attempts: %w", key, s.opts.Retries, lastErr)
+}

--- a/pkg/metadatacache/store_test.go
+++ b/pkg/metadatacache/store_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadatacache_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/opencloud-eu/reva/v2/pkg/metadatacache"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/metadata"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetadatacache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metadatacache Suite")
+}
+
+func newStoreOnDir(dir string) *metadatacache.Store[string, map[string]string] {
+	mds, err := metadata.NewDiskStorage(dir)
+	Expect(err).NotTo(HaveOccurred())
+	ctx := context.Background()
+	Expect(mds.Init(ctx, "test")).To(Succeed())
+	return metadatacache.New(metadatacache.Options[string, map[string]string]{
+		Storage: mds,
+		Path:    func(key string) string { return key + ".json" },
+		Init:    func() map[string]string { return map[string]string{} },
+	})
+}
+
+var _ = Describe("Store", func() {
+	var (
+		ctx   context.Context
+		dir   string
+		store *metadatacache.Store[string, map[string]string]
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		dir = GinkgoT().TempDir()
+		store = newStoreOnDir(dir)
+	})
+
+	Describe("Get", func() {
+		It("returns not-found for an absent key", func() {
+			unlock := store.Lock("alice")
+			defer unlock()
+			_, ok, err := store.Get(ctx, "alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("Update", func() {
+		It("creates an entry when createIfNotFound is true", func() {
+			err := store.Update(ctx, "alice", true, func(m map[string]string) (map[string]string, bool, error) {
+				m["k"] = "v"
+				return m, true, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			unlock := store.Lock("alice")
+			defer unlock()
+			val, ok, err := store.Get(ctx, "alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(val).To(HaveKeyWithValue("k", "v"))
+		})
+
+		It("returns NotFound when createIfNotFound is false and key is absent", func() {
+			err := store.Update(ctx, "bob", false, func(m map[string]string) (map[string]string, bool, error) {
+				return m, true, nil
+			})
+			Expect(err).To(BeAssignableToTypeOf(errtypes.NotFound("")))
+		})
+
+		It("does not persist when shouldPersist is false", func() {
+			// Seed a value first.
+			Expect(store.Update(ctx, "alice", true, func(m map[string]string) (map[string]string, bool, error) {
+				m["a"] = "1"
+				return m, true, nil
+			})).To(Succeed())
+
+			// Read-only update (shouldPersist=false).
+			var captured map[string]string
+			Expect(store.Update(ctx, "alice", false, func(m map[string]string) (map[string]string, bool, error) {
+				captured = m
+				return m, false, nil
+			})).To(Succeed())
+			Expect(captured).To(HaveKeyWithValue("a", "1"))
+		})
+
+		It("round-trips through Sync after Persist", func() {
+			Expect(store.Update(ctx, "alice", true, func(m map[string]string) (map[string]string, bool, error) {
+				m["hello"] = "world"
+				return m, true, nil
+			})).To(Succeed())
+
+			// Second store on the same directory simulates a fresh process.
+			store2 := newStoreOnDir(dir)
+			unlock := store2.Lock("alice")
+			defer unlock()
+			val, ok, err := store2.Get(ctx, "alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(val).To(HaveKeyWithValue("hello", "world"))
+		})
+
+		It("is safe under concurrent updates to the same key (race detector)", func() {
+			const goroutines = 20
+			var wg sync.WaitGroup
+			wg.Add(goroutines)
+			for i := 0; i < goroutines; i++ {
+				go func(n int) {
+					defer wg.Done()
+					_ = store.Update(ctx, "shared", true, func(m map[string]string) (map[string]string, bool, error) {
+						key := fmt.Sprintf("g%d", n)
+						m[key] = key
+						return m, true, nil
+					})
+				}(i)
+			}
+			wg.Wait()
+
+			unlock := store.Lock("shared")
+			defer unlock()
+			val, ok, err := store.Get(ctx, "shared")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(val).To(HaveLen(goroutines))
+		})
+
+		It("is safe under concurrent updates to different keys (race detector)", func() {
+			keys := []string{"alice", "bob", "carol", "dave"}
+			var wg sync.WaitGroup
+			wg.Add(len(keys))
+			for _, k := range keys {
+				go func(key string) {
+					defer wg.Done()
+					_ = store.Update(ctx, key, true, func(m map[string]string) (map[string]string, bool, error) {
+						m["x"] = key
+						return m, true, nil
+					})
+				}(k)
+			}
+			wg.Wait()
+		})
+	})
+})


### PR DESCRIPTION
This introduces a generic implementation of the write-through case implemented in the jsoncs3 share manager. As a first step that implementation is used by the apptoken manager to get rid of it's inefficient upload-retry loop.

This should avoid bugs like: https://github.com/opencloud-eu/opencloud/issues/2530

I am working on a separate PR that switches the various share-manager caches to the generic implementation. 