### PR TITLE
feat(tus): return etag and permissions after the last TUS chunk

### DIFF
--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -20,13 +20,17 @@ package tus
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
 	"regexp"
 	"runtime"
 
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -35,6 +39,8 @@ import (
 
 	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
+	"github.com/opencloud-eu/reva/v2/pkg/conversions"
+	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/events"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp/datatx"
@@ -108,6 +114,9 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		StoreComposer:         composer,
 		NotifyCompleteUploads: true,
 		Logger:                slog.New(tusdLogger{log: m.log}),
+		// Add the finalized resource's etag and permissions to the last chunk's response
+		// (see preFinishResponseCallback). https://github.com/opencloud-eu/opencloud/issues/2409
+		PreFinishResponseCallback: m.preFinishResponseCallback(fs),
 	}
 
 	if m.conf.CorsEnabled {
@@ -205,6 +214,83 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	}))
 
 	return h, nil
+}
+
+// preFinishResponseCallback returns the tusd callback that runs when an upload completes. Before the
+// final response is written, it looks up the finalized resource and attaches its etag and WebDAV
+// permissions to the response headers, so clients do not need a follow-up PROPFIND after the last
+// chunk. It mirrors the etag and permissions the ocdav gateway already produces for the
+// creation-with-upload path. It is best-effort: it logs any lookup failure and still completes the
+// upload (the client falls back to a PROPFIND).
+// https://github.com/opencloud-eu/opencloud/issues/2409
+func (m *manager) preFinishResponseCallback(fs storage.FS) func(tusd.HookEvent) (tusd.HTTPResponse, error) {
+	return func(hook tusd.HookEvent) (tusd.HTTPResponse, error) {
+		resp := tusd.HTTPResponse{Header: tusd.HTTPHeader{}}
+
+		info := hook.Upload
+		ref := &provider.Reference{ResourceId: &provider.ResourceId{
+			StorageId: info.MetaData["providerID"],
+			SpaceId:   info.Storage["SpaceRoot"],
+			OpaqueId:  info.Storage["NodeId"],
+		}}
+
+		// The data path is authenticated by the reva transfer token, which carries no user
+		// identity, so a plain GetMD would be permission-gated to NotFound. Restore the upload's
+		// executant into the context the same way the decomposedfs upload session does, so the
+		// stat resolves with the executant's permissions.
+		ctx := ctxpkg.ContextSetUser(hook.Context, executantFromUploadInfo(info))
+
+		ri, err := fs.GetMD(ctx, ref, nil, nil)
+		if err != nil || ri == nil {
+			// Most often the upload token expired during a long upload; the client recovers with a
+			// PROPFIND, so this is a warning, not an error.
+			appctx.GetLogger(ctx).Warn().Err(err).Msg("could not stat finished upload, not setting etag/permission headers")
+			return resp, nil
+		}
+
+		if ri.GetEtag() != "" {
+			resp.Header[net.HeaderOCETag] = ri.GetEtag()
+			resp.Header[net.HeaderETag] = ri.GetEtag()
+		}
+
+		// derive the WebDAV permissions the same way the ocdav gateway does for the creation-with-upload path
+		isPublic := false
+		if o := ri.GetOpaque(); o != nil && o.Map != nil {
+			if e := o.Map["link-share"]; e != nil && e.Decoder == "json" {
+				ls := &link.PublicShare{}
+				_ = json.Unmarshal(e.Value, ls)
+				isPublic = ls != nil
+			}
+		}
+		isShared := !net.IsCurrentUserOwnerOrManager(ctx, ri.GetOwner(), ri)
+		role := conversions.RoleFromResourcePermissions(ri.GetPermissionSet(), isPublic)
+		resp.Header[net.HeaderOCPermissions] = role.WebDAVPermissions(
+			ri.GetType() == provider.ResourceType_RESOURCE_TYPE_CONTAINER,
+			isShared,
+			false,
+			isPublic,
+		)
+
+		return resp, nil
+	}
+}
+
+// executantFromUploadInfo reconstructs the user that initiated the upload from the tus session
+// info. It mirrors the decomposedfs upload session's executantUser so the finalize stat can run
+// with the executant's identity. The storage writes these keys when the upload is created.
+func executantFromUploadInfo(info tusd.FileInfo) *userpb.User {
+	var o *typespb.Opaque
+	_ = json.Unmarshal([]byte(info.Storage["UserOpaque"]), &o)
+	return &userpb.User{
+		Id: &userpb.UserId{
+			Type:     userpb.UserType(userpb.UserType_value[info.Storage["UserType"]]),
+			Idp:      info.Storage["Idp"],
+			OpaqueId: info.Storage["UserId"],
+		},
+		Username:    info.Storage["UserName"],
+		DisplayName: info.Storage["UserDisplayName"],
+		Opaque:      o,
+	}
 }
 
 func setHeaders(fs storage.FS, w http.ResponseWriter, r *http.Request) {

--- a/pkg/rhttp/datatx/manager/tus/tus_internal_test.go
+++ b/pkg/rhttp/datatx/manager/tus/tus_internal_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package tus
+
+import (
+	"context"
+	"errors"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	tusd "github.com/tus/tusd/v2/pkg/handler"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/opencloud-eu/reva/v2/internal/http/services/owncloud/ocdav/net"
+	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/storage"
+)
+
+// fakeFS implements only GetMD; embedding storage.FS satisfies the rest of the
+// interface (those methods are never called by the callback under test). It records
+// the reference and the context user it was called with so the tests can assert how
+// the callback resolves and authenticates the stat.
+type fakeFS struct {
+	storage.FS
+	md         *provider.ResourceInfo
+	err        error
+	gotRef     *provider.Reference
+	gotUserID  string
+	gotUserIdp string
+}
+
+func (f *fakeFS) GetMD(ctx context.Context, ref *provider.Reference, _, _ []string) (*provider.ResourceInfo, error) {
+	f.gotRef = ref
+	if u, ok := ctxpkg.ContextGetUser(ctx); ok {
+		f.gotUserID = u.GetId().GetOpaqueId()
+		f.gotUserIdp = u.GetId().GetIdp()
+	}
+	return f.md, f.err
+}
+
+var _ = Describe("executantFromUploadInfo", func() {
+	It("maps the stored session keys onto a user", func() {
+		u := executantFromUploadInfo(tusd.FileInfo{Storage: map[string]string{
+			"UserType":        "USER_TYPE_PRIMARY",
+			"Idp":             "https://idp.example",
+			"UserId":          "opaque-123",
+			"UserName":        "alice",
+			"UserDisplayName": "Alice",
+		}})
+		Expect(u.GetId().GetOpaqueId()).To(Equal("opaque-123"))
+		Expect(u.GetId().GetIdp()).To(Equal("https://idp.example"))
+		Expect(u.GetId().GetType()).To(Equal(userpb.UserType_USER_TYPE_PRIMARY))
+		Expect(u.GetUsername()).To(Equal("alice"))
+		Expect(u.GetDisplayName()).To(Equal("Alice"))
+	})
+
+	It("does not panic on empty info and yields an invalid user type", func() {
+		u := executantFromUploadInfo(tusd.FileInfo{Storage: map[string]string{}})
+		Expect(u.GetId().GetType()).To(Equal(userpb.UserType_USER_TYPE_INVALID))
+		Expect(u.GetId().GetOpaqueId()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("preFinishResponseCallback", func() {
+	// the session keys the storage writes at upload-create time
+	hookFor := func() tusd.HookEvent {
+		return tusd.HookEvent{
+			Context: context.Background(),
+			Upload: tusd.FileInfo{
+				MetaData: map[string]string{"providerID": "provider-1"},
+				Storage: map[string]string{
+					"SpaceRoot": "space-1",
+					"NodeId":    "node-1",
+					"UserId":    "executant-1",
+					"Idp":       "https://idp.example",
+					"UserType":  "USER_TYPE_PRIMARY",
+				},
+			},
+		}
+	}
+
+	// a resource the executant may edit; owned by someone else unless overridden
+	editable := func(etag, ownerID string) *provider.ResourceInfo {
+		return &provider.ResourceInfo{
+			Etag:  etag,
+			Type:  provider.ResourceType_RESOURCE_TYPE_FILE,
+			Owner: &userpb.UserId{Idp: "https://idp.example", OpaqueId: ownerID},
+			PermissionSet: &provider.ResourcePermissions{
+				Stat: true, ListContainer: true, InitiateFileDownload: true,
+				InitiateFileUpload: true, Move: true, Delete: true,
+			},
+		}
+	}
+
+	It("stats the finalized node as the executant and sets etag and permissions", func() {
+		fs := &fakeFS{md: editable(`"abc123"`, "other-owner")}
+
+		resp, err := (&manager{}).preFinishResponseCallback(fs)(hookFor())
+
+		Expect(err).ToNot(HaveOccurred())
+		// the reference is reconstructed from the session keys
+		Expect(fs.gotRef.GetResourceId().GetStorageId()).To(Equal("provider-1"))
+		Expect(fs.gotRef.GetResourceId().GetSpaceId()).To(Equal("space-1"))
+		Expect(fs.gotRef.GetResourceId().GetOpaqueId()).To(Equal("node-1"))
+		// the stat runs with the executant's identity restored into the context
+		Expect(fs.gotUserID).To(Equal("executant-1"))
+		Expect(fs.gotUserIdp).To(Equal("https://idp.example"))
+		// etag mirrored into both headers
+		Expect(resp.Header[net.HeaderOCETag]).To(Equal(`"abc123"`))
+		Expect(resp.Header[net.HeaderETag]).To(Equal(`"abc123"`))
+		// not owned by the executant -> shared -> WebDAV permissions lead with S
+		Expect(resp.Header[net.HeaderOCPermissions]).To(HavePrefix("S"))
+	})
+
+	It("omits the shared marker when the executant owns the resource", func() {
+		fs := &fakeFS{md: editable(`"abc123"`, "executant-1")}
+
+		resp, err := (&manager{}).preFinishResponseCallback(fs)(hookFor())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Header[net.HeaderOCPermissions]).ToNot(BeEmpty())
+		Expect(resp.Header[net.HeaderOCPermissions]).ToNot(HavePrefix("S"))
+	})
+
+	It("is best-effort: no headers and no error when the stat fails", func() {
+		fs := &fakeFS{err: errors.New("not found")}
+
+		resp, err := (&manager{}).preFinishResponseCallback(fs)(hookFor())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderOCETag))
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderETag))
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderOCPermissions))
+	})
+
+	It("is best-effort: no headers and no error when the stat returns no resource", func() {
+		fs := &fakeFS{md: nil, err: nil}
+
+		resp, err := (&manager{}).preFinishResponseCallback(fs)(hookFor())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderOCPermissions))
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderOCETag))
+	})
+
+	It("omits the etag header when the resource has none", func() {
+		fs := &fakeFS{md: editable("", "other-owner")}
+
+		resp, err := (&manager{}).preFinishResponseCallback(fs)(hookFor())
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Header).ToNot(HaveKey(net.HeaderOCETag))
+		Expect(resp.Header).To(HaveKey(net.HeaderOCPermissions))
+	})
+})

--- a/pkg/rhttp/datatx/manager/tus/tus_suite_test.go
+++ b/pkg/rhttp/datatx/manager/tus/tus_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package tus
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tus Suite")
+}


### PR DESCRIPTION
<!-- Target: opencloud-eu/reva | head: michaelstingl:issue-2409-tus-finalize-etag | base: main
     Title: feat(tus): return etag and permissions after the last TUS chunk
     A human reviews and opens this PR (never the assistant).
     Maintainer applies the Type:Enhancement label so ready-release-go files the changelog entry. -->

## Description

The response to the finalizing PATCH of a chunked TUS upload carried only the file id, so a client had to issue a follow-up PROPFIND to learn the new etag, an extra round-trip per upload. The creation-with-upload path returns the etag and permissions directly: the ocdav gateway stats the resource and sets `OC-ETag`/`ETag`/`OC-Perm` (next to `OC-FileID`, `Last-Modified` and `Content-Type`) in its `finishUpload` branch. The chunked path finalizes with a PATCH at the dataprovider, where `setHeaders` set only `OC-FileID`.

This registers tusd's `PreFinishResponseCallback` in the dataprovider tus handler (`pkg/rhttp/datatx/manager/tus/tus.go`) to stat the finalized resource and attach `OC-ETag`/`ETag` and `OC-Perm`. The chunked finalize now returns the same etag and permissions as the creation-with-upload path, so the two upload paths behave consistently. The alignment is deliberately limited to those headers: `Last-Modified` and `Content-Type` are not mirrored (clients do not need them at finalize, and `Content-Type` on the `204` finalize would carry no body), and the finalize stays a `204`, not the gateway's `201`.

The data path is authenticated by the reva transfer token, which carries no user identity, so a plain `GetMD` is permission-gated to `NotFound`. The callback restores the upload's executant into the context before the stat, the same way the decomposedfs upload session does in `OcisSession.Context`. If you would prefer the etag be surfaced through a small storage interface instead of reconstructing the executant in the datatx layer, I am happy to reshape it.

The permission derivation mirrors the gateway's creation-with-upload block verbatim, so the two stay in lockstep. The lookup is best-effort: on a stat error or a nil resource it logs at warn and sets no headers, leaving the PROPFIND fallback intact rather than failing a completed upload.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/2409

## Motivation and Context

The desktop and Android clients already read the etag from the finalize response when present and PROPFIND otherwise, so the change is backward compatible: older servers keep working, updated ones drop the extra request. Both headers are set because the desktop fast-path needs the etag and the permissions together.

Under async postprocessing the etag at finalize is provisional, exactly as it already is for the creation-with-upload path. The existing `UploadReady` -> SSE `postprocessing-finished` flow and tree etag propagation communicate any later change to the client.

## How Has This Been Tested?

- test environment: reva `main`, built into a local opencloud single binary (`7.1.0+dev`) via a `go.mod` replace, Go 1.26
- `go build`, `gofmt`, and the pinned `golangci-lint` v2.10.1 on the changed package: 0 issues
- unit (ginkgo): `pkg/rhttp/datatx/manager/tus/tus_internal_test.go` (7 specs) covers `executantFromUploadInfo` (session-key mapping) and the callback with a fake `storage.FS` that records the reference and context user it was called with, asserting the reference is rebuilt from the session keys, the stat runs as the executant (whose identity flips the `isShared` marker), etag mirrored into both headers, best-effort no-op on stat error and on a nil resource, and etag omitted when absent
- the fix, over HTTP: chunked upload (POST create + 2 PATCHes) against the patched binary, inspecting the finalize PATCH headers. Before: only `OC-FileID`. After: `OC-ETag`/`ETag` (equal to the etag a follow-up PROPFIND returns) and `OC-Perm`, with `OC-FileID` unchanged
- confirmed identical with synchronous and `OC_ASYNC_UPLOADS=true`; the creation-with-upload path is unchanged
- the api-integration/behat TUS suite runs after a maintainer approves fork CI

## Screenshots (if appropriate):

n/a. Server-side response-header change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added (ginkgo, fake `storage.FS`; covers the callback success/best-effort/no-etag paths and the executant mapping)
- [ ] Acceptance tests added (the behat suite has no "etag present on chunked finalize" scenario; can follow in the opencloud repo)
- [ ] Documentation added (n/a: reva generates the changelog from the PR title + `Type:*` label via ready-release-go; no fragment needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
