### PR TITLE
Warmup space root id cache during start up already

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -198,14 +198,14 @@ func (t *Tree) warmupSpaceRootCache(options *options.Options) error {
 
 	var paths []string
 	personalEntries, err := os.ReadDir(personalRoot)
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return errors.Wrap(err, "could not read personal space root directory")
 	}
 	for _, entry := range personalEntries {
 		paths = append(paths, filepath.Join(personalRoot, entry.Name()))
 	}
 	projectEntries, err := os.ReadDir(projectRoot)
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return errors.Wrap(err, "could not read project space root directory")
 	}
 	for _, entry := range projectEntries {

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -54,6 +54,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/permissions"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/tree/propagator"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/usermapper"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/templates"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 )
 
@@ -176,12 +177,53 @@ func New(lu node.PathLookup, bs node.Blobstore, um usermapper.Mapper, trashbin *
 		go t.workScanQueue()
 	}
 	if o.ScanFS {
+		// warmup the cache for all space roots right away so clients and migrations don't get confused when starting with a cold cache
+		err := t.warmupSpaceRootCache(o)
+		if err != nil {
+			return nil, errors.Wrap(err, "error warming up space root cache")
+		}
+
+		// scan the whole tree asynchronously to pick up new nodes
 		go func() {
 			_ = t.WarmupIDCache(o.Root, true, false)
 		}()
 	}
 
 	return t, nil
+}
+
+func (t *Tree) warmupSpaceRootCache(options *options.Options) error {
+	personalRoot := filepath.Clean(filepath.Join(options.Root, templates.Base(options.PersonalSpacePathTemplate)))
+	projectRoot := filepath.Clean(filepath.Join(options.Root, templates.Base(options.GeneralSpacePathTemplate)))
+
+	var paths []string
+	personalEntries, err := os.ReadDir(personalRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not read personal space root directory")
+	}
+	for _, entry := range personalEntries {
+		paths = append(paths, filepath.Join(personalRoot, entry.Name()))
+	}
+	projectEntries, err := os.ReadDir(projectRoot)
+	if err != nil {
+		return errors.Wrap(err, "could not read project space root directory")
+	}
+	for _, entry := range projectEntries {
+		paths = append(paths, filepath.Join(projectRoot, entry.Name()))
+	}
+
+	for _, path := range paths {
+		spaceID, _, _, _, err := t.lookup.MetadataBackend().IdentifyPath(context.TODO(), path)
+		if err != nil {
+			t.log.Error().Err(err).Str("path", path).Msg("could not identify space root path")
+			continue
+		}
+		err = t.idCache.Set(context.TODO(), spaceID, spaceID, path)
+		if err != nil {
+			t.log.Error().Err(err).Str("spaceID", spaceID).Str("path", path).Msg("could not set space root id in cache")
+		}
+	}
+	return nil
 }
 
 func (t *Tree) checkStorage() error {

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -220,7 +220,7 @@ func (t *Tree) warmupSpaceRootCache(options *options.Options) error {
 		}
 		err = t.idCache.Set(context.TODO(), spaceID, spaceID, path)
 		if err != nil {
-			t.log.Error().Err(err).Str("spaceID", spaceID).Str("path", path).Msg("could not set space root id in cache")
+			return errors.Wrap(err, "could not cache space root path")
 		}
 	}
 	return nil


### PR DESCRIPTION
That prevents clients or migrations from getting confused by temporarily missing spaces.

Fixes opencloud-eu/opencloud#2907