### PR TITLE
chore: update go-cs3apis to latest (Jun 2026)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.1.7
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20260424072047-8d9ef7076ae9
+	github.com/cs3org/go-cs3apis v0.0.0-20260604164754-c3fdb0aa5e9e
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/emvi/iso-639-1 v1.1.1
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20260424072047-8d9ef7076ae9 h1:8WtMb7TKKx1AJM3j+uR+H25y4v+b8o8GIQg/2ooCyRo=
-github.com/cs3org/go-cs3apis v0.0.0-20260424072047-8d9ef7076ae9/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260604164754-c3fdb0aa5e9e h1:daOgm7xFqJi6LkKUBAENiHOy4IBVSlpculXLd1cPZWk=
+github.com/cs3org/go-cs3apis v0.0.0-20260604164754-c3fdb0aa5e9e/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/gateway/labels.go
+++ b/internal/grpc/services/gateway/labels.go
@@ -1,0 +1,61 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+
+	labels "github.com/cs3org/go-cs3apis/cs3/labels/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/status"
+	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	gstatus "google.golang.org/grpc/status"
+)
+
+func (s *svc) AddLabel(ctx context.Context, req *labels.AddLabelRequest) (*labels.AddLabelResponse, error) {
+	_, p, ref, err := s.findAndUnwrap(ctx, req.Ref)
+	if err != nil {
+		return &labels.AddLabelResponse{
+			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),
+		}, nil
+	}
+	req.Ref = ref
+
+	lc, err := s.getLabelsProviderClient(p.Address)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error getting labels client")
+	}
+	return lc.AddLabel(ctx, req)
+}
+
+func (s *svc) RemoveLabel(ctx context.Context, req *labels.RemoveLabelRequest) (*labels.RemoveLabelResponse, error) {
+	_, p, ref, err := s.findAndUnwrap(ctx, req.Ref)
+	if err != nil {
+		return &labels.RemoveLabelResponse{
+			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),
+		}, nil
+	}
+	req.Ref = ref
+
+	lc, err := s.getLabelsProviderClient(p.Address)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error getting labels client")
+	}
+	return lc.RemoveLabel(ctx, req)
+}
+
+func (s *svc) ListLabels(ctx context.Context, req *labels.ListLabelsRequest) (*labels.ListLabelsResponse, error) {
+	return nil, gstatus.Errorf(codes.Unimplemented, "ListLabels not yet implemented")
+}
+
+func (s *svc) ListResourcesForLabel(ctx context.Context, req *labels.ListResourcesForLabelRequest) (*labels.ListResourcesForLabelResponse, error) {
+	return nil, gstatus.Errorf(codes.Unimplemented, "ListResourcesForLabel not yet implemented")
+}
+
+func (s *svc) getLabelsProviderClient(address string) (labels.LabelsAPIClient, error) {
+	c, err := pool.GetLabelsProviderServiceClient(address)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -725,46 +725,6 @@ func (s *svc) CreateContainer(ctx context.Context, req *provider.CreateContainer
 	return res, nil
 }
 
-func (s *svc) AddLabel(ctx context.Context, req *provider.AddLabelRequest) (*provider.AddLabelResponse, error) {
-	var c provider.ProviderAPIClient
-	var err error
-	c, _, req.Ref, err = s.findAndUnwrap(ctx, req.Ref)
-	if err != nil {
-		return &provider.AddLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),
-		}, nil
-	}
-
-	res, err := c.AddLabel(ctx, req)
-	if err != nil {
-		return &provider.AddLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, "gateway could not call AddLabel", err),
-		}, nil
-	}
-
-	return res, nil
-}
-
-func (s *svc) RemoveLabel(ctx context.Context, req *provider.RemoveLabelRequest) (*provider.RemoveLabelResponse, error) {
-	var c provider.ProviderAPIClient
-	var err error
-	c, _, req.Ref, err = s.findAndUnwrap(ctx, req.Ref)
-	if err != nil {
-		return &provider.RemoveLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),
-		}, nil
-	}
-
-	res, err := c.RemoveLabel(ctx, req)
-	if err != nil {
-		return &provider.RemoveLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, "gateway could not call RemoveLabel", err),
-		}, nil
-	}
-
-	return res, nil
-}
-
 func (s *svc) TouchFile(ctx context.Context, req *provider.TouchFileRequest) (*provider.TouchFileResponse, error) {
 	var c provider.ProviderAPIClient
 	var err error

--- a/internal/grpc/services/gateway/storageprovidercache.go
+++ b/internal/grpc/services/gateway/storageprovidercache.go
@@ -264,9 +264,9 @@ func (c *cachedAPIClient) GetHome(ctx context.Context, in *provider.GetHomeReque
 func (c *cachedAPIClient) TouchFile(ctx context.Context, in *provider.TouchFileRequest, opts ...grpc.CallOption) (*provider.TouchFileResponse, error) {
 	return c.c.TouchFile(ctx, in, opts...)
 }
-func (c *cachedAPIClient) AddLabel(ctx context.Context, in *provider.AddLabelRequest, opts ...grpc.CallOption) (*provider.AddLabelResponse, error) {
-	return c.c.AddLabel(ctx, in, opts...)
+func (c *cachedAPIClient) SetImmutable(ctx context.Context, in *provider.SetImmutableRequest, opts ...grpc.CallOption) (*provider.SetImmutableResponse, error) {
+	return c.c.SetImmutable(ctx, in, opts...)
 }
-func (c *cachedAPIClient) RemoveLabel(ctx context.Context, in *provider.RemoveLabelRequest, opts ...grpc.CallOption) (*provider.RemoveLabelResponse, error) {
-	return c.c.RemoveLabel(ctx, in, opts...)
+func (c *cachedAPIClient) UnsetImmutable(ctx context.Context, in *provider.UnsetImmutableRequest, opts ...grpc.CallOption) (*provider.UnsetImmutableResponse, error) {
+	return c.c.UnsetImmutable(ctx, in, opts...)
 }

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -929,11 +929,11 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 
-func (s *service) AddLabel(ctx context.Context, req *provider.AddLabelRequest) (*provider.AddLabelResponse, error) {
+func (s *service) SetImmutable(ctx context.Context, req *provider.SetImmutableRequest) (*provider.SetImmutableResponse, error) {
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 
-func (s *service) RemoveLabel(ctx context.Context, req *provider.RemoveLabelRequest) (*provider.RemoveLabelResponse, error) {
+func (s *service) UnsetImmutable(ctx context.Context, req *provider.UnsetImmutableRequest) (*provider.UnsetImmutableResponse, error) {
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -1036,11 +1036,11 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 	}, nil
 }
 
-func (s *service) AddLabel(ctx context.Context, req *provider.AddLabelRequest) (*provider.AddLabelResponse, error) {
+func (s *service) SetImmutable(ctx context.Context, req *provider.SetImmutableRequest) (*provider.SetImmutableResponse, error) {
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 
-func (s *service) RemoveLabel(ctx context.Context, req *provider.RemoveLabelRequest) (*provider.RemoveLabelResponse, error) {
+func (s *service) UnsetImmutable(ctx context.Context, req *provider.UnsetImmutableRequest) (*provider.UnsetImmutableResponse, error) {
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	labels "github.com/cs3org/go-cs3apis/cs3/labels/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -119,6 +120,7 @@ func (s *Service) UnprotectedEndpoints() []string { return []string{} }
 func (s *Service) Register(ss *grpc.Server) {
 	provider.RegisterProviderAPIServer(ss, s)
 	provider.RegisterSpacesAPIServer(ss, s)
+	labels.RegisterLabelsAPIServer(ss, s)
 }
 
 func parseXSTypes(xsTypes map[string]uint32) ([]*provider.ResourceChecksumPriority, error) {
@@ -283,6 +285,54 @@ func (s *Service) Unlock(ctx context.Context, req *provider.UnlockRequest) (*pro
 
 	return &provider.UnlockResponse{
 		Status: status.NewStatusFromErrType(ctx, "unlock", err),
+	}, nil
+}
+
+func (s *Service) AddLabel(ctx context.Context, req *labels.AddLabelRequest) (*labels.AddLabelResponse, error) {
+	err := s.Storage.AddLabel(ctx, req.Ref, req.UserId, req.Label)
+	if err != nil {
+		return &labels.AddLabelResponse{
+			Status: status.NewStatusFromErrType(ctx, "add label", err),
+		}, nil
+	}
+	return &labels.AddLabelResponse{
+		Status: status.NewOK(ctx),
+	}, nil
+}
+
+func (s *Service) RemoveLabel(ctx context.Context, req *labels.RemoveLabelRequest) (*labels.RemoveLabelResponse, error) {
+	err := s.Storage.RemoveLabel(ctx, req.Ref, req.UserId, req.Label)
+	if err != nil {
+		return &labels.RemoveLabelResponse{
+			Status: status.NewStatusFromErrType(ctx, "remove label", err),
+		}, nil
+	}
+	return &labels.RemoveLabelResponse{
+		Status: status.NewOK(ctx),
+	}, nil
+}
+
+func (s *Service) ListLabels(ctx context.Context, req *labels.ListLabelsRequest) (*labels.ListLabelsResponse, error) {
+	return &labels.ListLabelsResponse{
+		Status: status.NewUnimplemented(ctx, nil, "ListLabels not yet implemented"),
+	}, nil
+}
+
+func (s *Service) ListResourcesForLabel(ctx context.Context, req *labels.ListResourcesForLabelRequest) (*labels.ListResourcesForLabelResponse, error) {
+	return &labels.ListResourcesForLabelResponse{
+		Status: status.NewUnimplemented(ctx, nil, "ListResourcesForLabel not yet implemented"),
+	}, nil
+}
+
+func (s *Service) SetImmutable(ctx context.Context, req *provider.SetImmutableRequest) (*provider.SetImmutableResponse, error) {
+	return &provider.SetImmutableResponse{
+		Status: status.NewUnimplemented(ctx, nil, "SetImmutable not yet implemented"),
+	}, nil
+}
+
+func (s *Service) UnsetImmutable(ctx context.Context, req *provider.UnsetImmutableRequest) (*provider.UnsetImmutableResponse, error) {
+	return &provider.UnsetImmutableResponse{
+		Status: status.NewUnimplemented(ctx, nil, "UnsetImmutable not yet implemented"),
 	}, nil
 }
 
@@ -709,36 +759,6 @@ func (s *Service) TouchFile(ctx context.Context, req *provider.TouchFileRequest)
 
 	return &provider.TouchFileResponse{
 		Status: status.NewStatusFromErrType(ctx, "touch file", err),
-	}, nil
-}
-
-func (s *Service) AddLabel(ctx context.Context, req *provider.AddLabelRequest) (*provider.AddLabelResponse, error) {
-	appctx.GetLogger(ctx).Debug().Msg("AddLabel")
-
-	err := s.Storage.AddLabel(ctx, req.Ref, req.UserId, req.Label)
-	if err != nil {
-		return &provider.AddLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, "add label", err),
-		}, nil
-	}
-
-	return &provider.AddLabelResponse{
-		Status: status.NewOK(ctx),
-	}, nil
-}
-
-func (s *Service) RemoveLabel(ctx context.Context, req *provider.RemoveLabelRequest) (*provider.RemoveLabelResponse, error) {
-	appctx.GetLogger(ctx).Debug().Msg("RemoveLabel")
-
-	err := s.Storage.RemoveLabel(ctx, req.Ref, req.UserId, req.Label)
-	if err != nil {
-		return &provider.RemoveLabelResponse{
-			Status: status.NewStatusFromErrType(ctx, "remove label", err),
-		}, nil
-	}
-
-	return &provider.RemoveLabelResponse{
-		Status: status.NewOK(ctx),
 	}, nil
 }
 

--- a/pkg/rgrpc/todo/pool/client.go
+++ b/pkg/rgrpc/todo/pool/client.go
@@ -25,6 +25,7 @@ import (
 	authprovider "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	authregistry "github.com/cs3org/go-cs3apis/cs3/auth/registry/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	labelsService "github.com/cs3org/go-cs3apis/cs3/labels/v1beta1"
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	tenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -74,6 +75,12 @@ func GetStorageProviderServiceClient(id string, opts ...Option) (storageprovider
 // GetSpacesProviderServiceClient returns a SpacesProviderServiceClient.
 func GetSpacesProviderServiceClient(id string, opts ...Option) (storageprovider.SpacesAPIClient, error) {
 	selector, _ := SpacesProviderSelector(id, opts...)
+	return selector.Next()
+}
+
+// GetLabelsProviderServiceClient returns a LabelsAPIClient connected to the StorageProvider.
+func GetLabelsProviderServiceClient(id string, opts ...Option) (labelsService.LabelsAPIClient, error) {
+	selector, _ := LabelsProviderSelector(id, opts...)
 	return selector.Next()
 }
 

--- a/pkg/rgrpc/todo/pool/selector.go
+++ b/pkg/rgrpc/todo/pool/selector.go
@@ -29,6 +29,7 @@ import (
 	authProvider "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	authRegistry "github.com/cs3org/go-cs3apis/cs3/auth/registry/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	labelsService "github.com/cs3org/go-cs3apis/cs3/labels/v1beta1"
 	identityGroup "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	identityTenant "github.com/cs3org/go-cs3apis/cs3/identity/tenant/v1beta1"
 	identityUser "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -201,6 +202,17 @@ func SpacesProviderSelector(id string, options ...Option) (*Selector[storageProv
 		"SpacesProviderSelector",
 		id,
 		storageProvider.NewSpacesAPIClient,
+		options...,
+	), nil
+}
+
+// LabelsProviderSelector returns a Selector[labelsService.LabelsAPIClient].
+// The LabelsAPI service is registered on the same GRPC server as the StorageProvider.
+func LabelsProviderSelector(id string, options ...Option) (*Selector[labelsService.LabelsAPIClient], error) {
+	return GetSelector[labelsService.LabelsAPIClient](
+		"LabelsProviderSelector",
+		id,
+		labelsService.NewLabelsAPIClient,
 		options...,
 	), nil
 }

--- a/tests/cs3mocks/mocks/GatewayAPIClient.go
+++ b/tests/cs3mocks/mocks/GatewayAPIClient.go
@@ -42,6 +42,8 @@ import (
 
 	invitev1beta1 "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 
+	labelsv1beta1 "github.com/cs3org/go-cs3apis/cs3/labels/v1beta1"
+
 	linkv1beta1 "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 
 	mock "github.com/stretchr/testify/mock"
@@ -225,7 +227,7 @@ func (_c *GatewayAPIClient_AddAppProvider_Call) RunAndReturn(run func(context.Co
 }
 
 // AddLabel provides a mock function with given fields: ctx, in, opts
-func (_m *GatewayAPIClient) AddLabel(ctx context.Context, in *providerv1beta1.AddLabelRequest, opts ...grpc.CallOption) (*providerv1beta1.AddLabelResponse, error) {
+func (_m *GatewayAPIClient) AddLabel(ctx context.Context, in *labelsv1beta1.AddLabelRequest, opts ...grpc.CallOption) (*labelsv1beta1.AddLabelResponse, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _m.Called(ctx, in, opts)
@@ -238,20 +240,20 @@ func (_m *GatewayAPIClient) AddLabel(ctx context.Context, in *providerv1beta1.Ad
 		panic("no return value specified for AddLabel")
 	}
 
-	var r0 *providerv1beta1.AddLabelResponse
+	var r0 *labelsv1beta1.AddLabelResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.AddLabelRequest, ...grpc.CallOption) (*providerv1beta1.AddLabelResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.AddLabelRequest, ...grpc.CallOption) (*labelsv1beta1.AddLabelResponse, error)); ok {
 		return rf(ctx, in, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.AddLabelRequest, ...grpc.CallOption) *providerv1beta1.AddLabelResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.AddLabelRequest, ...grpc.CallOption) *labelsv1beta1.AddLabelResponse); ok {
 		r0 = rf(ctx, in, opts...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*providerv1beta1.AddLabelResponse)
+			r0 = ret.Get(0).(*labelsv1beta1.AddLabelResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.AddLabelRequest, ...grpc.CallOption) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *labelsv1beta1.AddLabelRequest, ...grpc.CallOption) error); ok {
 		r1 = rf(ctx, in, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -267,14 +269,14 @@ type GatewayAPIClient_AddLabel_Call struct {
 
 // AddLabel is a helper method to define mock.On call
 //   - ctx context.Context
-//   - in *providerv1beta1.AddLabelRequest
+//   - in *labelsv1beta1.AddLabelRequest
 //   - opts ...grpc.CallOption
 func (_e *GatewayAPIClient_Expecter) AddLabel(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_AddLabel_Call {
 	return &GatewayAPIClient_AddLabel_Call{Call: _e.mock.On("AddLabel",
 		append([]interface{}{ctx, in}, opts...)...)}
 }
 
-func (_c *GatewayAPIClient_AddLabel_Call) Run(run func(ctx context.Context, in *providerv1beta1.AddLabelRequest, opts ...grpc.CallOption)) *GatewayAPIClient_AddLabel_Call {
+func (_c *GatewayAPIClient_AddLabel_Call) Run(run func(ctx context.Context, in *labelsv1beta1.AddLabelRequest, opts ...grpc.CallOption)) *GatewayAPIClient_AddLabel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
@@ -282,17 +284,17 @@ func (_c *GatewayAPIClient_AddLabel_Call) Run(run func(ctx context.Context, in *
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*providerv1beta1.AddLabelRequest), variadicArgs...)
+		run(args[0].(context.Context), args[1].(*labelsv1beta1.AddLabelRequest), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *GatewayAPIClient_AddLabel_Call) Return(_a0 *providerv1beta1.AddLabelResponse, _a1 error) *GatewayAPIClient_AddLabel_Call {
+func (_c *GatewayAPIClient_AddLabel_Call) Return(_a0 *labelsv1beta1.AddLabelResponse, _a1 error) *GatewayAPIClient_AddLabel_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *GatewayAPIClient_AddLabel_Call) RunAndReturn(run func(context.Context, *providerv1beta1.AddLabelRequest, ...grpc.CallOption) (*providerv1beta1.AddLabelResponse, error)) *GatewayAPIClient_AddLabel_Call {
+func (_c *GatewayAPIClient_AddLabel_Call) RunAndReturn(run func(context.Context, *labelsv1beta1.AddLabelRequest, ...grpc.CallOption) (*labelsv1beta1.AddLabelResponse, error)) *GatewayAPIClient_AddLabel_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5188,6 +5190,79 @@ func (_c *GatewayAPIClient_ListInviteTokens_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// ListLabels provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayAPIClient) ListLabels(ctx context.Context, in *labelsv1beta1.ListLabelsRequest, opts ...grpc.CallOption) (*labelsv1beta1.ListLabelsResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _m.Called(ctx, in, opts)
+	} else {
+		tmpRet = _m.Called(ctx, in)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListLabels")
+	}
+
+	var r0 *labelsv1beta1.ListLabelsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.ListLabelsRequest, ...grpc.CallOption) (*labelsv1beta1.ListLabelsResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.ListLabelsRequest, ...grpc.CallOption) *labelsv1beta1.ListLabelsResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*labelsv1beta1.ListLabelsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *labelsv1beta1.ListLabelsRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GatewayAPIClient_ListLabels_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListLabels'
+type GatewayAPIClient_ListLabels_Call struct {
+	*mock.Call
+}
+
+// ListLabels is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *labelsv1beta1.ListLabelsRequest
+//   - opts ...grpc.CallOption
+func (_e *GatewayAPIClient_Expecter) ListLabels(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_ListLabels_Call {
+	return &GatewayAPIClient_ListLabels_Call{Call: _e.mock.On("ListLabels",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *GatewayAPIClient_ListLabels_Call) Run(run func(ctx context.Context, in *labelsv1beta1.ListLabelsRequest, opts ...grpc.CallOption)) *GatewayAPIClient_ListLabels_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*labelsv1beta1.ListLabelsRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListLabels_Call) Return(_a0 *labelsv1beta1.ListLabelsResponse, _a1 error) *GatewayAPIClient_ListLabels_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListLabels_Call) RunAndReturn(run func(context.Context, *labelsv1beta1.ListLabelsRequest, ...grpc.CallOption) (*labelsv1beta1.ListLabelsResponse, error)) *GatewayAPIClient_ListLabels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListOCMShares provides a mock function with given fields: ctx, in, opts
 func (_m *GatewayAPIClient) ListOCMShares(ctx context.Context, in *ocmv1beta1.ListOCMSharesRequest, opts ...grpc.CallOption) (*ocmv1beta1.ListOCMSharesResponse, error) {
 	var tmpRet mock.Arguments
@@ -5622,6 +5697,79 @@ func (_c *GatewayAPIClient_ListRecycleStream_Call) Return(_a0 gatewayv1beta1.Gat
 }
 
 func (_c *GatewayAPIClient_ListRecycleStream_Call) RunAndReturn(run func(context.Context, *providerv1beta1.ListRecycleStreamRequest, ...grpc.CallOption) (gatewayv1beta1.GatewayAPI_ListRecycleStreamClient, error)) *GatewayAPIClient_ListRecycleStream_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListResourcesForLabel provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayAPIClient) ListResourcesForLabel(ctx context.Context, in *labelsv1beta1.ListResourcesForLabelRequest, opts ...grpc.CallOption) (*labelsv1beta1.ListResourcesForLabelResponse, error) {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _m.Called(ctx, in, opts)
+	} else {
+		tmpRet = _m.Called(ctx, in)
+	}
+	ret := tmpRet
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListResourcesForLabel")
+	}
+
+	var r0 *labelsv1beta1.ListResourcesForLabelResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.ListResourcesForLabelRequest, ...grpc.CallOption) (*labelsv1beta1.ListResourcesForLabelResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.ListResourcesForLabelRequest, ...grpc.CallOption) *labelsv1beta1.ListResourcesForLabelResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*labelsv1beta1.ListResourcesForLabelResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *labelsv1beta1.ListResourcesForLabelRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GatewayAPIClient_ListResourcesForLabel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListResourcesForLabel'
+type GatewayAPIClient_ListResourcesForLabel_Call struct {
+	*mock.Call
+}
+
+// ListResourcesForLabel is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *labelsv1beta1.ListResourcesForLabelRequest
+//   - opts ...grpc.CallOption
+func (_e *GatewayAPIClient_Expecter) ListResourcesForLabel(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_ListResourcesForLabel_Call {
+	return &GatewayAPIClient_ListResourcesForLabel_Call{Call: _e.mock.On("ListResourcesForLabel",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *GatewayAPIClient_ListResourcesForLabel_Call) Run(run func(ctx context.Context, in *labelsv1beta1.ListResourcesForLabelRequest, opts ...grpc.CallOption)) *GatewayAPIClient_ListResourcesForLabel_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*labelsv1beta1.ListResourcesForLabelRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListResourcesForLabel_Call) Return(_a0 *labelsv1beta1.ListResourcesForLabelResponse, _a1 error) *GatewayAPIClient_ListResourcesForLabel_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListResourcesForLabel_Call) RunAndReturn(run func(context.Context, *labelsv1beta1.ListResourcesForLabelRequest, ...grpc.CallOption) (*labelsv1beta1.ListResourcesForLabelResponse, error)) *GatewayAPIClient_ListResourcesForLabel_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6211,7 +6359,7 @@ func (_c *GatewayAPIClient_RefreshLock_Call) RunAndReturn(run func(context.Conte
 }
 
 // RemoveLabel provides a mock function with given fields: ctx, in, opts
-func (_m *GatewayAPIClient) RemoveLabel(ctx context.Context, in *providerv1beta1.RemoveLabelRequest, opts ...grpc.CallOption) (*providerv1beta1.RemoveLabelResponse, error) {
+func (_m *GatewayAPIClient) RemoveLabel(ctx context.Context, in *labelsv1beta1.RemoveLabelRequest, opts ...grpc.CallOption) (*labelsv1beta1.RemoveLabelResponse, error) {
 	var tmpRet mock.Arguments
 	if len(opts) > 0 {
 		tmpRet = _m.Called(ctx, in, opts)
@@ -6224,20 +6372,20 @@ func (_m *GatewayAPIClient) RemoveLabel(ctx context.Context, in *providerv1beta1
 		panic("no return value specified for RemoveLabel")
 	}
 
-	var r0 *providerv1beta1.RemoveLabelResponse
+	var r0 *labelsv1beta1.RemoveLabelResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.RemoveLabelRequest, ...grpc.CallOption) (*providerv1beta1.RemoveLabelResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.RemoveLabelRequest, ...grpc.CallOption) (*labelsv1beta1.RemoveLabelResponse, error)); ok {
 		return rf(ctx, in, opts...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *providerv1beta1.RemoveLabelRequest, ...grpc.CallOption) *providerv1beta1.RemoveLabelResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *labelsv1beta1.RemoveLabelRequest, ...grpc.CallOption) *labelsv1beta1.RemoveLabelResponse); ok {
 		r0 = rf(ctx, in, opts...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*providerv1beta1.RemoveLabelResponse)
+			r0 = ret.Get(0).(*labelsv1beta1.RemoveLabelResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.RemoveLabelRequest, ...grpc.CallOption) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *labelsv1beta1.RemoveLabelRequest, ...grpc.CallOption) error); ok {
 		r1 = rf(ctx, in, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -6253,14 +6401,14 @@ type GatewayAPIClient_RemoveLabel_Call struct {
 
 // RemoveLabel is a helper method to define mock.On call
 //   - ctx context.Context
-//   - in *providerv1beta1.RemoveLabelRequest
+//   - in *labelsv1beta1.RemoveLabelRequest
 //   - opts ...grpc.CallOption
 func (_e *GatewayAPIClient_Expecter) RemoveLabel(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_RemoveLabel_Call {
 	return &GatewayAPIClient_RemoveLabel_Call{Call: _e.mock.On("RemoveLabel",
 		append([]interface{}{ctx, in}, opts...)...)}
 }
 
-func (_c *GatewayAPIClient_RemoveLabel_Call) Run(run func(ctx context.Context, in *providerv1beta1.RemoveLabelRequest, opts ...grpc.CallOption)) *GatewayAPIClient_RemoveLabel_Call {
+func (_c *GatewayAPIClient_RemoveLabel_Call) Run(run func(ctx context.Context, in *labelsv1beta1.RemoveLabelRequest, opts ...grpc.CallOption)) *GatewayAPIClient_RemoveLabel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]grpc.CallOption, len(args)-2)
 		for i, a := range args[2:] {
@@ -6268,17 +6416,17 @@ func (_c *GatewayAPIClient_RemoveLabel_Call) Run(run func(ctx context.Context, i
 				variadicArgs[i] = a.(grpc.CallOption)
 			}
 		}
-		run(args[0].(context.Context), args[1].(*providerv1beta1.RemoveLabelRequest), variadicArgs...)
+		run(args[0].(context.Context), args[1].(*labelsv1beta1.RemoveLabelRequest), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *GatewayAPIClient_RemoveLabel_Call) Return(_a0 *providerv1beta1.RemoveLabelResponse, _a1 error) *GatewayAPIClient_RemoveLabel_Call {
+func (_c *GatewayAPIClient_RemoveLabel_Call) Return(_a0 *labelsv1beta1.RemoveLabelResponse, _a1 error) *GatewayAPIClient_RemoveLabel_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *GatewayAPIClient_RemoveLabel_Call) RunAndReturn(run func(context.Context, *providerv1beta1.RemoveLabelRequest, ...grpc.CallOption) (*providerv1beta1.RemoveLabelResponse, error)) *GatewayAPIClient_RemoveLabel_Call {
+func (_c *GatewayAPIClient_RemoveLabel_Call) RunAndReturn(run func(context.Context, *labelsv1beta1.RemoveLabelRequest, ...grpc.CallOption) (*labelsv1beta1.RemoveLabelResponse, error)) *GatewayAPIClient_RemoveLabel_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Update `go-cs3apis` to v0.0.0-20260604164754-c3fdb0aa5e9e (Jun 4 2026).

Three upstream cs3apis changes require adaptations:

1. **cs3org/cs3apis#272** — adds SetImmutable/UnsetImmutable RPCs to ProviderAPI
2. **cs3org/cs3apis#273** — OCM share state changes
3. **Labels API** — AddLabel/RemoveLabel moved from StorageProvider to cs3/labels/v1beta1

## Labels API Migration

```
Before (old cs3apis):

  opencloud ──AddLabel──► Gateway ──c.AddLabel()──► StorageProvider
  (graph)    provider.Req          ProviderAPIClient (ProviderAPI)
                                                     → Storage.AddLabel()

After (this PR):

  opencloud ──AddLabel──► Gateway ──lc.AddLabel()──► StorageProvider
  (graph)    labels.Req            LabelsAPIClient   (LabelsAPI service)
                                                     → Storage.AddLabel()
```

The StorageProvider now registers as **LabelsAPIServer** in addition to
ProviderAPIServer and SpacesAPIServer. The Gateway routes Labels calls
via a new LabelsAPIClient using the same GRPC connection pool.

**AddLabel/RemoveLabel continue to work end-to-end.** The only change
is the GRPC service name — the underlying Storage FS implementation is
unchanged.

## Changes

- `go.mod`: bump go-cs3apis
- **StorageProvider**: register as LabelsAPIServer, implement AddLabel/RemoveLabel/ListLabels/ListResourcesForLabel via Storage FS interface
- **Gateway**: route AddLabel/RemoveLabel to StorageProvider's LabelsAPI service
- **Pool**: add LabelsProviderSelector and GetLabelsProviderServiceClient
- **All ProviderAPI implementations**: add SetImmutable/UnsetImmutable stubs
- Regenerate mocks

## Test plan

- [x] Full build passes (`go build ./...`)
- [ ] Labels (favorites) still work end-to-end
- [ ] CI pipeline