### PR TITLE
fix(posix): make warmupSpaceRootCache errors non-fatal

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -183,7 +183,7 @@ func New(lu node.PathLookup, bs node.Blobstore, um usermapper.Mapper, trashbin *
 		// warmup the cache for all space roots right away so clients and migrations don't get confused when starting with a cold cache
 		err := t.warmupSpaceRootCache(o)
 		if err != nil {
-			return nil, errors.Wrap(err, "error warming up space root cache")
+			t.log.Error().Err(err).Msg("error warming up space root cache, continuing")
 		}
 
 		// scan the whole tree asynchronously to pick up new nodes
@@ -235,7 +235,7 @@ func (t *Tree) warmupSpaceRootCache(options *options.Options) error {
 		}
 		err = t.idCache.Set(context.TODO(), spaceID, spaceID, path)
 		if err != nil {
-			return errors.Wrap(err, "could not cache space root path")
+			t.log.Error().Err(err).Str("spaceID", spaceID).Str("path", path).Msg("could not cache space root path, continuing")
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- Make `warmupSpaceRootCache` errors non-fatal during tree initialization
- Cache write failures (e.g. NATS KV temporarily unavailable during upgrades) are logged instead of aborting the service
- The subsequent async `WarmupIDCache` will retry and fill in any missing entries

## Problem

Since commits 0ae322f4 and c5a3bca0, `warmupSpaceRootCache` runs synchronously during `tree.New()` and aborts on cache write errors. During upgrades (e.g. 5.x → 7.x) the NATS KV store may be temporarily unavailable, causing the storage-users service to fail startup entirely. This cascades: proxy never binds its port → 502 for all requests.

## Changes

Two lines changed in `pkg/storage/fs/posix/tree/tree.go`:
1. Caller: `return nil, errors.Wrap(...)` → `t.log.Error()...` (log and continue)
2. Function: `return errors.Wrap(...)` → `t.log.Error()...` (log and continue per space)

## Test plan

- [x] Verified that service starts successfully when NATS KV is temporarily unavailable
- [x] Verified that spaces are populated once NATS becomes available (via async WarmupIDCache)
- [x] Tested upgrade scenario from 5.1.0 to 7.x with existing NATS data