### PR TITLE
🎉 Release 2.46.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-16
+## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-17
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@rhafer
+@aduffeck, @rhafer
 
 ### 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- [stable-2.46] Backport #681 [[#686](https://github.com/opencloud-eu/reva/pull/686)]
 - Stable backports [[#679](https://github.com/opencloud-eu/reva/pull/679)]
 
 ## [2.46.3](https://github.com/opencloud-eu/reva/releases/tag/v2.46.3) - 2026-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-16
+
+### ❤️ Thanks to all contributors! ❤️
+
+@rhafer
+
+### 🐛 Bug Fixes
+
+- Stable backports [[#679](https://github.com/opencloud-eu/reva/pull/679)]
+
 ## [2.46.3](https://github.com/opencloud-eu/reva/releases/tag/v2.46.3) - 2026-06-10
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.46.4` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.46` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-17

### 🐛 Bug Fixes

- [stable-2.46] Backport #681 [[#686](https://github.com/opencloud-eu/reva/pull/686)]
- Stable backports [[#679](https://github.com/opencloud-eu/reva/pull/679)]