### PR TITLE
🎉 Release 2.40.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.40.5](https://github.com/opencloud-eu/reva/releases/tag/v2.40.5) - 2026-06-17
+
+### ❤️ Thanks to all contributors! ❤️
+
+@aduffeck
+
+### 🐛 Bug Fixes
+
+- [stable-2.40] Backport #681 [[#687](https://github.com/opencloud-eu/reva/pull/687)]
+
 ## [2.40.4](https://github.com/opencloud-eu/reva/releases/tag/v2.40.4) - 2026-03-27
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.40.5` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.40` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.40.5](https://github.com/opencloud-eu/reva/releases/tag/v2.40.5) - 2026-06-17

### 🐛 Bug Fixes

- [stable-2.40] Backport #681 [[#687](https://github.com/opencloud-eu/reva/pull/687)]