### PR TITLE
fix(decomposedfs): invalidate all space indexes on purge

### DIFF
--- a/pkg/storage/pkg/decomposedfs/spaces.go
+++ b/pkg/storage/pkg/decomposedfs/spaces.go
@@ -751,13 +751,45 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 			return errtypes.NewErrtypeFromStatus(status.NewInvalid(ctx, "can't purge enabled space"))
 		}
 
-		// TODO invalidate ALL indexes in msgpack, not only by type
 		spaceType, err := n.XattrString(ctx, prefixes.SpaceTypeAttr)
 		if err != nil {
 			return err
 		}
 		if err := fs.spaceTypeIndex.Remove(spaceType, spaceID); err != nil {
 			return err
+		}
+
+		// the by-type index is handled above; also remove the space from the user
+		// and group indexes for the owner and every grantee, or they keep stale
+		// entries pointing at the purged space. best effort, like the expired
+		// grant removal: log and continue.
+		// https://github.com/opencloud-eu/opencloud/issues/2985
+		sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Logger()
+		if ownerID, err := n.XattrString(ctx, prefixes.OwnerIDAttr); err != nil {
+			sublog.Error().Err(err).Msg("could not read space owner")
+		} else if ownerID != "" {
+			// remove from user index
+			if err := fs.userSpaceIndex.Remove(ownerID, spaceID); err != nil {
+				sublog.Error().Err(err).Msg("could not remove owner from user index")
+			}
+		}
+		grants, err := n.ListGrants(ctx)
+		if err != nil {
+			sublog.Error().Err(err).Msg("could not list grants")
+		}
+		for _, g := range grants {
+			switch g.Grantee.Type {
+			case provider.GranteeType_GRANTEE_TYPE_USER:
+				// remove from user index
+				if err := fs.userSpaceIndex.Remove(g.Grantee.GetUserId().GetOpaqueId(), spaceID); err != nil {
+					sublog.Error().Err(err).Str("grantee", g.Grantee.GetUserId().GetOpaqueId()).Msg("could not remove user from user index")
+				}
+			case provider.GranteeType_GRANTEE_TYPE_GROUP:
+				// remove from group index
+				if err := fs.groupSpaceIndex.Remove(g.Grantee.GetGroupId().GetOpaqueId(), spaceID); err != nil {
+					sublog.Error().Err(err).Str("grantee", g.Grantee.GetGroupId().GetOpaqueId()).Msg("could not remove group from group index")
+				}
+			}
 		}
 
 		// invalidate cache

--- a/pkg/storage/pkg/decomposedfs/spaces_test.go
+++ b/pkg/storage/pkg/decomposedfs/spaces_test.go
@@ -20,7 +20,9 @@ package decomposedfs_test
 
 import (
 	"context"
+	"path/filepath"
 
+	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -30,7 +32,9 @@ import (
 	. "github.com/onsi/gomega"
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/spaceidindex"
 	helpers "github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/testhelpers"
+	"github.com/opencloud-eu/reva/v2/pkg/storagespace"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 )
@@ -201,6 +205,115 @@ var _ = Describe("Spaces", func() {
 			It("succeeds as the space owner", func() {
 				err := env.Fs.DeleteStorageSpace(env.Ctx, delReq)
 				Expect(err).To(Not(HaveOccurred()))
+			})
+			// Reproducer for opencloud-eu/opencloud#2985: purging a space must
+			// invalidate ALL of its msgpack indexes, not only the by-type index.
+			// The by-user-id index keeps a stale entry pointing at the purged
+			// space, which is exactly the reporter's "stale references in
+			// indexes/by-user-id/*.mpk".
+			It("removes the space from the by-user-id index", func() {
+				_, spaceID, _, err := storagespace.SplitID(delReq.Id.GetOpaqueId())
+				Expect(err).ToNot(HaveOccurred())
+
+				// load via a fresh index instance each time: spaceidindex caches by
+				// mtime, and the purge rewrites the file within the same mtime tick.
+				loadOwnerIndex := func() map[string]string {
+					idx := spaceidindex.New(filepath.Join(env.Root, "indexes"), "by-user-id")
+					Expect(idx.Init()).To(Succeed())
+					m, lerr := idx.Load(helpers.OwnerID)
+					Expect(lerr).ToNot(HaveOccurred())
+					return m
+				}
+
+				// precondition: the owner's by-user-id index references the space
+				Expect(loadOwnerIndex()).To(HaveKey(spaceID))
+
+				// purge as the space owner
+				Expect(env.Fs.DeleteStorageSpace(env.Ctx, delReq)).To(Succeed())
+
+				// the by-user-id index entry must be gone after the purge
+				Expect(loadOwnerIndex()).ToNot(HaveKey(spaceID))
+			})
+			// Reproducer for the grantee side of opencloud-eu/opencloud#2985:
+			// the purge must also remove the space from a user grantee's
+			// by-user-id index and a group grantee's by-group-id index.
+			It("removes the space from the by-user-id and by-group indexes for grantees", func() {
+				resp, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: "Shared Space", Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				sid := resp.StorageSpace.GetId()
+				_, spaceID, _, err := storagespace.SplitID(sid.GetOpaqueId())
+				Expect(err).ToNot(HaveOccurred())
+				ref := &provider.Reference{ResourceId: resp.StorageSpace.GetRoot()}
+
+				userGrantee := helpers.User0ID
+				groupGrantee := "11111111-2222-3333-4444-555555555555"
+				Expect(env.Fs.AddGrant(env.Ctx, ref, &provider.Grant{
+					Grantee:     &provider.Grantee{Type: provider.GranteeType_GRANTEE_TYPE_USER, Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{OpaqueId: userGrantee}}},
+					Permissions: &provider.ResourcePermissions{Stat: true},
+					Creator:     &userv1beta1.UserId{OpaqueId: helpers.OwnerID},
+				})).To(Succeed())
+				Expect(env.Fs.AddGrant(env.Ctx, ref, &provider.Grant{
+					Grantee:     &provider.Grantee{Type: provider.GranteeType_GRANTEE_TYPE_GROUP, Id: &provider.Grantee_GroupId{GroupId: &grouppb.GroupId{OpaqueId: groupGrantee}}},
+					Permissions: &provider.ResourcePermissions{Stat: true},
+					Creator:     &userv1beta1.UserId{OpaqueId: helpers.OwnerID},
+				})).To(Succeed())
+
+				// seed the grantee space-index entries. The real share flow writes
+				// these via a space-typed context; here we add them directly so the
+				// purge has grantee index entries to remove.
+				target := "../../../spaces/" + spaceID
+				userIdx := spaceidindex.New(filepath.Join(env.Root, "indexes"), "by-user-id")
+				Expect(userIdx.Init()).To(Succeed())
+				Expect(userIdx.Add(userGrantee, spaceID, target)).To(Succeed())
+				groupIdx := spaceidindex.New(filepath.Join(env.Root, "indexes"), "by-group-id")
+				Expect(groupIdx.Init()).To(Succeed())
+				Expect(groupIdx.Add(groupGrantee, spaceID, target)).To(Succeed())
+
+				load := func(indexName, key string) map[string]string {
+					idx := spaceidindex.New(filepath.Join(env.Root, "indexes"), indexName)
+					Expect(idx.Init()).To(Succeed())
+					m, lerr := idx.Load(key)
+					Expect(lerr).ToNot(HaveOccurred())
+					return m
+				}
+
+				// precondition: both grantee indexes reference the space
+				Expect(load("by-user-id", userGrantee)).To(HaveKey(spaceID))
+				Expect(load("by-group-id", groupGrantee)).To(HaveKey(spaceID))
+
+				// disable, then purge as the space owner
+				Expect(env.Fs.DeleteStorageSpace(env.Ctx, &provider.DeleteStorageSpaceRequest{Id: sid})).To(Succeed())
+				Expect(env.Fs.DeleteStorageSpace(env.Ctx, &provider.DeleteStorageSpaceRequest{
+					Opaque: &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{"purge": {Decoder: "plain", Value: []byte("true")}}},
+					Id:     sid,
+				})).To(Succeed())
+
+				// the grantee index entries must be gone after the purge
+				Expect(load("by-user-id", userGrantee)).ToNot(HaveKey(spaceID))
+				Expect(load("by-group-id", groupGrantee)).ToNot(HaveKey(spaceID))
+			})
+			// purging one space must remove only that space's entry: a sibling
+			// space of the same owner must stay in the by-user-id index.
+			It("keeps a sibling space in the by-user-id index when another is purged", func() {
+				_, purgedID, _, err := storagespace.SplitID(delReq.Id.GetOpaqueId())
+				Expect(err).ToNot(HaveOccurred())
+				resp, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: "Sibling Space", Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				_, siblingID, _, err := storagespace.SplitID(resp.StorageSpace.GetId().GetOpaqueId())
+				Expect(err).ToNot(HaveOccurred())
+				loadOwnerIndex := func() map[string]string {
+					idx := spaceidindex.New(filepath.Join(env.Root, "indexes"), "by-user-id")
+					Expect(idx.Init()).To(Succeed())
+					m, lerr := idx.Load(helpers.OwnerID)
+					Expect(lerr).ToNot(HaveOccurred())
+					return m
+				}
+				Expect(loadOwnerIndex()).To(HaveKey(purgedID))
+				Expect(loadOwnerIndex()).To(HaveKey(siblingID))
+				Expect(env.Fs.DeleteStorageSpace(env.Ctx, delReq)).To(Succeed())
+				after := loadOwnerIndex()
+				Expect(after).ToNot(HaveKey(purgedID))
+				Expect(after).To(HaveKey(siblingID))
 			})
 		})
 	})


### PR DESCRIPTION
## Description

The `purge` branch of `DeleteStorageSpace` removed only the by-type index. It left the purged space referenced in the by-user-id and by-group indexes, for the space owner and for every grantee. After a purge the on-disk space tree is gone, but those index entries remain. The search service then walks each indexed space and logs an error for the missing one on every pass.

Root cause: `updateIndexes` populates the by-type index and the by-user-id / by-group indexes (the owner on space creation, each grantee on share), but the purge only called `spaceTypeIndex.Remove`. A `// TODO invalidate ALL indexes in msgpack, not only by type` at that call site noted the gap.

Fix: on purge, also remove the space from the by-user-id and by-group indexes, for the owner (read from the `OwnerIDAttr` extended attribute) and for each grantee (from `ListGrants`). Removal is best effort: the purge logs an index error and continues, the same way the expired-grant removal already does.

The same gap exists in both decomposedfs trees, so the fix covers both: `pkg/storage/pkg/decomposedfs` (used by the decomposeds3, decomposed and posix drivers) and `pkg/storage/utils/decomposedfs` (used by the ocis and s3ng drivers).

Scope: this stops new stale index entries on purge. It does not delete the S3 objects that a purge already leaves behind on the decomposedS3 driver (a separate blob-removal concern), and it does not clean up spaces that were orphaned before this change.

## Related Issue

- Fixes https://github.com/opencloud-eu/opencloud/issues/2985

## Motivation and Context

Any space purge leaves a stale reference in the by-user-id / by-group index. The issue surfaced after a delete-and-recreate of a project space, where the old space stays referenced for the owner and the shared users. The reproduction and the root-cause trace are in the linked issue.

## How Has This Been Tested?

- `go test` and `go vet` on both decomposedfs packages (full suites pass)
- `golangci-lint` v2.10.1 (pinned in the Makefile) on both packages: 0 issues
- new specs (both trees): purge removes the owner, user-grantee and group-grantee index entries, and keeps a sibling space's entry
- end to end on a patched build (decomposedS3 + MinIO): after sharing a space with a user and a group and purging it, the space id dropped from 4 index files to 0
- not covered: a behat acceptance scenario

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added (the behat suite has no space-purge index scenario; this PR covers it at the unit level, and a behat scenario can follow in the opencloud repo)
- [ ] Documentation added (n/a; reva builds the changelog from the PR title and `Type:*` label via ready-release-go, so no fragment is needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
