### PR TITLE
fix: include custom metadata in allprop PROPFIND response

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1292,6 +1292,21 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			appendMetadataProp(k, "oc", "location", "libre.graph.location", locationKeys)
 			appendMetadataProp(k, "oc", "image", "libre.graph.image", imageKeys)
 			appendMetadataProp(k, "oc", "photo", "libre.graph.photo", photoKeys)
+
+			// include arbitrary custom metadata (keys not handled above)
+			knownPrefixes := []string{"tags", "libre.graph.audio.", "libre.graph.location.", "libre.graph.image.", "libre.graph.photo."}
+			for key, val := range k {
+				isKnown := false
+				for _, prefix := range knownPrefixes {
+					if key == prefix || strings.HasPrefix(key, prefix) {
+						isKnown = true
+						break
+					}
+				}
+				if !isKnown && val != "" {
+					appendToOK(prop.EscapedNS(net.NsOwncloud, key, val))
+				}
+			}
 		}
 
 		if md.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {


### PR DESCRIPTION
## Summary

The allprop PROPFIND handler only outputs known metadata keys (tags, audio, location, image, photo). Arbitrary custom metadata set via the Graph Metadata API is silently omitted from the response.

## Changes

| File | Change |
|---|---|
| `propfind.go` | Iterate over `ArbitraryMetadata.Metadata` and include all non-empty custom keys in the allprop response |

## Motivation

Applications that store custom metadata (e.g. `oy.fileReference`, `oy.status`) via `SetArbitraryMetadata` expect these values to appear in PROPFIND allprop responses. Without this fix, only explicit prop requests (fixed in #693) return custom metadata — allprop silently drops them.

## Relation to other PRs

Companion to #693 (explicit metadata key requests). Together they ensure custom metadata is always returned in PROPFIND responses, regardless of request style.

## Test plan

- [x] Set custom metadata via Graph Metadata API
- [x] PROPFIND with allprop returns the custom metadata
- [x] Known metadata (tags, audio etc.) still works as before