### PR TITLE
🎉 Release 2.46.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 @rhafer
 
+### 🐛 Bug Fixes
 
+- [stable-2.46] fix: status codes on DeleteStorageSpace [[#692](https://github.com/opencloud-eu/reva/pull/692)]
 
 ## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.46.5](https://github.com/opencloud-eu/reva/releases/tag/v2.46.5) - 2026-06-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@rhafer
+
+
+
 ## [2.46.4](https://github.com/opencloud-eu/reva/releases/tag/v2.46.4) - 2026-06-17
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.46.5` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.46` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.46.5](https://github.com/opencloud-eu/reva/releases/tag/v2.46.5) - 2026-06-22

### 🐛 Bug Fixes

- [stable-2.46] fix: status codes on DeleteStorageSpace [[#692](https://github.com/opencloud-eu/reva/pull/692)]