### PR TITLE
Introduce LockAndRead which locks a node and returns a reader for it

### DIFF
--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -504,6 +504,11 @@ func (b HybridBackend) LockfilePath(n MetadataNode) string {
 
 // Lock locks the metadata for the given path
 func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
+	f, _, err := b.LockAndRead(n)
+	return f, err
+}
+
+func (b HybridBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
 	metaLockPath := b.LockfilePath(n)
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -511,20 +516,20 @@ func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 			// create the parent directory
 			err = os.MkdirAll(filepath.Dir(metaLockPath), 0700)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			mlock, err = lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 	return func() error {
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
-	}, nil
+	}, mlock, nil
 }
 
 func (b HybridBackend) cacheKey(n MetadataNode) string {

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -2,6 +2,7 @@ package metadata_test
 
 import (
 	"context"
+	"io"
 	"os"
 	"path"
 
@@ -301,6 +302,33 @@ var _ = Describe("HybridBackend", func() {
 
 			_, err = backend.Get(context.Background(), n, nonOffloadingKey)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("LockAndRead", func() {
+		It("acquires a lock and returns a reader", func() {
+			unlock, reader, err := backend.LockAndRead(n)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				err = unlock()
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			data, err := io.ReadAll(reader)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(data)).To(Equal(0))
+		})
+
+		It("releases the lock after unlock is called", func() {
+			unlock1, _, err := backend.LockAndRead(n)
+			Expect(err).ToNot(HaveOccurred())
+			err = unlock1()
+			Expect(err).ToNot(HaveOccurred())
+
+			unlock2, _, err := backend.LockAndRead(n)
+			Expect(err).ToNot(HaveOccurred())
+			err = unlock2()
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
@@ -325,6 +325,20 @@ func (b MessagePackBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	}, nil
 }
 
+func (b MessagePackBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
+	unlock, err := b.Lock(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f, err := os.Open(b.MetadataPath(n))
+	if err != nil {
+		_ = unlock()
+		return nil, nil, err
+	}
+	return unlock, f, nil
+}
+
 func (b MessagePackBackend) cacheKey(n MetadataNode) string {
 	return n.GetSpaceID() + "/" + n.GetID()
 }

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata.go
@@ -59,6 +59,7 @@ type Backend interface {
 	Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error
 
 	Lock(n MetadataNode) (UnlockFunc, error)
+	LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error)
 	Purge(ctx context.Context, n MetadataNode) error
 	Rename(oldNode, newNode MetadataNode) error
 	MetadataPath(n MetadataNode) string
@@ -111,6 +112,11 @@ func (NullBackend) Remove(ctx context.Context, n MetadataNode, key string, acqui
 // Lock locks the metadata for the given path
 func (NullBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	return nil, nil
+}
+
+// LockAndRead locks the metadata for reading
+func (NullBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
+	return nil, nil, nil
 }
 
 // IsMetaFile returns whether the given path represents a meta file

--- a/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
@@ -462,6 +462,73 @@ func (_c *Backend_Lock_Call) RunAndReturn(run func(metadata.MetadataNode) (metad
 	return _c
 }
 
+// LockAndRead provides a mock function with given fields: n
+func (_m *Backend) LockAndRead(n metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error) {
+	ret := _m.Called(n)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LockAndRead")
+	}
+
+	var r0 metadata.UnlockFunc
+	var r1 io.Reader
+	var r2 error
+	if rf, ok := ret.Get(0).(func(metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error)); ok {
+		return rf(n)
+	}
+	if rf, ok := ret.Get(0).(func(metadata.MetadataNode) metadata.UnlockFunc); ok {
+		r0 = rf(n)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(metadata.UnlockFunc)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(metadata.MetadataNode) io.Reader); ok {
+		r1 = rf(n)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(io.Reader)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(metadata.MetadataNode) error); ok {
+		r2 = rf(n)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// Backend_LockAndRead_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LockAndRead'
+type Backend_LockAndRead_Call struct {
+	*mock.Call
+}
+
+// LockAndRead is a helper method to define mock.On call
+//   - n metadata.MetadataNode
+func (_e *Backend_Expecter) LockAndRead(n interface{}) *Backend_LockAndRead_Call {
+	return &Backend_LockAndRead_Call{Call: _e.mock.On("LockAndRead", n)}
+}
+
+func (_c *Backend_LockAndRead_Call) Run(run func(n metadata.MetadataNode)) *Backend_LockAndRead_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(metadata.MetadataNode))
+	})
+	return _c
+}
+
+func (_c *Backend_LockAndRead_Call) Return(_a0 metadata.UnlockFunc, _a1 io.Reader, _a2 error) *Backend_LockAndRead_Call {
+	_c.Call.Return(_a0, _a1, _a2)
+	return _c
+}
+
+func (_c *Backend_LockAndRead_Call) RunAndReturn(run func(metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error)) *Backend_LockAndRead_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LockfilePath provides a mock function with given fields: n
 func (_m *Backend) LockfilePath(n metadata.MetadataNode) string {
 	ret := _m.Called(n)

--- a/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
@@ -286,6 +286,21 @@ func (b XattrsBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	}, nil
 }
 
+// LockAndRead locks the metadata for reading
+func (b XattrsBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
+	unlock, err := b.Lock(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f, err := os.Open(b.MetadataPath(n))
+	if err != nil {
+		_ = unlock()
+		return nil, nil, err
+	}
+	return unlock, f, nil
+}
+
 // AllWithLockedSource reads all extended attributes from the given reader.
 // The path argument is used for storing the data in the cache
 func (b XattrsBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -357,13 +357,13 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 
 	_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
 	bn := NewBaseNode(spaceID, nodeID, lu)
-	unlock, err := lu.MetadataBackend().Lock(bn)
+	unlock, r, err := lu.MetadataBackend().LockAndRead(bn)
 	subspan.End()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	n, err := ReadNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck)
+	n, err := readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, r)
 	if err != nil {
 		_ = unlock()
 		return nil, nil, err
@@ -378,6 +378,12 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 
 // ReadNode creates a new instance from an id and checks if it exists
 func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, error) {
+	return readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, nil)
+}
+
+// readNode reads a node by its id. If a reader is provided, it will be passed to the metadata backend to read the metadata.
+// This is useful when the caller already holds a lock to prevent deadlocks when reading the metadata.
+func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool, r io.Reader) (*Node, error) {
 	ctx, span := tracer.Start(ctx, "ReadNode")
 	defer span.End()
 	var err error
@@ -392,6 +398,20 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 			},
 		}
 		spaceRoot.SpaceRoot = spaceRoot
+
+		// If we hold the lock on the space root itself, prime its attribute cache
+		// through the no-lock path so the owner/name/disabled reads below do not try
+		// to re-acquire the already-held lock and self-deadlock.
+		if r != nil && nodeID == spaceID {
+			_, err = spaceRoot.XattrsWithReader(ctx, r)
+			switch {
+			case metadata.IsNotExist(err):
+				return spaceRoot, nil // swallow not found, the node defaults to exists = false
+			case err != nil:
+				return nil, err
+			}
+		}
+
 		spaceRoot.owner, err = spaceRoot.readOwner(ctx)
 		switch {
 		case metadata.IsNotExist(err):
@@ -456,7 +476,8 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		}
 	}()
 
-	attrs, err := n.Xattrs(ctx)
+	var attrs Attributes
+	attrs, err = n.XattrsWithReader(ctx, r)
 	switch {
 	case metadata.IsNotExist(err):
 		return n, nil // swallow not found, the node defaults to exists = false

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
@@ -285,28 +285,19 @@ func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, reca
 
 	attrs := node.Attributes{}
 
-	// lock parent before reading treesize or tree time
-	_, subspan = tracer.Start(ctx, "lockedfile.OpenFile")
-	unlock, err := p.lookup.MetadataBackend().Lock(pn)
+	_, subspan = tracer.Start(ctx, "node.LockAndReadNode")
+	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, pn.GetSpaceID(), pn.GetID(), "", false, nil, false)
 	subspan.End()
 	if err != nil {
-		log.Error().Err(err).
-			Str("lock filepath", p.lookup.MetadataBackend().LockfilePath(pn)).
-			Msg("Propagation failed. Could not open metadata for node with lock.")
+		if n != nil && !n.Exists {
+			log.Debug().Str("attr", prefixes.PropagationAttr).Msg("node does not exist anymore, not propagating")
+		} else {
+			log.Error().Err(err).Msg("Propagation failed. Could not read node with lock.")
+		}
 		cleanup()
 		return
 	}
 	defer func() { _ = unlock() }()
-
-	_, subspan = tracer.Start(ctx, "node.ReadNode")
-	n, err := node.ReadNode(ctx, p.lookup, pn.GetSpaceID(), pn.GetID(), "", false, nil, false)
-	if err != nil {
-		log.Error().Err(err).
-			Msg("Propagation failed. Could not read node.")
-		cleanup()
-		return
-	}
-	subspan.End()
 
 	if !n.Exists {
 		log.Debug().Str("attr", prefixes.PropagationAttr).Msg("node does not exist anymore, not propagating")


### PR DESCRIPTION
This supports node.LockAndReadNode in reading and locking a node without deadlocks even with cold caches.

Fixes #700 