### PR TITLE
🎉 Release 2.46.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.46.6](https://github.com/opencloud-eu/reva/releases/tag/v2.46.6) - 2026-06-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@aduffeck
+
+### 🐛 Bug Fixes
+
+- Backport the LockAndRead change from #701 [[#702](https://github.com/opencloud-eu/reva/pull/702)]
+
 ## [2.46.5](https://github.com/opencloud-eu/reva/releases/tag/v2.46.5) - 2026-06-22
 
 ### ❤️ Thanks to all contributors! ❤️


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `2.46.6` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `stable-2.46` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [2.46.6](https://github.com/opencloud-eu/reva/releases/tag/v2.46.6) - 2026-06-23

### 🐛 Bug Fixes

- Backport the LockAndRead change from #701 [[#702](https://github.com/opencloud-eu/reva/pull/702)]