### PR TITLE
test(decomposedfs): purge project spaces as a delete-all-spaces user

### DIFF
--- a/pkg/storage/pkg/decomposedfs/spaces_test.go
+++ b/pkg/storage/pkg/decomposedfs/spaces_test.go
@@ -200,6 +200,15 @@ var _ = Describe("Spaces", func() {
 				err := env.Fs.DeleteStorageSpace(ctx, delReq)
 				Expect(err).To(HaveOccurred())
 			})
+			It("succeeds at disabling as a space manager", func() {
+				// the counterpart to the purge denial above: since #672 a space
+				// manager may still disable (but not purge) a project space.
+				resp, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: "Manager Disables", Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.SpaceManager)
+				err = env.Fs.DeleteStorageSpace(ctx, &provider.DeleteStorageSpaceRequest{Id: resp.StorageSpace.GetId()})
+				Expect(err).To(Not(HaveOccurred()))
+			})
 			// Reproducer for opencloud-eu/opencloud#2985: purging a space must
 			// invalidate ALL of its msgpack indexes, not only the by-type index.
 			// The by-user-id index keeps a stale entry pointing at the purged
@@ -222,8 +231,10 @@ var _ = Describe("Spaces", func() {
 				// precondition: the owner's by-user-id index references the space
 				Expect(loadOwnerIndex()).To(HaveKey(spaceID))
 
-				// purge as the space owner
-				Expect(env.Fs.DeleteStorageSpace(env.Ctx, delReq)).To(Succeed())
+				// purge as an admin: since #672 space managers may disable but
+				// not purge a project space, only delete-all-spaces can.
+				adminCtx := ctxpkg.ContextSetUser(context.Background(), env.DeleteAllSpacesUser)
+				Expect(env.Fs.DeleteStorageSpace(adminCtx, delReq)).To(Succeed())
 
 				// the by-user-id index entry must be gone after the purge
 				Expect(loadOwnerIndex()).ToNot(HaveKey(spaceID))
@@ -275,9 +286,10 @@ var _ = Describe("Spaces", func() {
 				Expect(load("by-user-id", userGrantee)).To(HaveKey(spaceID))
 				Expect(load("by-group-id", groupGrantee)).To(HaveKey(spaceID))
 
-				// disable, then purge as the space owner
+				// disable as the manager, then purge as an admin (see #672)
 				Expect(env.Fs.DeleteStorageSpace(env.Ctx, &provider.DeleteStorageSpaceRequest{Id: sid})).To(Succeed())
-				Expect(env.Fs.DeleteStorageSpace(env.Ctx, &provider.DeleteStorageSpaceRequest{
+				adminCtx := ctxpkg.ContextSetUser(context.Background(), env.DeleteAllSpacesUser)
+				Expect(env.Fs.DeleteStorageSpace(adminCtx, &provider.DeleteStorageSpaceRequest{
 					Opaque: &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{"purge": {Decoder: "plain", Value: []byte("true")}}},
 					Id:     sid,
 				})).To(Succeed())
@@ -304,7 +316,9 @@ var _ = Describe("Spaces", func() {
 				}
 				Expect(loadOwnerIndex()).To(HaveKey(purgedID))
 				Expect(loadOwnerIndex()).To(HaveKey(siblingID))
-				Expect(env.Fs.DeleteStorageSpace(env.Ctx, delReq)).To(Succeed())
+				// purge as an admin (managers can no longer purge, see #672)
+				adminCtx := ctxpkg.ContextSetUser(context.Background(), env.DeleteAllSpacesUser)
+				Expect(env.Fs.DeleteStorageSpace(adminCtx, delReq)).To(Succeed())
 				after := loadOwnerIndex()
 				Expect(after).ToNot(HaveKey(purgedID))
 				Expect(after).To(HaveKey(siblingID))


### PR DESCRIPTION
## Description

Three tests in `pkg/storage/pkg/decomposedfs/spaces_test.go` (the "can delete (purge) project spaces" context) purge a project space as its owner, a space manager, and assert success:

- `removes the space from the by-user-id index`
- `removes the space from the by-user-id and by-group indexes for grantees`
- `keeps a sibling space in the by-user-id index when another is purged`

A space manager may disable a project space but not purge it; only a delete-all-spaces user may purge. `canDeleteSpace` now denies the purge, so the three tests fail on `main` with `permission denied: user is not allowed to delete space ...`.

This change purges as a delete-all-spaces user instead, the same actor the sibling `succeeds as a user with 'delete-all-spaces privilege` test already uses. It also adds the missing counterpart assertion: a space manager can still disable a project space. The change is limited to tests, with no production code change.

## Related Issue

No issue to close. This change realigns the tests with the permission model from #672. The tests were added in #695, which predated that restriction.

## Motivation and Context

The `decomposedfs` package currently fails on `main`: these three tests return `permission denied`, which blocks a clean CI run on every reva pull request. This change restores the package to passing and covers both sides of the space-manager permission, disable allowed and purge denied.

## How Has This Been Tested?

- test environment: `golang:1.25` container, source on an ext4 volume for `user.*` xattr support (the native macOS filesystem is unreliable for these decomposedfs tests)
- `go test ./pkg/storage/pkg/decomposedfs/`: red on `main` for the three tests, green with this change, including the new space-manager-disable assertion
- `gofmt`, `go vet` and `golangci-lint v2.10.1`: clean on the package

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added (n/a: reva builds the changelog from the PR title and `Type:*` label via ready-release-go, so no fragment is needed)

cc @aduffeck, familiar with both #672 and #695.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
