### PR TITLE
fix(decomposedfs): skip a space whose name attribute is unset

### DIFF
--- a/pkg/storage/pkg/decomposedfs/spaces.go
+++ b/pkg/storage/pkg/decomposedfs/spaces.go
@@ -45,6 +45,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/rgrpc/todo/pool"
 	sdk "github.com/opencloud-eu/reva/v2/pkg/sdk/common"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/lookup"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/permissions"
@@ -314,6 +315,14 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 		// try directly reading the node
 		n, err := node.ReadNode(ctx, fs.lu, spaceID, entry, "", true, nil, false) // permission to read disabled space is checked later
 		if err != nil {
+			if metadata.IsAttrUnset(err) {
+				// the node is partial, e.g. its owner/user was deleted and the name
+				// attribute is gone. treat it as non-existent instead of failing the
+				// whole listing, the same way the !n.Exists branch below does.
+				// https://github.com/opencloud-eu/opencloud/issues/1878
+				appctx.GetLogger(ctx).Debug().Err(err).Str("id", entry).Msg("node has no name attribute, treating as non-existent")
+				return spaces, nil
+			}
 			appctx.GetLogger(ctx).Error().Err(err).Str("id", entry).Msg("could not read node")
 			return nil, err
 		}
@@ -451,6 +460,14 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 				n, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, "", true, nil, true)
 				if err != nil {
+					if metadata.IsAttrUnset(err) {
+						// the node is partial, e.g. its owner/user was deleted and the
+						// name attribute is gone. skip it quietly instead of logging an
+						// error on every listing.
+						// https://github.com/opencloud-eu/opencloud/issues/1878
+						appctx.GetLogger(ctx).Debug().Err(err).Str("id", spaceID).Msg("node has no name attribute, skipping")
+						continue
+					}
 					appctx.GetLogger(ctx).Error().Err(err).Str("id", spaceID).Msg("could not read node, skipping")
 					continue
 				}

--- a/pkg/storage/pkg/decomposedfs/spaces_test.go
+++ b/pkg/storage/pkg/decomposedfs/spaces_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/spaceidindex"
 	helpers "github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/testhelpers"
@@ -153,6 +154,60 @@ var _ = Describe("Spaces", func() {
 					Id: resp[0].GetId(),
 				})
 				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		// Reproducer for opencloud-eu/opencloud#1878: a ListStorageSpaces that
+		// resolves a node whose name attribute is gone (e.g. after the owning user
+		// was deleted) must skip it, not hard-fail the whole listing with code 15
+		// ("error listing spaces") or spam an error log on every call.
+		Context("when a space node's name attribute is unset", func() {
+			// orphanSpace creates a project space and removes its name attribute, so
+			// reading it returns ENOATTR ("no data available"), the exact #1878 state.
+			orphanSpace := func(name string) *provider.StorageSpace {
+				resp, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: name, Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				root := resp.StorageSpace.GetRoot()
+				n, err := node.ReadNode(env.Ctx, env.Lookup, root.GetSpaceId(), root.GetOpaqueId(), "", true, nil, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(n.RemoveXattr(env.Ctx, prefixes.NameAttr, true)).To(Succeed())
+				return resp.StorageSpace
+			}
+
+			It("returns an empty result instead of failing for an id filter", func() {
+				space := orphanSpace("Nameless")
+				// the id filter (not the +grant type) is what routes the request into
+				// the direct-read branch; +grant mirrors the real caller from the issue.
+				filters := []*provider.ListStorageSpacesRequest_Filter{
+					{
+						Type: provider.ListStorageSpacesRequest_Filter_TYPE_ID,
+						Term: &provider.ListStorageSpacesRequest_Filter_Id{Id: &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(space.GetRoot())}},
+					},
+					{
+						Type: provider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE,
+						Term: &provider.ListStorageSpacesRequest_Filter_SpaceType{SpaceType: "+grant"},
+					},
+				}
+				spaces, err := env.Fs.ListStorageSpaces(env.Ctx, filters, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spaces).To(BeEmpty())
+			})
+
+			It("skips the unreadable space but still returns the healthy ones for a list-all", func() {
+				healthy, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: "Healthy", Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				orphan := orphanSpace("Nameless")
+
+				// list-all exercises the worker-loop path; it must skip the orphan and
+				// still return the healthy space, not truncate the whole result.
+				spaces, err := env.Fs.ListStorageSpaces(env.Ctx, nil, false)
+				Expect(err).ToNot(HaveOccurred())
+				ids := make([]string, 0, len(spaces))
+				for _, s := range spaces {
+					ids = append(ids, s.GetId().GetOpaqueId())
+				}
+				Expect(ids).To(ContainElement(healthy.StorageSpace.GetId().GetOpaqueId()))
+				Expect(ids).ToNot(ContainElement(orphan.GetId().GetOpaqueId()))
 			})
 		})
 


### PR DESCRIPTION
## Description

`ListStorageSpaces` fails when it reads a space node that has no `user.oc.name` attribute. The read returns `node.Xattr ... user.oc.name: no data available`. This state appears after the owning user is deleted while a grant still points at the node, for example after inviting an already-deleted user to a space.

Two paths in `pkg/storage/pkg/decomposedfs/spaces.go` handle that read error differently:

- direct read (an id filter): returns the error and fails the whole call with gRPC code 15 ("error listing spaces").
- worker loop: already skips the node, but logs it at error level on every listing.

The fix treats such a node as non-existent, like the adjacent `!n.Exists` branch: it matches `metadata.IsAttrUnset` and skips it. The direct read returns an empty result, the worker loop continues, and the skip is logged at debug. Other read errors are unchanged.

## Related Issue

Part of https://github.com/opencloud-eu/opencloud/issues/1878

This fixes the `storage-users` error reported there. It does not clean up the orphaned index entries, and the search service hits the same node at a separate site in the opencloud repository, so the issue is not fully resolved.

## Motivation and Context

On the list-all path the call still returns and the failure shows up only as error-log lines, repeated on every listing that reads such a node. The id-filter path also fails the call, but that resolves a share for a now-gone user. The issue reports the log noise. The fix removes it and keeps one unreadable node from failing a listing.

## How Has This Been Tested?

- reproduction: OpenCloud 7.1.0 (posix), acceptance scenario `apiSharingNgShareInvitation/shareInvitations.feature` ("send share invitation to deleted user"). The server logs the code-15 error during the run; the scenario itself passes.
- unit test in `spaces_test.go`: remove a space node's name attribute, then check that `ListStorageSpaces` returns empty for an id filter and still returns the healthy spaces for a list-all. Red on `main`, green with this change.
- with #709 applied on top, the full `decomposedfs` package passes in a `golang:1.25` container on an ext4 volume (102 specs); `gofmt`, `go vet` and `golangci-lint v2.10.1` are clean.

> [!NOTE]
> On its own, CI shows three failing `decomposedfs` purge tests until #709 merges: they broke when #695 merged on top of #672 (a semantic conflict), predate this change, and are fixed by #709. The change here is verified green on top of #709 (above), and this branch will be rebased onto green `main` after #709 merges.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added (n/a: reva builds the changelog from the PR title and `Type:*` label via ready-release-go, so no fragment is needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
