### PR TITLE
feat(gateway): implement ListContainerStream forwarding

### DIFF
--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -976,8 +977,34 @@ func (s *svc) Stat(ctx context.Context, req *provider.StatRequest) (*provider.St
 	})
 }
 
-func (s *svc) ListContainerStream(_ *provider.ListContainerStreamRequest, _ gateway.GatewayAPI_ListContainerStreamServer) error {
-	return errtypes.NotSupported("Unimplemented")
+func (s *svc) ListContainerStream(req *provider.ListContainerStreamRequest, ss gateway.GatewayAPI_ListContainerStreamServer) error {
+	c, _, ref, err := s.findAndUnwrap(ss.Context(), req.Ref)
+	if err != nil {
+		return errors.Wrap(err, "gateway: could not find space for ListContainerStream")
+	}
+
+	stream, err := c.ListContainerStream(ss.Context(), &provider.ListContainerStreamRequest{
+		Opaque:                req.Opaque,
+		Ref:                   ref,
+		ArbitraryMetadataKeys: req.ArbitraryMetadataKeys,
+		FieldMask:             req.FieldMask,
+	})
+	if err != nil {
+		return errors.Wrap(err, "gateway: error calling ListContainerStream on provider")
+	}
+
+	for {
+		res, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return errors.Wrap(err, "gateway: error receiving from ListContainerStream")
+		}
+		if err := ss.Send(res); err != nil {
+			return errors.Wrap(err, "gateway: error sending ListContainerStream response")
+		}
+	}
 }
 
 // ListContainer lists the Resoure infos for a given resource by forwarding the request to the responsible provider.


### PR DESCRIPTION
## Summary

The `ListContainerStream` gRPC RPC is defined in the CS3 API and already implemented in the storage provider, but the gateway returned `Unimplemented`. This change forwards the server-streaming RPC from the gateway to the responsible storage provider.

- Resolves the space reference via `findAndUnwrap` (same as `ListContainer`)
- Forwards all request fields (Opaque, Ref, ArbitraryMetadataKeys, FieldMask)
- Streams individual `ListContainerStreamResponse` messages back to the caller
- Same auth/permission chain as the existing unary `ListContainer`

## Motivation

Internal OpenCloud services that traverse large directories (search indexer, thumbnail generator) currently use the unary `ListContainer` which buffers all entries in memory before responding. With the streaming variant, services can start processing entries immediately and reduce memory pressure for directories with thousands of files.

## Test plan

- [x] Builds clean against current main
- [x] Verified against running OpenCloud instance: unpatched gateway returns `Unimplemented`, confirming the gap
- [ ] Integration test with search service using streaming variant

Co-Authored-By: flash <flash7777>