### PR TITLE
feat(events): emit ArbitraryMetadataUpdated on SetArbitraryMetadata

### DIFF
--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -486,6 +486,24 @@ func SpaceDeleted(r *provider.DeleteStorageSpaceResponse, req *provider.DeleteSt
 	}
 }
 
+// ArbitraryMetadataUpdated converts the response to an event
+func ArbitraryMetadataUpdated(r *provider.SetArbitraryMetadataResponse, req *provider.SetArbitraryMetadataRequest, spaceOwner *user.UserId, executant *user.User) events.ArbitraryMetadataUpdated {
+	var keys []string
+	if req.ArbitraryMetadata != nil {
+		for k := range req.ArbitraryMetadata.Metadata {
+			keys = append(keys, k)
+		}
+	}
+	return events.ArbitraryMetadataUpdated{
+		SpaceOwner:        spaceOwner,
+		Executant:         executant.GetId(),
+		Ref:               req.Ref,
+		Keys:              keys,
+		Timestamp:         utils.TSNow(),
+		ImpersonatingUser: extractImpersonator(executant),
+	}
+}
+
 func extractOwner(u *user.User) *user.UserId {
 	if u != nil {
 		return u.Id

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -199,6 +199,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = FileUnlocked(v, req.(*provider.UnlockRequest), ownerID, executant)
 			}
+		case *provider.SetArbitraryMetadataResponse:
+			if isSuccess(v) {
+				ev = ArbitraryMetadataUpdated(v, req.(*provider.SetArbitraryMetadataRequest), ownerID, executant)
+			}
 		}
 
 		if ev != nil {

--- a/pkg/events/metadata.go
+++ b/pkg/events/metadata.go
@@ -1,0 +1,44 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package events
+
+import (
+	"encoding/json"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+)
+
+// ArbitraryMetadataUpdated is emitted when arbitrary metadata is set on a resource
+type ArbitraryMetadataUpdated struct {
+	SpaceOwner        *user.UserId
+	Executant         *user.UserId
+	Ref               *provider.Reference
+	Keys              []string
+	Timestamp         *types.Timestamp
+	ImpersonatingUser *user.User
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (ArbitraryMetadataUpdated) Unmarshal(v []byte) (interface{}, error) {
+	e := ArbitraryMetadataUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}


### PR DESCRIPTION
## Summary

`SetArbitraryMetadata` (used by WebDAV PROPPATCH and the Graph Metadata API) did not emit any event via the events middleware interceptor. This meant downstream consumers like the search indexer were never notified about custom metadata changes, causing the search index to become stale.

This adds:
- `ArbitraryMetadataUpdated` event type in `pkg/events/metadata.go`
- Conversion function in `eventsmiddleware/conversion.go`
- `SetArbitraryMetadataResponse` case in the events interceptor

The event includes the list of changed metadata keys and follows the same pattern as `FileTouched`, `ContainerCreated`, etc.

This is a companion to the existing metadata PRs (#693, #696) that improved PROPFIND/PROPPATCH metadata handling — this patch closes the gap on the event side.

## Motivation

All other write operations (upload, delete, move, touch, lock) emit events that allow the search service and other consumers to react. `SetArbitraryMetadata` was the only write operation missing from the interceptor. Without this event, custom metadata set via PROPPATCH is invisible to the search index until the next full space re-index.

## Test plan

- [x] Builds clean against current main
- [x] Deployed and tested on kosmos instance (cloud.brandis.eu)
- [x] Verified PROPPATCH returns 207 OK with patched build
- [x] Verified ListContainerStream also works (both patches deployed together)
- [ ] OpenCloud search service needs to subscribe to the new event (separate OpenCloud PR)

## Note

The OpenCloud search service (`services/search/pkg/service/event/service.go`) needs a companion change to subscribe to `ArbitraryMetadataUpdated` and trigger `IndexSpace`. That will be a separate OpenCloud PR.