### PR TITLE
fix(decomposedfs): tolerate a space root with an unset name attribute

### DIFF
--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -422,8 +422,14 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		spaceRoot.Exists = true
 
 		// lookup name in extended attributes
-		spaceRoot.Name, err = spaceRoot.XattrString(ctx, prefixes.NameAttr)
-		if err != nil {
+		var name string
+		name, err = spaceRoot.XattrString(ctx, prefixes.NameAttr)
+		switch {
+		case err == nil:
+			spaceRoot.Name = name
+		case metadata.IsAttrUnset(err):
+			// ignore
+		default:
 			return nil, err
 		}
 	}

--- a/pkg/storage/pkg/decomposedfs/node/node_test.go
+++ b/pkg/storage/pkg/decomposedfs/node/node_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	ocsconv "github.com/opencloud-eu/reva/v2/pkg/conversions"
 	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 	helpers "github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/testhelpers"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/grants"
@@ -80,6 +81,21 @@ var _ = Describe("Node", func() {
 			n, err := node.ReadNode(env.Ctx, env.Lookup, lookupNode.SpaceID, lookupNode.ID, "", false, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n.BlobID).To(Equal("file1-blobid"))
+		})
+
+		It("treats a space root with an unset name attribute as nameless instead of failing", func() {
+			spaceRoot, err := env.Lookup.NodeFromSpaceID(env.Ctx, env.SpaceRootRes.SpaceId)
+			Expect(err).ToNot(HaveOccurred())
+
+			// simulate a half-deleted space root whose name attribute is gone
+			err = spaceRoot.RemoveXattr(env.Ctx, prefixes.NameAttr, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			n, err := node.ReadNode(env.Ctx, env.Lookup, spaceRoot.SpaceID, spaceRoot.ID, "", false, nil, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n).ToNot(BeNil())
+			Expect(n.Exists).To(BeTrue())
+			Expect(n.Name).To(Equal(""))
 		})
 	})
 


### PR DESCRIPTION
## Description

`ReadNode` fails when a space root has no `user.oc.name` attribute, which happens for a half-deleted user space (the node lingers after the name attribute is gone). Reading the name returns ENODATA and aborts the read, which surfaces to the caller as code 15. The fix swallows the unset-name case in `readNode` the same way the owner lookup just above already does: match `metadata.IsAttrUnset` and keep the empty name. Any other read error still propagates.

## Related Issue

Part of https://github.com/opencloud-eu/opencloud/issues/1878

It stops the read crash for every `ReadNode` caller but does not clean up the orphaned index entries the half-deletion leaves behind, so it does not fully resolve the issue.

## Motivation and Context

Two paths stat a space root through `ReadNode` and hit the failure: the search indexer's tree walk, which logs `error while indexing a space` on every pass, and `ListStorageSpaces`, which fails a listing by id outright. Fixing `ReadNode` at the root covers both, plus every other caller. `StorageSpaceFromNode` already tolerates a missing name downstream, so the nameless space flows through without a second failure.

## How Has This Been Tested?

- `node_test.go`: strip a space root's name attribute, `ReadNode` it, assert it returns the node with an empty name and `Exists == true` instead of erroring. Red without the change (the exact `user.oc.name: no data available`), green with it.
- `decomposedfs/node` package green in a `golang:1.25` container on ext4; `gofmt`, `go vet`, `golangci-lint v2.10.1` clean.
- e2e: after the `shareInvitations.feature` "deleted user" scenario, the `error while indexing a space` log lines drop from 4 to 0 on a patched build.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added (n/a: reva builds the changelog from the PR title and `Type:*` label via ready-release-go, so no fragment is needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
