### PR TITLE
fix: retry xattr.List on ERANGE/E2BIG

### DIFF
--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -176,6 +176,9 @@ func New(lu node.PathLookup, bs node.Blobstore, um usermapper.Mapper, trashbin *
 			watchPath = o.Root
 		}
 
+		if o.ScanDebounceDelay == 0 {
+			log.Warn().Msg("'scan_debounce_delay' is set to 0. This is not recommended for production setups.")
+		}
 		go t.watcher.Watch(watchPath)
 		go t.workScanQueue()
 	}

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -114,7 +114,7 @@ func (b HybridBackend) list(ctx context.Context, n MetadataNode) (attribs []stri
 		return nil, &xattr.Error{Op: "HybridBackend.list", Path: n.InternalPath(), Err: syscall.ENOENT} // attribute not found
 	}
 
-	return xattr.List(filePath)
+	return listXattr(filePath)
 }
 
 // All reads all extended attributes for a node, protected by a

--- a/pkg/storage/pkg/decomposedfs/metadata/list.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/list.go
@@ -1,0 +1,66 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/pkg/xattr"
+)
+
+// maxListXattrRetries bounds the number of attempts made by listXattr when it
+// keeps racing with a concurrent writer.
+const maxListXattrRetries = 10
+
+// listXattr lists the extended attribute names of the file at path, retrying on
+// transient ERANGE/E2BIG errors.
+//
+// xattr.List is not atomic: internally it issues a listxattr syscall to learn
+// the size of the extended-attribute name list, allocates a buffer of that
+// size and issues a second listxattr to read the names into it. If another
+// goroutine or process adds an extended attribute to the same inode between the
+// two syscalls, the name list grows beyond the buffer and the kernel returns
+// ERANGE ("numerical result out of range") (or E2BIG on some filesystems).
+//
+// This is a transient condition: a fresh size query on the next attempt
+// reflects the new size, so we simply retry a bounded number of times. See the
+// posix fs watcher, whose assimilation can read a node's xattrs while the node
+// is still being created, for a concrete source of such concurrent writes.
+func listXattr(path string) ([]string, error) {
+	var (
+		attrs []string
+		err   error
+	)
+	for i := 0; i < maxListXattrRetries; i++ {
+		attrs, err = xattr.List(path)
+		if err == nil || !isRangeError(err) {
+			return attrs, err
+		}
+	}
+	return attrs, err
+}
+
+// isRangeError reports whether err is a transient listxattr "buffer too small"
+// error (ERANGE or E2BIG) caused by the name list growing concurrently.
+func isRangeError(err error) bool {
+	var xerr *xattr.Error
+	if errors.As(err, &xerr) {
+		if serr, ok := xerr.Err.(syscall.Errno); ok {
+			return serr == syscall.ERANGE || serr == syscall.E2BIG
+		}
+	}
+	return false
+}

--- a/pkg/storage/pkg/decomposedfs/metadata/list.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/list.go
@@ -1,16 +1,5 @@
 // Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package metadata
 

--- a/pkg/storage/pkg/decomposedfs/metadata/list_internal_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/list_internal_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/xattr"
+)
+
+var _ = Describe("listXattr", func() {
+	Describe("isRangeError", func() {
+		It("reports ERANGE as a range error", func() {
+			Expect(isRangeError(&xattr.Error{Op: "xattr.list", Err: syscall.ERANGE})).To(BeTrue())
+		})
+
+		It("reports E2BIG as a range error", func() {
+			Expect(isRangeError(&xattr.Error{Op: "xattr.list", Err: syscall.E2BIG})).To(BeTrue())
+		})
+
+		It("does not report ENOENT as a range error", func() {
+			Expect(isRangeError(&xattr.Error{Op: "xattr.list", Err: syscall.ENOENT})).To(BeFalse())
+		})
+
+		It("does not report a nil error as a range error", func() {
+			Expect(isRangeError(nil)).To(BeFalse())
+		})
+	})
+
+	// xattr.List is non-atomic (a listxattr size query followed by a read into a
+	// buffer sized from that query), so a concurrent write that grows the name
+	// list makes the raw call return ERANGE. The wrapper must retry and never
+	// surface that transient error.
+	It("survives a concurrent writer that grows the attribute name list", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "f")
+		Expect(os.WriteFile(path, nil, 0600)).To(Succeed())
+
+		if err := xattr.Set(path, "user.seed", []byte("1")); err != nil {
+			Skip(fmt.Sprintf("extended attributes not supported on %s: %v", dir, err))
+		}
+
+		stop := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				key := fmt.Sprintf("user.k%d", i%16)
+				if i%2 == 0 {
+					_ = xattr.Set(path, key, []byte("value"))
+				} else {
+					_ = xattr.Remove(path, key)
+				}
+			}
+		}()
+		defer func() {
+			close(stop)
+			wg.Wait()
+		}()
+
+		for i := 0; i < 20000; i++ {
+			_, err := listXattr(path)
+			Expect(err).ToNot(HaveOccurred(), "listXattr must retry transient ERANGE from concurrent writes")
+		}
+	})
+})

--- a/pkg/storage/pkg/decomposedfs/metadata/list_internal_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/list_internal_test.go
@@ -1,16 +1,5 @@
 // Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package metadata
 

--- a/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
@@ -89,7 +89,7 @@ func (b XattrsBackend) GetInt64(ctx context.Context, n MetadataNode, key string)
 
 func (b XattrsBackend) list(ctx context.Context, n MetadataNode, acquireLock bool) (attribs []string, err error) {
 	filePath := n.InternalPath()
-	attrs, err := xattr.List(filePath)
+	attrs, err := listXattr(filePath)
 	if err == nil {
 		return attrs, nil
 	}
@@ -104,7 +104,7 @@ func (b XattrsBackend) list(ctx context.Context, n MetadataNode, acquireLock boo
 		defer f.Close()
 
 	}
-	return xattr.List(filePath)
+	return listXattr(filePath)
 }
 
 // All reads all extended attributes for a node, protected by a


### PR DESCRIPTION
xattr.List is not atomic: it issues one listxattr syscall to size the name list, then a second to read it into a buffer sized from the first. If a concurrent writer adds an extended attribute between the two calls, the second listxattr overflows the buffer and the kernel returns ERANGE ("numerical result out of range"). The posix fs watcher hits this when it assimilates a node while it is still being created, surfacing as random test failures and failed assimilations.

Wrap xattr.List in listXattr, which retries on these transient range errors, and use it in the hybrid and xattrs backends.
