### PR TITLE
Sync uploads incrementally to avoid fsync freezes

### DIFF
--- a/pkg/storage/fs/posix/blobstore/blobstore.go
+++ b/pkg/storage/fs/posix/blobstore/blobstore.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,12 +43,15 @@ const (
 // Blobstore provides an interface to an filesystem based blobstore
 type Blobstore struct {
 	root string
+
+	canUseRenameForUpload bool
 }
 
 // New returns a new Blobstore
 func New(root string) (*Blobstore, error) {
 	return &Blobstore{
-		root: root,
+		root:                  root,
+		canUseRenameForUpload: true, // let's assume the upload area is on the same device as the blobstore root by default
 	}, nil
 }
 
@@ -61,29 +65,44 @@ func (bs *Blobstore) Upload(n *node.Node, source, copyTarget string) error {
 		return err
 	}
 
-	sourceFile, err := os.Open(source)
-	if err != nil {
-		return fmt.Errorf("failed to open source file '%s': %v", source, err)
-	}
-	defer func() {
-		_ = sourceFile.Close()
-	}()
-
-	tempFile, err := os.OpenFile(tempName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("unable to create temp file '%s': %v", tempName, err)
-	}
-
-	if _, err := tempFile.ReadFrom(sourceFile); err != nil {
-		return fmt.Errorf("failed to write data from source file '%s' to temp file '%s' - %v", source, tempName, err)
+	if bs.canUseRenameForUpload {
+		err := os.Rename(source, tempName)
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, syscall.EXDEV):
+			// the upload and target file are on different devices, we need to copy the file instead of renaming it
+			bs.canUseRenameForUpload = false
+		default:
+			return fmt.Errorf("failed to move source file '%s' to temp file '%s' - %v", source, tempName, err)
+		}
 	}
 
-	if err := tempFile.Sync(); err != nil {
-		return fmt.Errorf("failed to sync temp file '%s' - %v", tempName, err)
-	}
+	if !bs.canUseRenameForUpload {
+		sourceFile, err := os.Open(source)
+		if err != nil {
+			return fmt.Errorf("failed to open source file '%s': %v", source, err)
+		}
+		defer func() {
+			_ = sourceFile.Close()
+		}()
 
-	if err := tempFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file '%s' - %v", tempName, err)
+		tempFile, err := os.OpenFile(tempName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+		if err != nil {
+			return fmt.Errorf("unable to create temp file '%s': %v", tempName, err)
+		}
+
+		if _, err := tempFile.ReadFrom(sourceFile); err != nil {
+			return fmt.Errorf("failed to write data from source file '%s' to temp file '%s' - %v", source, tempName, err)
+		}
+
+		if err := tempFile.Sync(); err != nil {
+			return fmt.Errorf("failed to sync temp file '%s' - %v", tempName, err)
+		}
+
+		if err := tempFile.Close(); err != nil {
+			return fmt.Errorf("failed to close temp file '%s' - %v", tempName, err)
+		}
 	}
 
 	nodeAttributes, err := n.Xattrs(context.Background())
@@ -137,11 +156,15 @@ func (bs *Blobstore) Upload(n *node.Node, source, copyTarget string) error {
 	}
 
 	// also "upload" the file to a local path, e.g., for keeping the "current" version of the file
-	if err := os.MkdirAll(filepath.Dir(copyTarget), 0700); err != nil {
-		return err
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "could not open source file '%s' for reading", source)
 	}
+	defer func() {
+		_ = sourceFile.Close()
+	}()
 
-	if _, err := sourceFile.Seek(0, 0); err != nil {
+	if err := os.MkdirAll(filepath.Dir(copyTarget), 0700); err != nil {
 		return err
 	}
 

--- a/pkg/storage/fs/posix/blobstore/blobstore.go
+++ b/pkg/storage/fs/posix/blobstore/blobstore.go
@@ -32,12 +32,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/disk"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 )
 
 const (
-	TMPDir = ".oc-tmp"
+	TMPDir     = ".oc-tmp"
+	fsyncEvery = 16 << 20 // 16 MiB
 )
 
 // Blobstore provides an interface to an filesystem based blobstore
@@ -92,12 +94,8 @@ func (bs *Blobstore) Upload(n *node.Node, source, copyTarget string) error {
 			return fmt.Errorf("unable to create temp file '%s': %v", tempName, err)
 		}
 
-		if _, err := tempFile.ReadFrom(sourceFile); err != nil {
-			return fmt.Errorf("failed to write data from source file '%s' to temp file '%s' - %v", source, tempName, err)
-		}
-
-		if err := tempFile.Sync(); err != nil {
-			return fmt.Errorf("failed to sync temp file '%s' - %v", tempName, err)
+		if err := copyWithPeriodicSync(tempFile, sourceFile); err != nil {
+			return fmt.Errorf("failed to copy source file '%s' to temp file '%s' - %v", source, tempName, err)
 		}
 
 		if err := tempFile.Close(); err != nil {
@@ -176,7 +174,7 @@ func (bs *Blobstore) Upload(n *node.Node, source, copyTarget string) error {
 		_ = copyFile.Close()
 	}()
 
-	if _, err := copyFile.ReadFrom(sourceFile); err != nil {
+	if err := copyWithPeriodicSync(copyFile, sourceFile); err != nil {
 		return errors.Wrapf(err, "could not write blob copy of '%s' to '%s'", n.InternalPath(), copyTarget)
 	}
 
@@ -195,4 +193,22 @@ func (bs *Blobstore) Download(node *node.Node) (io.ReadCloser, error) {
 // Delete deletes a blob from the blobstore
 func (bs *Blobstore) Delete(node *node.Node) error {
 	return nil
+}
+
+func copyWithPeriodicSync(dst, src *os.File) error {
+	for {
+		n, err := io.CopyN(dst, src, fsyncEvery)
+		if n > 0 {
+			if serr := disk.Fdatasync(dst); serr != nil {
+				return serr
+			}
+		}
+		if err == io.EOF {
+			_ = dst.Sync()
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
 }

--- a/pkg/storage/fs/posix/blobstore/blobstore_copy_fallback_test.go
+++ b/pkg/storage/fs/posix/blobstore/blobstore_copy_fallback_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package blobstore_test
+
+import (
+	"crypto/rand"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	posixblobstore "github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/blobstore"
+	posixhelpers "github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/testhelpers"
+)
+
+var _ = Describe("Blobstore with copy fallback", func() {
+	var (
+		env *posixhelpers.TestEnv
+		bs  *posixblobstore.Blobstore
+	)
+
+	BeforeEach(func() {
+		var err error
+		env, err = posixhelpers.NewTestEnv(map[string]interface{}{})
+		Expect(err).ToNot(HaveOccurred())
+
+		bs, err = posixblobstore.New(env.Root)
+		Expect(err).ToNot(HaveOccurred())
+
+		// force the copy-based upload path, as if the upload area and the
+		// blobstore root were on different devices
+		bs.SetCanUseRenameForUpload(false)
+	})
+
+	AfterEach(func() {
+		env.Cleanup()
+	})
+
+	DescribeTable("stores the blob using the copy fallback",
+		func(size int) {
+			n, err := env.CreateTestFile("blob.bin", "", env.SpaceRootRes.OpaqueId, env.SpaceRootRes.SpaceId, int64(size))
+			Expect(err).ToNot(HaveOccurred())
+
+			data := make([]byte, size)
+			_, err = rand.Read(data)
+			Expect(err).ToNot(HaveOccurred())
+
+			source := filepath.Join(env.Root, "upload-source")
+			Expect(os.WriteFile(source, data, 0600)).To(Succeed())
+
+			Expect(bs.Upload(n, source, "")).To(Succeed())
+
+			written, err := os.ReadFile(n.InternalPath())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(written).To(Equal(data))
+		},
+		Entry("small file", 1024),
+		Entry("large file bigger than the 16MiB fsync window", 17<<20),
+	)
+})

--- a/pkg/storage/fs/posix/blobstore/export_test.go
+++ b/pkg/storage/fs/posix/blobstore/export_test.go
@@ -1,0 +1,11 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package blobstore
+
+// SetCanUseRenameForUpload is a test-only seam that forces the upload code path.
+// When set to false, Upload uses the copy-with-periodic-sync fallback instead of
+// renaming the source into place.
+func (bs *Blobstore) SetCanUseRenameForUpload(v bool) {
+	bs.canUseRenameForUpload = v
+}

--- a/pkg/storage/pkg/decomposedfs/disk/disk_fallback.go
+++ b/pkg/storage/pkg/decomposedfs/disk/disk_fallback.go
@@ -1,0 +1,12 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux && !freebsd && !darwin
+
+package disk
+
+import "os"
+
+func Fdatasync(f *os.File) error {
+	return nil
+}

--- a/pkg/storage/pkg/decomposedfs/disk/disk_linux.go
+++ b/pkg/storage/pkg/decomposedfs/disk/disk_linux.go
@@ -1,0 +1,15 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package disk
+
+import (
+	"os"
+	"syscall"
+)
+
+func Fdatasync(f *os.File) error {
+	return syscall.Fdatasync(int(f.Fd()))
+}

--- a/pkg/storage/pkg/decomposedfs/disk/disk_unix.go
+++ b/pkg/storage/pkg/decomposedfs/disk/disk_unix.go
@@ -1,0 +1,12 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build freebsd || darwin
+
+package disk
+
+import "os"
+
+func Fdatasync(file *os.File) error {
+	return file.Sync()
+}

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -46,6 +46,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/events"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp/datatx/utils/download"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/disk"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
@@ -74,7 +75,7 @@ func (session *DecomposedFsSession) WriteChunk(ctx context.Context, _ int64, src
 		// sync the written chunk to disk. This ensures that the upload can be resumed,
 		// and helps to prevent issues with filesystem/journal freezes at the end of the upload
 		// when commiting a large fsync operation on slow disks.
-		_ = file.Sync()
+		_ = disk.Fdatasync(file)
 		_ = file.Close()
 	}()
 

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -71,6 +71,10 @@ func (session *DecomposedFsSession) WriteChunk(ctx context.Context, _ int64, src
 		return 0, err
 	}
 	defer func() {
+		// sync the written chunk to disk. This ensures that the upload can be resumed,
+		// and helps to prevent issues with filesystem/journal freezes at the end of the upload
+		// when commiting a large fsync operation on slow disks.
+		_ = file.Sync()
 		_ = file.Close()
 	}()
 

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -74,7 +74,7 @@ func (session *DecomposedFsSession) WriteChunk(ctx context.Context, _ int64, src
 	defer func() {
 		// sync the written chunk to disk. This ensures that the upload can be resumed,
 		// and helps to prevent issues with filesystem/journal freezes at the end of the upload
-		// when commiting a large fsync operation on slow disks.
+		// when committing a large fsync operation on slow disks.
 		_ = disk.Fdatasync(file)
 		_ = file.Close()
 	}()


### PR DESCRIPTION
This PR improves how data is written into the upload area and the posixfs blobstore, avoiding large Fsync freezes with large files/slow disks.

Instead of relying on the OS dirty page handling - which can lead to filesystem/journal freezes in certain setups - each TUS chunk is now fdatasynced as soon as it arrives, spreading the write-out over the course of the upload.

Moving the uploaded file into the posixfs tree now tries to use `os.Rename` first, avoiding the copy-and-delete entirely where possible. When the rename fails because it would cross a device boundary it falls back to the previous copy-and-delete behavior again. The fallback copy also syncs the files to disk periodically to avoid the freezese.

Fixes opencloud-eu/opencloud#3027