### PR TITLE
Fix Metadata locking and Reading for decomposedfs and align defaults with OpenCloud

### DIFF
--- a/pkg/storage/fs/posix/lookup/lookup.go
+++ b/pkg/storage/fs/posix/lookup/lookup.go
@@ -404,22 +404,6 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 // of the read unless the caller already holds it (src.LockHeld()), and the target is write
 // locked while its attributes are written unless the caller already holds its lock
 func (lu *Lookup) CopyMetadata(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool)) (err error) {
-	if !src.LockHeld() {
-		// lock the source node before reading its metadata
-		unlock, lerr := lu.MetadataBackend().Lock(src)
-		if lerr != nil {
-			return errors.Wrap(lerr, "posix: Unable to lock source to read")
-		}
-		defer func() {
-			rerr := unlock()
-
-			// if err is non nil we do not overwrite that
-			if err == nil {
-				err = rerr
-			}
-		}()
-	}
-
 	attrs, err := lu.metadataBackend.All(ctx, src)
 	if err != nil {
 		return err

--- a/pkg/storage/fs/posix/lookup/lookup.go
+++ b/pkg/storage/fs/posix/lookup/lookup.go
@@ -41,7 +41,6 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/usermapper"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/templates"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -400,21 +399,16 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 
 // CopyMetadata copies all extended attributes from source to target.
 // The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, a shared lock is acquired.
+// For the source file, the metadata lock is acquired for the duration of the copy.
 // NOTE: target resource will be write locked!
 func (lu *Lookup) CopyMetadata(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	// Acquire a read log on the source node
-	// write lock existing node before reading treesize or tree time
-	lock, err := lockedfile.OpenFile(lu.MetadataBackend().LockfilePath(src), os.O_RDONLY|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-
+	// lock the source node before reading its metadata
+	unlock, err := lu.MetadataBackend().Lock(src)
 	if err != nil {
 		return errors.Wrap(err, "xattrs: Unable to lock source to read")
 	}
 	defer func() {
-		rerr := lock.Close()
+		rerr := unlock()
 
 		// if err is non nil we do not overwrite that
 		if err == nil {
@@ -422,22 +416,16 @@ func (lu *Lookup) CopyMetadata(ctx context.Context, src, target metadata.Metadat
 		}
 	}()
 
-	return lu.CopyMetadataWithSourceLock(ctx, src, target, filter, lock, acquireTargetLock)
+	return lu.CopyMetadataWithSourceLock(ctx, src, target, filter, acquireTargetLock)
 }
 
 // CopyMetadataWithSourceLock copies all extended attributes from source to target.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, a matching lockedfile is required.
-// NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), lockedSource *lockedfile.File, acquireTargetLock bool) (err error) {
-	switch {
-	case lockedSource == nil:
-		return errors.New("no lock provided")
-	case lockedSource.Name() != lu.MetadataBackend().LockfilePath(src):
-		return errors.New("lockpath does not match filepath")
-	}
-
-	attrs, err := lu.metadataBackend.AllWithLockedSource(ctx, src, lockedSource)
+// The caller MUST already hold the source node's metadata lock (e.g. via
+// MetadataBackend().Lock); the source attributes are read without re-acquiring it.
+// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix.
+// NOTE: target resource will be write locked when acquireTargetLock is set!
+func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
+	attrs, err := lu.metadataBackend.AllWhileLocked(ctx, src)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/posix/lookup/lookup.go
+++ b/pkg/storage/fs/posix/lookup/lookup.go
@@ -397,35 +397,30 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 	}, nil
 }
 
-// CopyMetadata copies all extended attributes from source to target.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, the metadata lock is acquired for the duration of the copy.
-// NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadata(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	// lock the source node before reading its metadata
-	unlock, err := lu.MetadataBackend().Lock(src)
-	if err != nil {
-		return errors.Wrap(err, "xattrs: Unable to lock source to read")
-	}
-	defer func() {
-		rerr := unlock()
-
-		// if err is non nil we do not overwrite that
-		if err == nil {
-			err = rerr
+// CopyMetadata copies all extended attributes from source to target. The optional filter
+// function can be used to filter by attribute name, e.g. by checking a prefix.
+//
+// Locking is derived from the nodes: the source's metadata lock is acquired for the duration
+// of the read unless the caller already holds it (src.LockHeld()), and the target is write
+// locked while its attributes are written unless the caller already holds its lock
+func (lu *Lookup) CopyMetadata(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool)) (err error) {
+	if !src.LockHeld() {
+		// lock the source node before reading its metadata
+		unlock, lerr := lu.MetadataBackend().Lock(src)
+		if lerr != nil {
+			return errors.Wrap(lerr, "posix: Unable to lock source to read")
 		}
-	}()
+		defer func() {
+			rerr := unlock()
 
-	return lu.CopyMetadataWithSourceLock(ctx, src, target, filter, acquireTargetLock)
-}
+			// if err is non nil we do not overwrite that
+			if err == nil {
+				err = rerr
+			}
+		}()
+	}
 
-// CopyMetadataWithSourceLock copies all extended attributes from source to target.
-// The caller MUST already hold the source node's metadata lock (e.g. via
-// MetadataBackend().Lock); the source attributes are read without re-acquiring it.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix.
-// NOTE: target resource will be write locked when acquireTargetLock is set!
-func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, src, target metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	attrs, err := lu.metadataBackend.AllWhileLocked(ctx, src)
+	attrs, err := lu.metadataBackend.All(ctx, src)
 	if err != nil {
 		return err
 	}
@@ -441,7 +436,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, src, target me
 		newAttrs[attrName] = val
 	}
 
-	return lu.MetadataBackend().SetMultiple(ctx, target, newAttrs, acquireTargetLock)
+	return lu.MetadataBackend().SetMultiple(ctx, target, newAttrs)
 }
 
 // GenerateSpaceID generates a space id for the given space type and owner

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -418,7 +418,7 @@ func (t *TestEnv) CreateTestFile(name, blobID, parentID, spaceID string, blobSiz
 	}
 	attrs := n.NodeMetadata(t.Ctx)
 	attrs.SetString(prefixes.IDAttr, n.ID)
-	err = n.SetXattrs(attrs, true)
+	err = n.SetXattrs(attrs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/fs/posix/timemanager/timemanager.go
+++ b/pkg/storage/fs/posix/timemanager/timemanager.go
@@ -68,7 +68,7 @@ func (m *Manager) TMTime(ctx context.Context, n *node.Node) (time.Time, error) {
 // If tmtime is nil, the tmtime attribute is removed.
 func (m *Manager) SetTMTime(ctx context.Context, n *node.Node, tmtime *time.Time) error {
 	if tmtime == nil {
-		return n.RemoveXattr(ctx, prefixes.TreeMTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.TreeMTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.TreeMTimeAttr, tmtime.UTC().Format(time.RFC3339Nano))
 }
@@ -113,7 +113,7 @@ func (m *Manager) DTime(ctx context.Context, n *node.Node) (tmTime time.Time, er
 // If t is nil, the dtime attribute is removed.
 func (m *Manager) SetDTime(ctx context.Context, n *node.Node, t *time.Time) (err error) {
 	if t == nil {
-		return n.RemoveXattr(ctx, prefixes.DTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.DTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.DTimeAttr, t.UTC().Format(time.RFC3339Nano))
 }

--- a/pkg/storage/fs/posix/trashbin/trashbin.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin.go
@@ -40,6 +40,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/lookup"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/options"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/internal/goroutinelock"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
@@ -63,10 +64,10 @@ type Trashbin struct {
 
 // trashNode is a helper struct to make trash items available for manipulation in the metadata backend
 type trashNode struct {
-	spaceID  string
-	id       string
-	path     string
-	lockHeld bool
+	spaceID string
+	id      string
+	path    string
+	lock    goroutinelock.Lock
 }
 
 func (tn *trashNode) GetSpaceID() string {
@@ -82,11 +83,15 @@ func (tn *trashNode) InternalPath() string {
 }
 
 func (tn *trashNode) LockHeld() bool {
-	return tn.lockHeld
+	return tn.lock.Held()
 }
 
 func (tn *trashNode) SetLockHeld(held bool) {
-	tn.lockHeld = held
+	if held {
+		tn.lock.Hold()
+		return
+	}
+	tn.lock.Release()
 }
 
 const (

--- a/pkg/storage/fs/posix/trashbin/trashbin.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin.go
@@ -63,9 +63,10 @@ type Trashbin struct {
 
 // trashNode is a helper struct to make trash items available for manipulation in the metadata backend
 type trashNode struct {
-	spaceID string
-	id      string
-	path    string
+	spaceID  string
+	id       string
+	path     string
+	lockHeld bool
 }
 
 func (tn *trashNode) GetSpaceID() string {
@@ -78,6 +79,14 @@ func (tn *trashNode) GetID() string {
 
 func (tn *trashNode) InternalPath() string {
 	return tn.path
+}
+
+func (tn *trashNode) LockHeld() bool {
+	return tn.lockHeld
+}
+
+func (tn *trashNode) SetLockHeld(held bool) {
+	tn.lockHeld = held
 }
 
 const (
@@ -345,7 +354,7 @@ func (tb *Trashbin) RestoreRecycleItem(ctx context.Context, spaceID string, key,
 	if err = tb.lu.MetadataBackend().SetMultiple(ctx, trashedNode, map[string][]byte{
 		prefixes.NameAttr:     []byte(filepath.Base(restorePath)),
 		prefixes.ParentidAttr: []byte(parentID),
-	}, true); err != nil {
+	}); err != nil {
 		return nil, fmt.Errorf("posixfs: failed to update trashed node metadata: %w", err)
 	}
 

--- a/pkg/storage/fs/posix/trashbin/trashbin_test.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin_test.go
@@ -72,7 +72,7 @@ func TestTrashbin_RestoreRecycleItem(t *testing.T) {
 			return "", "parentID", "", time.Time{}, nil
 		}).Once()
 
-		backend.EXPECT().SetMultiple(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ metadata.MetadataNode, m map[string][]byte, _ bool) error {
+		backend.EXPECT().SetMultiple(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ metadata.MetadataNode, m map[string][]byte) error {
 			nameAttr, ok := m[prefixes.NameAttr]
 			assert.True(t, ok)
 			assert.Equal(t, nameAttr, []byte("basename"))
@@ -102,7 +102,7 @@ func TestTrashbin_RestoreRecycleItem(t *testing.T) {
 			return "", "parentID", "", time.Time{}, nil
 		}).Once()
 
-		backend.EXPECT().SetMultiple(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ metadata.MetadataNode, m map[string][]byte, _ bool) error {
+		backend.EXPECT().SetMultiple(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ metadata.MetadataNode, m map[string][]byte) error {
 			nameAttr, ok := m[prefixes.NameAttr]
 			assert.True(t, ok)
 			assert.Equal(t, nameAttr, []byte("BASENAME (1)"))

--- a/pkg/storage/fs/posix/trashbin/trashbin_whitebox_test.go
+++ b/pkg/storage/fs/posix/trashbin/trashbin_whitebox_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package trashbin
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTrashbinWhitebox(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Trashbin Whitebox Suite")
+}
+
+var _ = Describe("trashNode", func() {
+	It("keeps LockHeld scoped to the owning goroutine", func() {
+		n := &trashNode{spaceID: "space", id: "node", path: "/tmp/node"}
+
+		// The owning goroutine takes the lock.
+		n.SetLockHeld(true)
+		Expect(n.LockHeld()).To(BeTrue())
+
+		// A different goroutine must not observe the same instance as lock-held.
+		otherObservedHeld := make(chan bool, 1)
+		go func() {
+			otherObservedHeld <- n.LockHeld()
+		}()
+		Expect(<-otherObservedHeld).To(BeFalse())
+
+		// Releasing in the owning goroutine clears ownership.
+		n.SetLockHeld(false)
+		Expect(n.LockHeld()).To(BeFalse())
+	})
+})

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -714,7 +714,7 @@ assimilate:
 		}
 	}
 
-	attrs, err := t.lookup.MetadataBackend().AllWithLockedSource(context.Background(), bn, nil)
+	attrs, err := t.lookup.MetadataBackend().AllWhileLocked(context.Background(), bn)
 	if err != nil && !metadata.IsAttrUnset(err) {
 		return nil, nil, errors.Wrap(err, "failed to get item attribs")
 	}

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -42,6 +42,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/events"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/fs/posix/watcher"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/internal/goroutinelock"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
@@ -69,10 +70,10 @@ type queueItem struct {
 const dirtyFlag = prefixes.OcPrefix + "dirty"
 
 type assimilationNode struct {
-	path     string
-	nodeId   string
-	spaceID  string
-	lockHeld bool
+	path    string
+	nodeId  string
+	spaceID string
+	lock    goroutinelock.Lock
 }
 
 func (d assimilationNode) GetID() string {
@@ -88,11 +89,15 @@ func (d assimilationNode) InternalPath() string {
 }
 
 func (d *assimilationNode) LockHeld() bool {
-	return d.lockHeld
+	return d.lock.Held()
 }
 
 func (d *assimilationNode) SetLockHeld(held bool) {
-	d.lockHeld = held
+	if held {
+		d.lock.Hold()
+		return
+	}
+	d.lock.Release()
 }
 
 // NewScanDebouncer returns a new SpaceDebouncer instance

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -69,9 +69,10 @@ type queueItem struct {
 const dirtyFlag = prefixes.OcPrefix + "dirty"
 
 type assimilationNode struct {
-	path    string
-	nodeId  string
-	spaceID string
+	path     string
+	nodeId   string
+	spaceID  string
+	lockHeld bool
 }
 
 func (d assimilationNode) GetID() string {
@@ -84,6 +85,14 @@ func (d assimilationNode) GetSpaceID() string {
 
 func (d assimilationNode) InternalPath() string {
 	return d.path
+}
+
+func (d *assimilationNode) LockHeld() bool {
+	return d.lockHeld
+}
+
+func (d *assimilationNode) SetLockHeld(held bool) {
+	d.lockHeld = held
 }
 
 // NewScanDebouncer returns a new SpaceDebouncer instance
@@ -673,7 +682,8 @@ func (t *Tree) assimilate(item scanItem) error {
 func (t *Tree) updateFile(path, id, spaceID string, fi fs.FileInfo) (fs.FileInfo, node.Attributes, error) {
 	retries := 1
 	parentID := ""
-	bn := assimilationNode{spaceID: spaceID, nodeId: id, path: path}
+	bn := &assimilationNode{spaceID: spaceID, nodeId: id, path: path}
+	bn.SetLockHeld(true)
 assimilate:
 	if id != spaceID {
 		// read parent
@@ -714,7 +724,7 @@ assimilate:
 		}
 	}
 
-	attrs, err := t.lookup.MetadataBackend().AllWhileLocked(context.Background(), bn)
+	attrs, err := t.lookup.MetadataBackend().All(context.Background(), bn)
 	if err != nil && !metadata.IsAttrUnset(err) {
 		return nil, nil, errors.Wrap(err, "failed to get item attribs")
 	}
@@ -788,6 +798,8 @@ assimilate:
 		go func() {
 			// Copy the previous current version to a revision
 			currentNode := node.NewBaseNode(n.SpaceID, n.ID+node.CurrentIDDelimiter, t.lookup)
+			currentNode.SetLockHeld(true)
+
 			currentPath := currentNode.InternalPath()
 			stat, err := os.Stat(currentPath)
 			if err == nil {
@@ -834,7 +846,7 @@ assimilate:
 					attributeName == prefixes.TypeAttr ||
 					attributeName == prefixes.BlobIDAttr ||
 					attributeName == prefixes.BlobsizeAttr
-			}, false)
+			})
 			if err != nil {
 				t.log.Error().Err(err).Str("currentPath", currentPath).Str("path", path).Msg("failed to copy xattrs to 'current' file")
 				return
@@ -848,7 +860,7 @@ assimilate:
 	}
 
 	t.log.Debug().Str("path", path).Interface("attributes", attributes).Msg("setting attributes")
-	err = t.lookup.MetadataBackend().SetMultiple(context.Background(), bn, attributes, false)
+	err = t.lookup.MetadataBackend().SetMultiple(context.Background(), bn, attributes)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to set attributes")
 	}
@@ -856,7 +868,7 @@ assimilate:
 	// clear the status attribute if it was set before, if there was any upload to this file in progress
 	// it needs notice that this file was changes meanwhile.
 	if _, ok := previousAttribs[prefixes.StatusPrefix]; ok {
-		err = t.lookup.MetadataBackend().Remove(context.Background(), bn, prefixes.StatusPrefix, false)
+		err = t.lookup.MetadataBackend().Remove(context.Background(), bn, prefixes.StatusPrefix)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to clear status attribute")
 		}

--- a/pkg/storage/fs/posix/tree/assimilation.go
+++ b/pkg/storage/fs/posix/tree/assimilation.go
@@ -76,15 +76,15 @@ type assimilationNode struct {
 	lock    goroutinelock.Lock
 }
 
-func (d assimilationNode) GetID() string {
+func (d *assimilationNode) GetID() string {
 	return d.nodeId
 }
 
-func (d assimilationNode) GetSpaceID() string {
+func (d *assimilationNode) GetSpaceID() string {
 	return d.spaceID
 }
 
-func (d assimilationNode) InternalPath() string {
+func (d *assimilationNode) InternalPath() string {
 	return d.path
 }
 

--- a/pkg/storage/fs/posix/tree/assimilation_whitebox_test.go
+++ b/pkg/storage/fs/posix/tree/assimilation_whitebox_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package tree
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("assimilationNode", func() {
+	It("keeps LockHeld scoped to the owning goroutine", func() {
+		n := &assimilationNode{spaceID: "space", nodeId: "node", path: "/tmp/node"}
+
+		// The owning goroutine takes the lock.
+		n.SetLockHeld(true)
+		Expect(n.LockHeld()).To(BeTrue())
+
+		// A different goroutine must not observe the same instance as lock-held.
+		otherObservedHeld := make(chan bool, 1)
+		go func() {
+			otherObservedHeld <- n.LockHeld()
+		}()
+		Expect(<-otherObservedHeld).To(BeFalse())
+
+		// Releasing in the owning goroutine clears ownership.
+		n.SetLockHeld(false)
+		Expect(n.LockHeld()).To(BeFalse())
+	})
+})

--- a/pkg/storage/fs/posix/tree/revisions.go
+++ b/pkg/storage/fs/posix/tree/revisions.go
@@ -44,9 +44,7 @@ import (
 // The `.REV.` indicates it is a revision and what follows is a timestamp, so multiple versions
 // can be kept in the same location.
 
-// CreateRevision creates a new version of the node. The caller MUST already hold the
-// metadata lock of n, as the node's metadata is read (without re-locking) to copy the
-// blob metadata onto the new revision.
+// CreateRevision creates a new version of the node
 func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string) (string, error) {
 	revNode := node.NewBaseNode(n.SpaceID, n.ID+node.RevisionIDDelimiter+version, tp.lookup)
 	versionPath := revNode.InternalPath()
@@ -120,13 +118,13 @@ func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string
 	}
 
 	// copy blob metadata to version node
-	if err := tp.lookup.CopyMetadataWithSourceLock(ctx, n, revNode, func(attributeName string, value []byte) (newValue []byte, copy bool) {
+	if err := tp.lookup.CopyMetadata(ctx, n, revNode, func(attributeName string, value []byte) (newValue []byte, copy bool) {
 		return value, strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr ||
 			attributeName == prefixes.MTimeAttr
-	}, true); err != nil {
+	}); err != nil {
 		return "", err
 	}
 
@@ -301,7 +299,7 @@ func (tp *Tree) RestoreRevision(ctx context.Context, srcNode, targetNode metadat
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr
-	}, false)
+	})
 	if err != nil {
 		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 	}
@@ -318,8 +316,7 @@ func (tp *Tree) RestoreRevision(ctx context.Context, srcNode, targetNode metadat
 	err = tp.lookup.MetadataBackend().SetMultiple(ctx, targetNode,
 		map[string][]byte{
 			prefixes.MTimeAttr: []byte(mtime.UTC().Format(time.RFC3339Nano)),
-		},
-		false)
+		})
 	if err != nil {
 		return errtypes.InternalError("failed to set mtime attribute on node: " + err.Error())
 	}
@@ -351,7 +348,7 @@ func (tp *Tree) RestoreRevision(ctx context.Context, srcNode, targetNode metadat
 				attributeName == prefixes.TypeAttr ||
 				attributeName == prefixes.BlobIDAttr ||
 				attributeName == prefixes.BlobsizeAttr
-		}, false)
+		})
 		if err != nil {
 			return errtypes.InternalError("failed to copy xattrs to 'current' file: " + err.Error())
 		}

--- a/pkg/storage/fs/posix/tree/revisions.go
+++ b/pkg/storage/fs/posix/tree/revisions.go
@@ -30,7 +30,6 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
@@ -45,8 +44,10 @@ import (
 // The `.REV.` indicates it is a revision and what follows is a timestamp, so multiple versions
 // can be kept in the same location.
 
-// CreateRevision creates a new version of the node
-func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string, f *lockedfile.File) (string, error) {
+// CreateRevision creates a new version of the node. The caller MUST already hold the
+// metadata lock of n, as the node's metadata is read (without re-locking) to copy the
+// blob metadata onto the new revision.
+func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string) (string, error) {
 	revNode := node.NewBaseNode(n.SpaceID, n.ID+node.RevisionIDDelimiter+version, tp.lookup)
 	versionPath := revNode.InternalPath()
 
@@ -125,7 +126,7 @@ func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr ||
 			attributeName == prefixes.MTimeAttr
-	}, f, true); err != nil {
+	}, true); err != nil {
 		return "", err
 	}
 

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -397,7 +397,7 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node, markprocessing bool,
 		attributes[prefixes.MTimeAttr] = []byte(mtime.UTC().Format(time.RFC3339Nano))
 	}
 
-	err = n.SetXattrsWithContext(ctx, attributes, false)
+	err = n.SetXattrsWithContext(ctx, attributes)
 	if err != nil {
 		return err
 	}
@@ -480,7 +480,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 	attribs := node.Attributes{}
 	attribs.SetString(prefixes.ParentidAttr, newNode.ParentID)
 	attribs.SetString(prefixes.NameAttr, newNode.Name)
-	if err := newNode.SetXattrsWithContext(ctx, attribs, true); err != nil {
+	if err := newNode.SetXattrsWithContext(ctx, attribs); err != nil {
 		return errors.Wrap(err, "posixfs: could not update node attributes")
 	}
 
@@ -729,7 +729,7 @@ func (t *Tree) WriteBlob(n *node.Node, source string) error {
 			attrs.SetString(prefixes.BlobIDAttr, n.BlobID)
 			attrs.SetInt64(prefixes.BlobsizeAttr, n.Blobsize)
 
-			err := t.lookup.MetadataBackend().SetMultiple(context.Background(), node.NewBaseNode(n.SpaceID, n.ID+node.CurrentIDDelimiter, t.lookup), attrs, true)
+			err := t.lookup.MetadataBackend().SetMultiple(context.Background(), node.NewBaseNode(n.SpaceID, n.ID+node.CurrentIDDelimiter, t.lookup), attrs)
 			if err != nil {
 				t.log.Error().Err(err).Str("spaceID", n.SpaceID).Str("id", n.ID).Msg("could not copy metadata to current revision")
 			}
@@ -799,7 +799,7 @@ func (t *Tree) InitNewNode(ctx context.Context, n *node.Node, fsize uint64) (met
 	mtime := fi.ModTime()
 	err = n.SetXattrsWithContext(ctx, map[string][]byte{
 		prefixes.MTimeAttr: []byte(mtime.UTC().Format(time.RFC3339Nano)),
-	}, false)
+	})
 	if err != nil {
 		t.log.Error().Err(err).Str("path", n.InternalPath()).Msg("could not set mtime attribute on new node")
 	}
@@ -871,5 +871,5 @@ func (t *Tree) createDirNode(ctx context.Context, n *node.Node) (err error) {
 	if t.options.TreeTimeAccounting || t.options.TreeSizeAccounting {
 		attributes[prefixes.PropagationAttr] = []byte("1") // mark the node for propagation
 	}
-	return n.SetXattrsWithContext(ctx, attributes, false)
+	return n.SetXattrsWithContext(ctx, attributes)
 }

--- a/pkg/storage/internal/goroutinelock/lock.go
+++ b/pkg/storage/internal/goroutinelock/lock.go
@@ -1,0 +1,47 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package goroutinelock
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+)
+
+// Lock tracks which goroutine currently owns a metadata lock.
+//
+// Held() only returns true in the owning goroutine, which prevents lock-held
+// state from leaking across goroutine boundaries when helper nodes are shared.
+type Lock struct {
+	gid atomic.Uint64
+}
+
+func (o *Lock) Hold() {
+	o.gid.Store(goid())
+}
+
+func (o *Lock) Release() {
+	o.gid.Store(0)
+}
+
+func (o *Lock) Held() bool {
+	return o.gid.Load() == goid()
+}
+
+func goid() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+
+	// The header has the form "goroutine 1234 [running]:".
+	fields := bytes.Fields(buf[:n])
+	if len(fields) < 2 {
+		return 0
+	}
+	id, err := strconv.ParseUint(string(fields[1]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}

--- a/pkg/storage/internal/goroutinelock/lock.go
+++ b/pkg/storage/internal/goroutinelock/lock.go
@@ -7,7 +7,10 @@ import (
 	"bytes"
 	"runtime"
 	"strconv"
+	"sync"
 	"sync/atomic"
+
+	"github.com/rs/zerolog/log"
 )
 
 // Lock tracks which goroutine currently owns a metadata lock.
@@ -17,6 +20,8 @@ import (
 type Lock struct {
 	gid atomic.Uint64
 }
+
+var goidLogOnce sync.Once
 
 func (o *Lock) Hold() {
 	o.gid.Store(goid())
@@ -37,10 +42,20 @@ func goid() uint64 {
 	// The header has the form "goroutine 1234 [running]:".
 	fields := bytes.Fields(buf[:n])
 	if len(fields) < 2 {
+		goidLogOnce.Do(func() {
+			log.Error().
+				Str("stack_header", string(buf[:n])).
+				Msg("goroutinelock: could not determine goroutine id from runtime stack header")
+		})
 		return 0
 	}
 	id, err := strconv.ParseUint(string(fields[1]), 10, 64)
 	if err != nil {
+		goidLogOnce.Do(func() {
+			log.Error().Err(err).
+				Str("goroutine_id_field", string(fields[1])).
+				Msg("goroutinelock: could not parse goroutine id")
+		})
 		return 0
 	}
 	return id

--- a/pkg/storage/pkg/decomposedfs/grants.go
+++ b/pkg/storage/pkg/decomposedfs/grants.go
@@ -223,7 +223,7 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 		}
 	}
 
-	if err := grantNode.DeleteGrant(ctx, g, false); err != nil {
+	if err := grantNode.DeleteGrant(ctx, g); err != nil {
 		return err
 	}
 
@@ -349,7 +349,7 @@ func (fs *Decomposedfs) storeGrant(ctx context.Context, n *node.Node, g *provide
 	attribs := node.Attributes{
 		prefixes.GrantPrefix + principal: value,
 	}
-	if err := n.SetXattrsWithContext(ctx, attribs, false); err != nil {
+	if err := n.SetXattrsWithContext(ctx, attribs); err != nil {
 		appctx.GetLogger(ctx).Error().Err(err).
 			Str("principal", principal).Msg("Could not set grant for principal")
 		return err

--- a/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -313,35 +313,30 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 	}, nil
 }
 
-// CopyMetadata copies all extended attributes from source to target.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, the metadata lock is acquired for the duration of the copy.
-// NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	// lock the source node before reading its metadata
-	unlock, err := lu.MetadataBackend().Lock(sourceNode)
-	if err != nil {
-		return errors.Wrap(err, "xattrs: Unable to lock source to read")
-	}
-	defer func() {
-		rerr := unlock()
-
-		// if err is non nil we do not overwrite that
-		if err == nil {
-			err = rerr
+// CopyMetadata copies all extended attributes from source to target. The optional filter
+// function can be used to filter by attribute name, e.g. by checking a prefix.
+//
+// Locking is derived from the nodes: the source's metadata lock is acquired for the duration
+// of the read unless the caller already holds it (sourceNode.LockHeld()), and the target is
+// write locked while its attributes are written unless the caller already holds its lock
+func (lu *Lookup) CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool)) (err error) {
+	if !sourceNode.LockHeld() {
+		// lock the source node before reading its metadata
+		unlock, lerr := lu.MetadataBackend().Lock(sourceNode)
+		if lerr != nil {
+			return errors.Wrap(lerr, "xattrs: Unable to lock source to read")
 		}
-	}()
+		defer func() {
+			rerr := unlock()
 
-	return lu.CopyMetadataWithSourceLock(ctx, sourceNode, targetNode, filter, acquireTargetLock)
-}
+			// if err is non nil we do not overwrite that
+			if err == nil {
+				err = rerr
+			}
+		}()
+	}
 
-// CopyMetadataWithSourceLock copies all extended attributes from source to target.
-// The caller MUST already hold the source node's metadata lock (e.g. via
-// MetadataBackend().Lock); the source attributes are read without re-acquiring it.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix.
-// NOTE: target resource will be write locked when acquireTargetLock is set!
-func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	attrs, err := lu.metadataBackend.AllWhileLocked(ctx, sourceNode)
+	attrs, err := lu.metadataBackend.All(ctx, sourceNode)
 	if err != nil {
 		return err
 	}
@@ -357,7 +352,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, ta
 		newAttrs[attrName] = val
 	}
 
-	return lu.MetadataBackend().SetMultiple(ctx, targetNode, newAttrs, acquireTargetLock)
+	return lu.MetadataBackend().SetMultiple(ctx, targetNode, newAttrs)
 }
 
 func (lu *Lookup) PurgeNode(n *node.Node) error {

--- a/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -320,22 +320,6 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 // of the read unless the caller already holds it (sourceNode.LockHeld()), and the target is
 // write locked while its attributes are written unless the caller already holds its lock
 func (lu *Lookup) CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool)) (err error) {
-	if !sourceNode.LockHeld() {
-		// lock the source node before reading its metadata
-		unlock, lerr := lu.MetadataBackend().Lock(sourceNode)
-		if lerr != nil {
-			return errors.Wrap(lerr, "xattrs: Unable to lock source to read")
-		}
-		defer func() {
-			rerr := unlock()
-
-			// if err is non nil we do not overwrite that
-			if err == nil {
-				err = rerr
-			}
-		}()
-	}
-
 	attrs, err := lu.metadataBackend.All(ctx, sourceNode)
 	if err != nil {
 		return err

--- a/pkg/storage/pkg/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/pkg/decomposedfs/lookup/lookup.go
@@ -36,7 +36,6 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/options"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -316,21 +315,16 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 
 // CopyMetadata copies all extended attributes from source to target.
 // The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, a shared lock is acquired.
+// For the source file, the metadata lock is acquired for the duration of the copy.
 // NOTE: target resource will be write locked!
 func (lu *Lookup) CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
-	// Acquire a read log on the source node
-	// write lock existing node before reading treesize or tree time
-	lock, err := lockedfile.OpenFile(lu.MetadataBackend().LockfilePath(sourceNode), os.O_RDONLY|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-
+	// lock the source node before reading its metadata
+	unlock, err := lu.MetadataBackend().Lock(sourceNode)
 	if err != nil {
 		return errors.Wrap(err, "xattrs: Unable to lock source to read")
 	}
 	defer func() {
-		rerr := lock.Close()
+		rerr := unlock()
 
 		// if err is non nil we do not overwrite that
 		if err == nil {
@@ -338,22 +332,16 @@ func (lu *Lookup) CopyMetadata(ctx context.Context, sourceNode, targetNode metad
 		}
 	}()
 
-	return lu.CopyMetadataWithSourceLock(ctx, sourceNode, targetNode, filter, lock, acquireTargetLock)
+	return lu.CopyMetadataWithSourceLock(ctx, sourceNode, targetNode, filter, acquireTargetLock)
 }
 
 // CopyMetadataWithSourceLock copies all extended attributes from source to target.
-// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
-// For the source file, a matching lockedfile is required.
-// NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), lockedSource *lockedfile.File, acquireTargetLock bool) (err error) {
-	switch {
-	case lockedSource == nil:
-		return errors.New("no lock provided")
-	case lockedSource.Name() != lu.MetadataBackend().LockfilePath(sourceNode):
-		return errors.New("lockpath does not match filepath")
-	}
-
-	attrs, err := lu.metadataBackend.All(ctx, sourceNode)
+// The caller MUST already hold the source node's metadata lock (e.g. via
+// MetadataBackend().Lock); the source attributes are read without re-acquiring it.
+// The optional filter function can be used to filter by attribute name, e.g. by checking a prefix.
+// NOTE: target resource will be write locked when acquireTargetLock is set!
+func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
+	attrs, err := lu.metadataBackend.AllWhileLocked(ctx, sourceNode)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/pkg/decomposedfs/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata.go
@@ -142,7 +142,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 
 	errs := []error{}
 	for _, k := range keys {
-		if err = n.RemoveXattr(ctx, prefixes.MetadataPrefix+k, true); err != nil {
+		if err = n.RemoveXattr(ctx, prefixes.MetadataPrefix+k); err != nil {
 			if metadata.IsAttrUnset(err) {
 				continue // already gone, ignore
 			}

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -116,8 +116,8 @@ func (b HybridBackend) list(ctx context.Context, n MetadataNode) (attribs []stri
 	return listXattr(filePath)
 }
 
-// All reads all extended attributes for a node, protected by a
-// shared file lock
+// All reads all extended attributes for a node. It acquires a shared file lock
+// unless the caller already holds the node's metadata lock (n.LockHeld()).
 func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
 	attribs := map[string][]byte{}
 
@@ -126,23 +126,12 @@ func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]by
 		return attribs, err
 	}
 
-	unlock, err := b.Lock(n)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = unlock() }()
-
-	return b.getAll(ctx, n, false, false)
-}
-
-// AllWhileLocked reads all extended attributes assuming the caller already holds
-// the node's metadata lock. It does not acquire the lock again.
-func (b HybridBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	attribs := map[string][]byte{}
-
-	err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
-	if err == nil {
-		return attribs, err
+	if !n.LockHeld() {
+		unlock, err := b.Lock(n)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = unlock() }()
 	}
 
 	return b.getAll(ctx, n, false, false)
@@ -214,13 +203,13 @@ func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipCache, sk
 
 // Set sets one attribute for the given path
 func (b HybridBackend) Set(ctx context.Context, n MetadataNode, key string, val []byte) (err error) {
-	return b.SetMultiple(ctx, n, map[string][]byte{key: val}, true)
+	return b.SetMultiple(ctx, n, map[string][]byte{key: val})
 }
 
 // SetMultiple sets a set of attribute for the given path
-func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) (err error) {
+func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte) (err error) {
 	path := n.InternalPath()
-	if acquireLock {
+	if !n.LockHeld() {
 		unlock, err := b.Lock(n)
 		if err != nil {
 			return err
@@ -376,9 +365,9 @@ func (b HybridBackend) offloadMetadata(ctx context.Context, n MetadataNode) erro
 }
 
 // Remove an extended attribute key
-func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error {
+func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string) error {
 	path := n.InternalPath()
-	if acquireLock {
+	if !n.LockHeld() {
 		unlock, err := b.Lock(n)
 		if err != nil {
 			return err
@@ -503,6 +492,10 @@ func (b HybridBackend) LockfilePath(n MetadataNode) string {
 
 // Lock locks the metadata for the given path
 func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
+	if n.LockHeld() {
+		return func() error { return nil }, nil
+	}
+
 	metaLockPath := b.LockfilePath(n)
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -520,7 +513,9 @@ func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 			return nil, err
 		}
 	}
+	n.SetLockHeld(true)
 	return func() error {
+		n.SetLockHeld(false)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
 	}, nil

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -3,7 +3,6 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -136,9 +135,9 @@ func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]by
 	return b.getAll(ctx, n, false, false)
 }
 
-// AllWithLockedSource reads all extended attributes from the given reader.
-// The path argument is used for storing the data in the cache
-func (b HybridBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {
+// AllWhileLocked reads all extended attributes assuming the caller already holds
+// the node's metadata lock. It does not acquire the lock again.
+func (b HybridBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
 	attribs := map[string][]byte{}
 
 	err := b.metaCache.PullFromCache(b.cacheKey(n), &attribs)
@@ -504,11 +503,6 @@ func (b HybridBackend) LockfilePath(n MetadataNode) string {
 
 // Lock locks the metadata for the given path
 func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
-	f, _, err := b.LockAndRead(n)
-	return f, err
-}
-
-func (b HybridBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
 	metaLockPath := b.LockfilePath(n)
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -516,20 +510,20 @@ func (b HybridBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error
 			// create the parent directory
 			err = os.MkdirAll(filepath.Dir(metaLockPath), 0700)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			mlock, err = lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 		} else {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 	return func() error {
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
-	}, mlock, nil
+	}, nil
 }
 
 func (b HybridBackend) cacheKey(n MetadataNode) string {

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -134,10 +134,10 @@ func (b HybridBackend) All(ctx context.Context, n MetadataNode) (map[string][]by
 		defer func() { _ = unlock() }()
 	}
 
-	return b.getAll(ctx, n, false, false)
+	return b.getAll(ctx, n, false)
 }
 
-func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipCache, skipOffloaded bool) (map[string][]byte, error) {
+func (b HybridBackend) getAll(ctx context.Context, n MetadataNode, skipOffloaded bool) (map[string][]byte, error) {
 	attribs := map[string][]byte{}
 	attrNames, err := b.list(ctx, n)
 	if err != nil {
@@ -235,7 +235,7 @@ func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 				mdSize += len(attribs[key]) + len(key)
 			}
 		}
-		existingAttribs, err := b.getAll(ctx, n, true, true)
+		existingAttribs, err := b.getAll(ctx, n, true)
 		if err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func (b HybridBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 	}
 
 	// Update the cache with the new values
-	_, err = b.getAll(ctx, n, true, false)
+	_, err = b.getAll(ctx, n, false)
 	return err
 }
 
@@ -319,7 +319,7 @@ func (b HybridBackend) offloadMetadata(ctx context.Context, n MetadataNode) erro
 	var xerr error
 
 	// collect attributes to move
-	existingAttribs, err := b.getAll(ctx, n, true, true)
+	existingAttribs, err := b.getAll(ctx, n, true)
 	if err != nil {
 		return err
 	}
@@ -432,7 +432,7 @@ func (b HybridBackend) Remove(ctx context.Context, n MetadataNode, key string) e
 	}
 
 	// Update the cache with the new values
-	_, err := b.getAll(ctx, n, true, false)
+	_, err := b.getAll(ctx, n, false)
 	return err
 }
 
@@ -450,7 +450,7 @@ func (b HybridBackend) Purge(ctx context.Context, n MetadataNode) error {
 		}
 		defer func() { _ = unlock() }()
 
-		attribs, err := b.getAll(ctx, n, true, false)
+		attribs, err := b.getAll(ctx, n, false)
 		if err == nil {
 			for attr := range attribs {
 				if strings.HasPrefix(attr, prefixes.OcPrefix) {

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("HybridBackend", func() {
 	var (
 		tmpdir string
-		n      testNode
+		n      *testNode
 
 		backend metadata.Backend
 
@@ -47,7 +47,7 @@ var _ = Describe("HybridBackend", func() {
 	})
 
 	JustBeforeEach(func() {
-		n = testNode{
+		n = &testNode{
 			spaceID: "123",
 			id:      "456",
 			path:    path.Join(tmpdir, "file"),
@@ -225,7 +225,7 @@ var _ = Describe("HybridBackend", func() {
 					keySmall:         dataSmall,
 					keyBig:           dataBig,
 					nonOffloadingKey: nonOffloadingData,
-				}, false)
+				})
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -261,7 +261,7 @@ var _ = Describe("HybridBackend", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(readData).To(Equal(nonOffloadingData))
 
-			err = backend.Remove(context.Background(), n, nonOffloadingKey, true)
+			err = backend.Remove(context.Background(), n, nonOffloadingKey)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = backend.Get(context.Background(), n, nonOffloadingKey)
@@ -275,7 +275,7 @@ var _ = Describe("HybridBackend", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(readData).To(Equal(dataBig))
 
-			err = backend.Remove(context.Background(), n, keyBig, true)
+			err = backend.Remove(context.Background(), n, keyBig)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = backend.Get(context.Background(), n, keyBig)
@@ -287,7 +287,7 @@ var _ = Describe("HybridBackend", func() {
 				keySmall:         dataSmall,
 				keyBig:           dataBig,
 				nonOffloadingKey: nonOffloadingData,
-			}, false)
+			})
 			Expect(err).ToNot(HaveOccurred())
 			readData, err := backend.Get(context.Background(), n, keyBig)
 			Expect(err).ToNot(HaveOccurred())
@@ -296,7 +296,7 @@ var _ = Describe("HybridBackend", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(readData).To(Equal(nonOffloadingData))
 
-			err = backend.Remove(context.Background(), n, nonOffloadingKey, true)
+			err = backend.Remove(context.Background(), n, nonOffloadingKey)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = backend.Get(context.Background(), n, nonOffloadingKey)
@@ -313,9 +313,27 @@ var _ = Describe("HybridBackend", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}()
 
-			attribs, err := backend.AllWhileLocked(context.Background(), n)
+			attribs, err := backend.All(context.Background(), n)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(attribs).ToNot(BeNil())
+		})
+
+		It("is a no-op when the node's lock is already held", func() {
+			unlock, err := backend.Lock(n)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n.LockHeld()).To(BeTrue())
+			defer func() {
+				Expect(unlock()).ToNot(HaveOccurred())
+			}()
+
+			// Locking the same, already-locked node must not block or deadlock.
+			// It returns a no-op unlock that must not release the real lock.
+			unlock2, err := backend.Lock(n)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unlock2()).ToNot(HaveOccurred())
+
+			// the real lock (and its held state) survives the no-op unlock
+			Expect(n.LockHeld()).To(BeTrue())
 		})
 
 		It("releases the lock after unlock is called", func() {

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -2,7 +2,6 @@ package metadata_test
 
 import (
 	"context"
-	"io"
 	"os"
 	"path"
 
@@ -305,27 +304,27 @@ var _ = Describe("HybridBackend", func() {
 		})
 	})
 
-	Describe("LockAndRead", func() {
-		It("acquires a lock and returns a reader", func() {
-			unlock, reader, err := backend.LockAndRead(n)
+	Describe("Lock", func() {
+		It("acquires a lock", func() {
+			unlock, err := backend.Lock(n)
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
 				err = unlock()
 				Expect(err).ToNot(HaveOccurred())
 			}()
 
-			data, err := io.ReadAll(reader)
+			attribs, err := backend.AllWhileLocked(context.Background(), n)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(data)).To(Equal(0))
+			Expect(attribs).ToNot(BeNil())
 		})
 
 		It("releases the lock after unlock is called", func() {
-			unlock1, _, err := backend.LockAndRead(n)
+			unlock1, err := backend.Lock(n)
 			Expect(err).ToNot(HaveOccurred())
 			err = unlock1()
 			Expect(err).ToNot(HaveOccurred())
 
-			unlock2, _, err := backend.LockAndRead(n)
+			unlock2, err := backend.Lock(n)
 			Expect(err).ToNot(HaveOccurred())
 			err = unlock2()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
@@ -86,12 +86,12 @@ func (b MessagePackBackend) IdentifyPath(_ context.Context, path string) (string
 
 // All reads all extended attributes for a node
 func (b MessagePackBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return b.loadAttributes(ctx, n, nil)
+	return b.loadAttributes(ctx, n)
 }
 
 // Get an extended attribute value for the given key
 func (b MessagePackBackend) Get(ctx context.Context, n MetadataNode, key string) ([]byte, error) {
-	attribs, err := b.loadAttributes(ctx, n, nil)
+	attribs, err := b.loadAttributes(ctx, n)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -104,7 +104,7 @@ func (b MessagePackBackend) Get(ctx context.Context, n MetadataNode, key string)
 
 // GetInt64 reads a string as int64 from the xattrs
 func (b MessagePackBackend) GetInt64(ctx context.Context, n MetadataNode, key string) (int64, error) {
-	attribs, err := b.loadAttributes(ctx, n, nil)
+	attribs, err := b.loadAttributes(ctx, n)
 	if err != nil {
 		return 0, err
 	}
@@ -134,10 +134,11 @@ func (b MessagePackBackend) Remove(ctx context.Context, n MetadataNode, key stri
 	return b.saveAttributes(ctx, n, nil, []string{key}, acquireLock)
 }
 
-// AllWithLockedSource reads all extended attributes from the given reader (if possible).
-// The path argument is used for storing the data in the cache
-func (b MessagePackBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, source io.Reader) (map[string][]byte, error) {
-	return b.loadAttributes(ctx, n, source)
+// AllWhileLocked reads all extended attributes assuming the caller already holds
+// the node's metadata lock. It reads the metadata file directly and does not
+// acquire the lock again.
+func (b MessagePackBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
+	return b.loadAttributes(ctx, n)
 }
 
 func (b MessagePackBackend) saveAttributes(ctx context.Context, n MetadataNode, setAttribs map[string][]byte, deleteAttribs []string, acquireLock bool) error {
@@ -211,7 +212,7 @@ func (b MessagePackBackend) saveAttributes(ctx context.Context, n MetadataNode, 
 	return err
 }
 
-func (b MessagePackBackend) loadAttributes(ctx context.Context, n MetadataNode, source io.Reader) (map[string][]byte, error) {
+func (b MessagePackBackend) loadAttributes(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
 	ctx, span := tracer.Start(ctx, "loadAttributes")
 	defer span.End()
 	attribs := map[string][]byte{}
@@ -221,39 +222,31 @@ func (b MessagePackBackend) loadAttributes(ctx context.Context, n MetadataNode, 
 	}
 
 	metaPath := b.MetadataPath(n)
-	var msgBytes []byte
 
-	if source == nil {
-		// // No cached entry found. Read from storage and store in cache
-		_, subspan := tracer.Start(ctx, "os.OpenFile")
-		// source, err = lockedfile.Open(metaPath)
-		source, err = os.Open(metaPath)
-		subspan.End()
-		// // No cached entry found. Read from storage and store in cache
-		if err != nil {
-			if os.IsNotExist(err) {
-				// some of the caller rely on ENOTEXISTS to be returned when the
-				// actual file (not the metafile) does not exist in order to
-				// determine whether a node exists or not -> stat the actual node
-				_, subspan := tracer.Start(ctx, "os.Stat")
-				_, err := os.Stat(n.InternalPath())
-				subspan.End()
-				if err != nil {
-					return nil, err
-				}
-				return attribs, nil // no attributes set yet
+	// No cached entry found. Read from storage and store in cache
+	_, subspan := tracer.Start(ctx, "os.Open")
+	source, err := os.Open(metaPath)
+	subspan.End()
+	if err != nil {
+		if os.IsNotExist(err) {
+			// some of the callers rely on ENOTEXISTS to be returned when the
+			// actual file (not the metafile) does not exist in order to
+			// determine whether a node exists or not -> stat the actual node
+			_, subspan := tracer.Start(ctx, "os.Stat")
+			_, err := os.Stat(n.InternalPath())
+			subspan.End()
+			if err != nil {
+				return nil, err
 			}
+			return attribs, nil // no attributes set yet
 		}
-		_, subspan = tracer.Start(ctx, "io.ReadAll")
-		msgBytes, err = io.ReadAll(source)
-		source.(*os.File).Close()
-		subspan.End()
-	} else {
-		_, subspan := tracer.Start(ctx, "io.ReadAll")
-		msgBytes, err = io.ReadAll(source)
-		subspan.End()
+		return nil, err
 	}
 
+	_, subspan = tracer.Start(ctx, "io.ReadAll")
+	msgBytes, err := io.ReadAll(source)
+	_ = source.Close()
+	subspan.End()
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +257,7 @@ func (b MessagePackBackend) loadAttributes(ctx context.Context, n MetadataNode, 
 		}
 	}
 
-	_, subspan := tracer.Start(ctx, "metaCache.PushToCache")
+	_, subspan = tracer.Start(ctx, "metaCache.PushToCache")
 	err = b.metaCache.PushToCache(b.cacheKey(n), attribs)
 	subspan.End()
 	if err != nil {
@@ -323,20 +316,6 @@ func (b MessagePackBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
 	}, nil
-}
-
-func (b MessagePackBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
-	unlock, err := b.Lock(n)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	f, err := os.Open(b.MetadataPath(n))
-	if err != nil {
-		_ = unlock()
-		return nil, nil, err
-	}
-	return unlock, f, nil
 }
 
 func (b MessagePackBackend) cacheKey(n MetadataNode) string {

--- a/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/messagepack_backend.go
@@ -121,27 +121,20 @@ func (b MessagePackBackend) GetInt64(ctx context.Context, n MetadataNode, key st
 
 // Set sets one attribute for the given path
 func (b MessagePackBackend) Set(ctx context.Context, n MetadataNode, key string, val []byte) error {
-	return b.SetMultiple(ctx, n, map[string][]byte{key: val}, true)
+	return b.SetMultiple(ctx, n, map[string][]byte{key: val})
 }
 
 // SetMultiple sets a set of attribute for the given path
-func (b MessagePackBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) error {
-	return b.saveAttributes(ctx, n, attribs, nil, acquireLock)
+func (b MessagePackBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte) error {
+	return b.saveAttributes(ctx, n, attribs, nil)
 }
 
 // Remove an extended attribute key
-func (b MessagePackBackend) Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error {
-	return b.saveAttributes(ctx, n, nil, []string{key}, acquireLock)
+func (b MessagePackBackend) Remove(ctx context.Context, n MetadataNode, key string) error {
+	return b.saveAttributes(ctx, n, nil, []string{key})
 }
 
-// AllWhileLocked reads all extended attributes assuming the caller already holds
-// the node's metadata lock. It reads the metadata file directly and does not
-// acquire the lock again.
-func (b MessagePackBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return b.loadAttributes(ctx, n)
-}
-
-func (b MessagePackBackend) saveAttributes(ctx context.Context, n MetadataNode, setAttribs map[string][]byte, deleteAttribs []string, acquireLock bool) error {
+func (b MessagePackBackend) saveAttributes(ctx context.Context, n MetadataNode, setAttribs map[string][]byte, deleteAttribs []string) error {
 	var (
 		err error
 	)
@@ -156,7 +149,7 @@ func (b MessagePackBackend) saveAttributes(ctx context.Context, n MetadataNode, 
 	}()
 
 	metaPath := b.MetadataPath(n)
-	if acquireLock {
+	if !n.LockHeld() {
 		unlock, err := b.Lock(n)
 		if err != nil {
 			return err
@@ -307,12 +300,18 @@ func (MessagePackBackend) LockfilePath(n MetadataNode) string { return n.Interna
 
 // Lock locks the metadata for the given path
 func (b MessagePackBackend) Lock(n MetadataNode) (UnlockFunc, error) {
+	if n.LockHeld() {
+		return func() error { return nil }, nil
+	}
+
 	metaLockPath := b.LockfilePath(n)
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
+	n.SetLockHeld(true)
 	return func() error {
+		n.SetLockHeld(false)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
 	}, nil

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata.go
@@ -21,7 +21,6 @@ package metadata
 import (
 	"context"
 	"errors"
-	"io"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -50,7 +49,10 @@ type Backend interface {
 	IdentifyPath(ctx context.Context, path string) (string, string, string, time.Time, error)
 
 	All(ctx context.Context, n MetadataNode) (map[string][]byte, error)
-	AllWithLockedSource(ctx context.Context, n MetadataNode, source io.Reader) (map[string][]byte, error)
+	// AllWhileLocked reads all extended attributes assuming the caller already holds
+	// the node's metadata lock. Unlike All it does not (re-)acquire the lock, so it is
+	// safe to call while holding it.
+	AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error)
 
 	Get(ctx context.Context, n MetadataNode, key string) ([]byte, error)
 	GetInt64(ctx context.Context, n MetadataNode, key string) (int64, error)
@@ -59,7 +61,6 @@ type Backend interface {
 	Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error
 
 	Lock(n MetadataNode) (UnlockFunc, error)
-	LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error)
 	Purge(ctx context.Context, n MetadataNode) error
 	Rename(oldNode, newNode MetadataNode) error
 	MetadataPath(n MetadataNode) string
@@ -114,11 +115,6 @@ func (NullBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	return nil, nil
 }
 
-// LockAndRead locks the metadata for reading
-func (NullBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
-	return nil, nil, nil
-}
-
 // IsMetaFile returns whether the given path represents a meta file
 func (NullBackend) IsMetaFile(path string) bool { return false }
 
@@ -134,8 +130,7 @@ func (NullBackend) MetadataPath(n MetadataNode) string { return "" }
 // LockfilePath returns the path of the lock file
 func (NullBackend) LockfilePath(n MetadataNode) string { return "" }
 
-// AllWithLockedSource reads all extended attributes from the given reader
-// The path argument is used for storing the data in the cache
-func (NullBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, source io.Reader) (map[string][]byte, error) {
+// AllWhileLocked reads all extended attributes assuming the caller holds the lock
+func (NullBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
 	return nil, errUnconfiguredError
 }

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata.go
@@ -41,24 +41,39 @@ type MetadataNode interface {
 	GetSpaceID() string
 	GetID() string
 	InternalPath() string
+	// LockHeld reports whether the caller already holds this node's metadata lock.
+	// Backends use it to decide whether they must (re-)acquire the lock when reading
+	// metadata; re-acquiring a held, non-reentrant advisory file lock self-deadlocks.
+	LockHeld() bool
+	SetLockHeld(held bool)
 }
+
+// lockHeldNode wraps a MetadataNode and reports that its metadata lock is held.
+type lockHeldNode struct {
+	MetadataNode
+}
+
+// LockHeld always returns true.
+func (lockHeldNode) LockHeld() bool { return true }
 
 // Backend defines the interface for file attribute backends
 type Backend interface {
 	Name() string
 	IdentifyPath(ctx context.Context, path string) (string, string, string, time.Time, error)
 
+	// All reads all extended attributes for a node. It acquires the node's metadata
+	// lock unless n.LockHeld() reports that the caller already holds it.
 	All(ctx context.Context, n MetadataNode) (map[string][]byte, error)
-	// AllWhileLocked reads all extended attributes assuming the caller already holds
-	// the node's metadata lock. Unlike All it does not (re-)acquire the lock, so it is
-	// safe to call while holding it.
-	AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error)
 
 	Get(ctx context.Context, n MetadataNode, key string) ([]byte, error)
 	GetInt64(ctx context.Context, n MetadataNode, key string) (int64, error)
 	Set(ctx context.Context, n MetadataNode, key string, val []byte) error
-	SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) error
-	Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error
+	// SetMultiple sets multiple extended attributes for a node. It acquires the node's
+	// metadata lock unless n.LockHeld() reports that the caller already holds it.
+	SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte) error
+	// Remove removes an extended attribute key. It acquires the node's metadata lock
+	// unless n.LockHeld() reports that the caller already holds it.
+	Remove(ctx context.Context, n MetadataNode, key string) error
 
 	Lock(n MetadataNode) (UnlockFunc, error)
 	Purge(ctx context.Context, n MetadataNode) error
@@ -101,12 +116,12 @@ func (NullBackend) Set(ctx context.Context, n MetadataNode, key string, val []by
 }
 
 // SetMultiple sets a set of attribute for the given path
-func (NullBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) error {
+func (NullBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte) error {
 	return errUnconfiguredError
 }
 
 // Remove removes an extended attribute key
-func (NullBackend) Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error {
+func (NullBackend) Remove(ctx context.Context, n MetadataNode, key string) error {
 	return errUnconfiguredError
 }
 
@@ -129,8 +144,3 @@ func (NullBackend) MetadataPath(n MetadataNode) string { return "" }
 
 // LockfilePath returns the path of the lock file
 func (NullBackend) LockfilePath(n MetadataNode) string { return "" }
-
-// AllWhileLocked reads all extended attributes assuming the caller holds the lock
-func (NullBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return nil, errUnconfiguredError
-}

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata.go
@@ -48,14 +48,6 @@ type MetadataNode interface {
 	SetLockHeld(held bool)
 }
 
-// lockHeldNode wraps a MetadataNode and reports that its metadata lock is held.
-type lockHeldNode struct {
-	MetadataNode
-}
-
-// LockHeld always returns true.
-func (lockHeldNode) LockHeld() bool { return true }
-
 // Backend defines the interface for file attribute backends
 type Backend interface {
 	Name() string

--- a/pkg/storage/pkg/decomposedfs/metadata/metadata_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/metadata_test.go
@@ -30,9 +30,10 @@ import (
 )
 
 type testNode struct {
-	spaceID string
-	id      string
-	path    string
+	spaceID  string
+	id       string
+	path     string
+	lockHeld bool
 }
 
 func (t testNode) GetSpaceID() string {
@@ -47,10 +48,18 @@ func (t testNode) InternalPath() string {
 	return t.path
 }
 
+func (t *testNode) LockHeld() bool {
+	return t.lockHeld
+}
+
+func (t *testNode) SetLockHeld(held bool) {
+	t.lockHeld = held
+}
+
 var _ = Describe("Backend", func() {
 	var (
 		tmpdir string
-		n      testNode
+		n      *testNode
 
 		backend metadata.Backend
 	)
@@ -62,7 +71,7 @@ var _ = Describe("Backend", func() {
 	})
 
 	JustBeforeEach(func() {
-		n = testNode{
+		n = &testNode{
 			spaceID: "123",
 			id:      "456",
 			path:    path.Join(tmpdir, "file"),
@@ -130,7 +139,7 @@ var _ = Describe("Backend", func() {
 		Describe("SetMultiple", func() {
 			It("sets attributes", func() {
 				data := map[string][]byte{"foo": []byte("bar"), "baz": []byte("qux")}
-				err := backend.SetMultiple(context.Background(), n, data, true)
+				err := backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				readData, err := backend.All(context.Background(), n)
@@ -143,7 +152,7 @@ var _ = Describe("Backend", func() {
 
 				data := map[string][]byte{"foo": []byte("bar"), "baz": []byte("qux")}
 				Expect(err).ToNot(HaveOccurred())
-				err = backend.SetMultiple(context.Background(), n, data, true)
+				err = backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				readData, err := backend.All(context.Background(), n)
@@ -155,7 +164,7 @@ var _ = Describe("Backend", func() {
 		Describe("All", func() {
 			It("returns the entries", func() {
 				data := map[string][]byte{"foo": []byte("123"), "bar": []byte("baz")}
-				err := backend.SetMultiple(context.Background(), n, data, true)
+				err := backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				v, err := backend.All(context.Background(), n)
@@ -174,7 +183,7 @@ var _ = Describe("Backend", func() {
 		Describe("Get", func() {
 			It("returns the attribute", func() {
 				data := map[string][]byte{"foo": []byte("bar")}
-				err := backend.SetMultiple(context.Background(), n, data, true)
+				err := backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				v, err := backend.Get(context.Background(), n, "foo")
@@ -191,7 +200,7 @@ var _ = Describe("Backend", func() {
 		Describe("GetInt64", func() {
 			It("returns the attribute", func() {
 				data := map[string][]byte{"foo": []byte("123")}
-				err := backend.SetMultiple(context.Background(), n, data, true)
+				err := backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				v, err := backend.GetInt64(context.Background(), n, "foo")
@@ -208,14 +217,14 @@ var _ = Describe("Backend", func() {
 		Describe("Remove", func() {
 			It("deletes an attribute", func() {
 				data := map[string][]byte{"foo": []byte("bar")}
-				err := backend.SetMultiple(context.Background(), n, data, true)
+				err := backend.SetMultiple(context.Background(), n, data)
 				Expect(err).ToNot(HaveOccurred())
 
 				v, err := backend.Get(context.Background(), n, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal([]byte("bar")))
 
-				err = backend.Remove(context.Background(), n, "foo", true)
+				err = backend.Remove(context.Background(), n, "foo")
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = backend.Get(context.Background(), n, "foo")

--- a/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
@@ -22,7 +22,6 @@ package mocks
 
 import (
 	context "context"
-	io "io"
 
 	metadata "github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
 	mock "github.com/stretchr/testify/mock"
@@ -102,29 +101,29 @@ func (_c *Backend_All_Call) RunAndReturn(run func(context.Context, metadata.Meta
 	return _c
 }
 
-// AllWithLockedSource provides a mock function with given fields: ctx, n, source
-func (_m *Backend) AllWithLockedSource(ctx context.Context, n metadata.MetadataNode, source io.Reader) (map[string][]byte, error) {
-	ret := _m.Called(ctx, n, source)
+// AllWhileLocked provides a mock function with given fields: ctx, n
+func (_m *Backend) AllWhileLocked(ctx context.Context, n metadata.MetadataNode) (map[string][]byte, error) {
+	ret := _m.Called(ctx, n)
 
 	if len(ret) == 0 {
-		panic("no return value specified for AllWithLockedSource")
+		panic("no return value specified for AllWhileLocked")
 	}
 
 	var r0 map[string][]byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, io.Reader) (map[string][]byte, error)); ok {
-		return rf(ctx, n, source)
+	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode) (map[string][]byte, error)); ok {
+		return rf(ctx, n)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, io.Reader) map[string][]byte); ok {
-		r0 = rf(ctx, n, source)
+	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode) map[string][]byte); ok {
+		r0 = rf(ctx, n)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, metadata.MetadataNode, io.Reader) error); ok {
-		r1 = rf(ctx, n, source)
+	if rf, ok := ret.Get(1).(func(context.Context, metadata.MetadataNode) error); ok {
+		r1 = rf(ctx, n)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -132,32 +131,31 @@ func (_m *Backend) AllWithLockedSource(ctx context.Context, n metadata.MetadataN
 	return r0, r1
 }
 
-// Backend_AllWithLockedSource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllWithLockedSource'
-type Backend_AllWithLockedSource_Call struct {
+// Backend_AllWhileLocked_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllWhileLocked'
+type Backend_AllWhileLocked_Call struct {
 	*mock.Call
 }
 
-// AllWithLockedSource is a helper method to define mock.On call
+// AllWhileLocked is a helper method to define mock.On call
 //   - ctx context.Context
 //   - n metadata.MetadataNode
-//   - source io.Reader
-func (_e *Backend_Expecter) AllWithLockedSource(ctx interface{}, n interface{}, source interface{}) *Backend_AllWithLockedSource_Call {
-	return &Backend_AllWithLockedSource_Call{Call: _e.mock.On("AllWithLockedSource", ctx, n, source)}
+func (_e *Backend_Expecter) AllWhileLocked(ctx interface{}, n interface{}) *Backend_AllWhileLocked_Call {
+	return &Backend_AllWhileLocked_Call{Call: _e.mock.On("AllWhileLocked", ctx, n)}
 }
 
-func (_c *Backend_AllWithLockedSource_Call) Run(run func(ctx context.Context, n metadata.MetadataNode, source io.Reader)) *Backend_AllWithLockedSource_Call {
+func (_c *Backend_AllWhileLocked_Call) Run(run func(ctx context.Context, n metadata.MetadataNode)) *Backend_AllWhileLocked_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metadata.MetadataNode), args[2].(io.Reader))
+		run(args[0].(context.Context), args[1].(metadata.MetadataNode))
 	})
 	return _c
 }
 
-func (_c *Backend_AllWithLockedSource_Call) Return(_a0 map[string][]byte, _a1 error) *Backend_AllWithLockedSource_Call {
+func (_c *Backend_AllWhileLocked_Call) Return(_a0 map[string][]byte, _a1 error) *Backend_AllWhileLocked_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Backend_AllWithLockedSource_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode, io.Reader) (map[string][]byte, error)) *Backend_AllWithLockedSource_Call {
+func (_c *Backend_AllWhileLocked_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode) (map[string][]byte, error)) *Backend_AllWhileLocked_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -458,73 +456,6 @@ func (_c *Backend_Lock_Call) Return(_a0 metadata.UnlockFunc, _a1 error) *Backend
 }
 
 func (_c *Backend_Lock_Call) RunAndReturn(run func(metadata.MetadataNode) (metadata.UnlockFunc, error)) *Backend_Lock_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// LockAndRead provides a mock function with given fields: n
-func (_m *Backend) LockAndRead(n metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error) {
-	ret := _m.Called(n)
-
-	if len(ret) == 0 {
-		panic("no return value specified for LockAndRead")
-	}
-
-	var r0 metadata.UnlockFunc
-	var r1 io.Reader
-	var r2 error
-	if rf, ok := ret.Get(0).(func(metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error)); ok {
-		return rf(n)
-	}
-	if rf, ok := ret.Get(0).(func(metadata.MetadataNode) metadata.UnlockFunc); ok {
-		r0 = rf(n)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(metadata.UnlockFunc)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(metadata.MetadataNode) io.Reader); ok {
-		r1 = rf(n)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(io.Reader)
-		}
-	}
-
-	if rf, ok := ret.Get(2).(func(metadata.MetadataNode) error); ok {
-		r2 = rf(n)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
-// Backend_LockAndRead_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LockAndRead'
-type Backend_LockAndRead_Call struct {
-	*mock.Call
-}
-
-// LockAndRead is a helper method to define mock.On call
-//   - n metadata.MetadataNode
-func (_e *Backend_Expecter) LockAndRead(n interface{}) *Backend_LockAndRead_Call {
-	return &Backend_LockAndRead_Call{Call: _e.mock.On("LockAndRead", n)}
-}
-
-func (_c *Backend_LockAndRead_Call) Run(run func(n metadata.MetadataNode)) *Backend_LockAndRead_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(metadata.MetadataNode))
-	})
-	return _c
-}
-
-func (_c *Backend_LockAndRead_Call) Return(_a0 metadata.UnlockFunc, _a1 io.Reader, _a2 error) *Backend_LockAndRead_Call {
-	_c.Call.Return(_a0, _a1, _a2)
-	return _c
-}
-
-func (_c *Backend_LockAndRead_Call) RunAndReturn(run func(metadata.MetadataNode) (metadata.UnlockFunc, io.Reader, error)) *Backend_LockAndRead_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/mocks/Backend.go
@@ -101,65 +101,6 @@ func (_c *Backend_All_Call) RunAndReturn(run func(context.Context, metadata.Meta
 	return _c
 }
 
-// AllWhileLocked provides a mock function with given fields: ctx, n
-func (_m *Backend) AllWhileLocked(ctx context.Context, n metadata.MetadataNode) (map[string][]byte, error) {
-	ret := _m.Called(ctx, n)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AllWhileLocked")
-	}
-
-	var r0 map[string][]byte
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode) (map[string][]byte, error)); ok {
-		return rf(ctx, n)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode) map[string][]byte); ok {
-		r0 = rf(ctx, n)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string][]byte)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, metadata.MetadataNode) error); ok {
-		r1 = rf(ctx, n)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Backend_AllWhileLocked_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AllWhileLocked'
-type Backend_AllWhileLocked_Call struct {
-	*mock.Call
-}
-
-// AllWhileLocked is a helper method to define mock.On call
-//   - ctx context.Context
-//   - n metadata.MetadataNode
-func (_e *Backend_Expecter) AllWhileLocked(ctx interface{}, n interface{}) *Backend_AllWhileLocked_Call {
-	return &Backend_AllWhileLocked_Call{Call: _e.mock.On("AllWhileLocked", ctx, n)}
-}
-
-func (_c *Backend_AllWhileLocked_Call) Run(run func(ctx context.Context, n metadata.MetadataNode)) *Backend_AllWhileLocked_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metadata.MetadataNode))
-	})
-	return _c
-}
-
-func (_c *Backend_AllWhileLocked_Call) Return(_a0 map[string][]byte, _a1 error) *Backend_AllWhileLocked_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *Backend_AllWhileLocked_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode) (map[string][]byte, error)) *Backend_AllWhileLocked_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Get provides a mock function with given fields: ctx, n, key
 func (_m *Backend) Get(ctx context.Context, n metadata.MetadataNode, key string) ([]byte, error) {
 	ret := _m.Called(ctx, n, key)
@@ -644,17 +585,17 @@ func (_c *Backend_Purge_Call) RunAndReturn(run func(context.Context, metadata.Me
 	return _c
 }
 
-// Remove provides a mock function with given fields: ctx, n, key, acquireLock
-func (_m *Backend) Remove(ctx context.Context, n metadata.MetadataNode, key string, acquireLock bool) error {
-	ret := _m.Called(ctx, n, key, acquireLock)
+// Remove provides a mock function with given fields: ctx, n, key
+func (_m *Backend) Remove(ctx context.Context, n metadata.MetadataNode, key string) error {
+	ret := _m.Called(ctx, n, key)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Remove")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, string, bool) error); ok {
-		r0 = rf(ctx, n, key, acquireLock)
+	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, string) error); ok {
+		r0 = rf(ctx, n, key)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -671,14 +612,13 @@ type Backend_Remove_Call struct {
 //   - ctx context.Context
 //   - n metadata.MetadataNode
 //   - key string
-//   - acquireLock bool
-func (_e *Backend_Expecter) Remove(ctx interface{}, n interface{}, key interface{}, acquireLock interface{}) *Backend_Remove_Call {
-	return &Backend_Remove_Call{Call: _e.mock.On("Remove", ctx, n, key, acquireLock)}
+func (_e *Backend_Expecter) Remove(ctx interface{}, n interface{}, key interface{}) *Backend_Remove_Call {
+	return &Backend_Remove_Call{Call: _e.mock.On("Remove", ctx, n, key)}
 }
 
-func (_c *Backend_Remove_Call) Run(run func(ctx context.Context, n metadata.MetadataNode, key string, acquireLock bool)) *Backend_Remove_Call {
+func (_c *Backend_Remove_Call) Run(run func(ctx context.Context, n metadata.MetadataNode, key string)) *Backend_Remove_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metadata.MetadataNode), args[2].(string), args[3].(bool))
+		run(args[0].(context.Context), args[1].(metadata.MetadataNode), args[2].(string))
 	})
 	return _c
 }
@@ -688,7 +628,7 @@ func (_c *Backend_Remove_Call) Return(_a0 error) *Backend_Remove_Call {
 	return _c
 }
 
-func (_c *Backend_Remove_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode, string, bool) error) *Backend_Remove_Call {
+func (_c *Backend_Remove_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode, string) error) *Backend_Remove_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -789,17 +729,17 @@ func (_c *Backend_Set_Call) RunAndReturn(run func(context.Context, metadata.Meta
 	return _c
 }
 
-// SetMultiple provides a mock function with given fields: ctx, n, attribs, acquireLock
-func (_m *Backend) SetMultiple(ctx context.Context, n metadata.MetadataNode, attribs map[string][]byte, acquireLock bool) error {
-	ret := _m.Called(ctx, n, attribs, acquireLock)
+// SetMultiple provides a mock function with given fields: ctx, n, attribs
+func (_m *Backend) SetMultiple(ctx context.Context, n metadata.MetadataNode, attribs map[string][]byte) error {
+	ret := _m.Called(ctx, n, attribs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetMultiple")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, map[string][]byte, bool) error); ok {
-		r0 = rf(ctx, n, attribs, acquireLock)
+	if rf, ok := ret.Get(0).(func(context.Context, metadata.MetadataNode, map[string][]byte) error); ok {
+		r0 = rf(ctx, n, attribs)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -816,14 +756,13 @@ type Backend_SetMultiple_Call struct {
 //   - ctx context.Context
 //   - n metadata.MetadataNode
 //   - attribs map[string][]byte
-//   - acquireLock bool
-func (_e *Backend_Expecter) SetMultiple(ctx interface{}, n interface{}, attribs interface{}, acquireLock interface{}) *Backend_SetMultiple_Call {
-	return &Backend_SetMultiple_Call{Call: _e.mock.On("SetMultiple", ctx, n, attribs, acquireLock)}
+func (_e *Backend_Expecter) SetMultiple(ctx interface{}, n interface{}, attribs interface{}) *Backend_SetMultiple_Call {
+	return &Backend_SetMultiple_Call{Call: _e.mock.On("SetMultiple", ctx, n, attribs)}
 }
 
-func (_c *Backend_SetMultiple_Call) Run(run func(ctx context.Context, n metadata.MetadataNode, attribs map[string][]byte, acquireLock bool)) *Backend_SetMultiple_Call {
+func (_c *Backend_SetMultiple_Call) Run(run func(ctx context.Context, n metadata.MetadataNode, attribs map[string][]byte)) *Backend_SetMultiple_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(metadata.MetadataNode), args[2].(map[string][]byte), args[3].(bool))
+		run(args[0].(context.Context), args[1].(metadata.MetadataNode), args[2].(map[string][]byte))
 	})
 	return _c
 }
@@ -833,7 +772,7 @@ func (_c *Backend_SetMultiple_Call) Return(_a0 error) *Backend_SetMultiple_Call 
 	return _c
 }
 
-func (_c *Backend_SetMultiple_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode, map[string][]byte, bool) error) *Backend_SetMultiple_Call {
+func (_c *Backend_SetMultiple_Call) RunAndReturn(run func(context.Context, metadata.MetadataNode, map[string][]byte) error) *Backend_SetMultiple_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
@@ -99,17 +99,21 @@ func (b XattrsBackend) list(ctx context.Context, n MetadataNode, acquireLock boo
 		if err != nil {
 			return nil, err
 		}
+		n.SetLockHeld(true)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
-		defer f.Close()
+		defer func() {
+			n.SetLockHeld(false)
+			_ = f.Close()
+		}()
 
 	}
 	return listXattr(filePath)
 }
 
-// All reads all extended attributes for a node, protected by a
-// shared file lock
+// All reads all extended attributes for a node. It acquires a shared file lock
+// unless the caller already holds the node's metadata lock (n.LockHeld()).
 func (b XattrsBackend) All(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return b.getAll(ctx, n, false, true)
+	return b.getAll(ctx, n, false, !n.LockHeld())
 }
 
 func (b XattrsBackend) getAll(ctx context.Context, n MetadataNode, skipCache, acquireLock bool) (map[string][]byte, error) {
@@ -162,13 +166,13 @@ func (b XattrsBackend) getAll(ctx context.Context, n MetadataNode, skipCache, ac
 
 // Set sets one attribute for the given path
 func (b XattrsBackend) Set(ctx context.Context, n MetadataNode, key string, val []byte) (err error) {
-	return b.SetMultiple(ctx, n, map[string][]byte{key: val}, true)
+	return b.SetMultiple(ctx, n, map[string][]byte{key: val})
 }
 
 // SetMultiple sets a set of attribute for the given path
-func (b XattrsBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte, acquireLock bool) (err error) {
+func (b XattrsBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs map[string][]byte) (err error) {
 	path := n.InternalPath()
-	if acquireLock {
+	if !n.LockHeld() {
 		err := os.MkdirAll(filepath.Dir(path), 0700)
 		if err != nil {
 			return err
@@ -177,8 +181,12 @@ func (b XattrsBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 		if err != nil {
 			return err
 		}
+		n.SetLockHeld(true)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
-		defer lockedFile.Close()
+		defer func() {
+			n.SetLockHeld(false)
+			_ = lockedFile.Close()
+		}()
 	}
 
 	// error handling: Count if there are errors while setting the attribs.
@@ -205,15 +213,19 @@ func (b XattrsBackend) SetMultiple(ctx context.Context, n MetadataNode, attribs 
 }
 
 // Remove an extended attribute key
-func (b XattrsBackend) Remove(ctx context.Context, n MetadataNode, key string, acquireLock bool) error {
+func (b XattrsBackend) Remove(ctx context.Context, n MetadataNode, key string) error {
 	path := n.InternalPath()
-	if acquireLock {
+	if !n.LockHeld() {
 		lockedFile, err := lockedfile.OpenFile(path+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			return err
 		}
+		n.SetLockHeld(true)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
-		defer lockedFile.Close()
+		defer func() {
+			n.SetLockHeld(false)
+			_ = lockedFile.Close()
+		}()
 	}
 
 	err := xattr.Remove(path, key)
@@ -274,21 +286,21 @@ func (XattrsBackend) LockfilePath(n MetadataNode) string { return n.InternalPath
 
 // Lock locks the metadata for the given path
 func (b XattrsBackend) Lock(n MetadataNode) (UnlockFunc, error) {
+	if n.LockHeld() {
+		return func() error { return nil }, nil
+	}
+
 	metaLockPath := b.LockfilePath(n)
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
+	n.SetLockHeld(true)
 	return func() error {
+		n.SetLockHeld(false)
 		// Warning: do not remove the lockfile or we may lock the same file more than once, https://github.com/opencloud-eu/opencloud/issues/1793
 		return mlock.Close()
 	}, nil
-}
-
-// AllWhileLocked reads all extended attributes assuming the caller already holds
-// the node's metadata lock.
-func (b XattrsBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
-	return b.All(ctx, n)
 }
 
 func (b XattrsBackend) cacheKey(n MetadataNode) string {

--- a/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/xattrs_backend.go
@@ -20,7 +20,6 @@ package metadata
 
 import (
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -286,24 +285,9 @@ func (b XattrsBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	}, nil
 }
 
-// LockAndRead locks the metadata for reading
-func (b XattrsBackend) LockAndRead(n MetadataNode) (UnlockFunc, io.Reader, error) {
-	unlock, err := b.Lock(n)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	f, err := os.Open(b.MetadataPath(n))
-	if err != nil {
-		_ = unlock()
-		return nil, nil, err
-	}
-	return unlock, f, nil
-}
-
-// AllWithLockedSource reads all extended attributes from the given reader.
-// The path argument is used for storing the data in the cache
-func (b XattrsBackend) AllWithLockedSource(ctx context.Context, n MetadataNode, _ io.Reader) (map[string][]byte, error) {
+// AllWhileLocked reads all extended attributes assuming the caller already holds
+// the node's metadata lock.
+func (b XattrsBackend) AllWhileLocked(ctx context.Context, n MetadataNode) (map[string][]byte, error) {
 	return b.All(ctx, n)
 }
 

--- a/pkg/storage/pkg/decomposedfs/node/lockowner_test.go
+++ b/pkg/storage/pkg/decomposedfs/node/lockowner_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package node_test
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/node"
+)
+
+var _ = Describe("BaseNode lock ownership", func() {
+	It("keeps LockHeld scoped to the owning goroutine", func() {
+		n := node.NewBaseNode("spaceid", "nodeid", nil)
+
+		// The owning goroutine takes the lock.
+		n.SetLockHeld(true)
+		Expect(n.LockHeld()).To(BeTrue())
+
+		// A different goroutine must not observe the same instance as lock-held.
+		otherObservedHeld := make(chan bool, 1)
+		go func() {
+			otherObservedHeld <- n.LockHeld()
+		}()
+		Expect(<-otherObservedHeld).To(BeFalse())
+
+		// Releasing in the owning goroutine clears ownership.
+		n.SetLockHeld(false)
+		Expect(n.LockHeld()).To(BeFalse())
+	})
+
+	It("stays race-free under concurrent LockHeld reads", func() {
+		n := node.NewBaseNode("spaceid", "nodeid", nil)
+
+		var wg sync.WaitGroup
+		errs := make(chan error, 16)
+
+		// Readers from other goroutines: they are not owners and must always observe false.
+		for range 16 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 1000 {
+					if n.LockHeld() {
+						errs <- fmt.Errorf("non-owning goroutine unexpectedly observed LockHeld() == true")
+						return
+					}
+				}
+			}()
+		}
+
+		// The owner repeatedly acquires and releases.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				n.SetLockHeld(true)
+				_ = n.LockHeld()
+				n.SetLockHeld(false)
+			}
+		}()
+
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+})

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -165,8 +165,7 @@ type PathLookup interface {
 	MetadataBackend() metadata.Backend
 	TimeManager() TimeManager
 	ReadBlobIDAndSizeAttr(ctx context.Context, n metadata.MetadataNode, attrs Attributes) (string, int64, error)
-	CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error)
-	CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error)
+	CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool)) (err error)
 
 	PurgeNode(n *Node) error
 }
@@ -179,6 +178,10 @@ type IDCacher interface {
 type BaseNode struct {
 	SpaceID string
 	ID      string
+
+	// lockHeld records that the caller already holds this node's metadata lock, so
+	// the metadata backend must not (re-)acquire it when reading attributes.
+	lockHeld bool
 
 	lu             PathLookup
 	internalPathID string
@@ -195,6 +198,14 @@ func NewBaseNode(spaceID, nodeID string, lu PathLookup) *BaseNode {
 
 func (n *BaseNode) GetSpaceID() string { return n.SpaceID }
 func (n *BaseNode) GetID() string      { return n.ID }
+
+// LockHeld reports whether the caller already holds this node's metadata lock.
+func (n *BaseNode) LockHeld() bool { return n.lockHeld }
+
+// SetLockHeld records whether the caller holds this node's metadata lock. The
+// metadata backend uses LockHeld to decide whether to (re-)acquire the lock when
+// reading attributes.
+func (n *BaseNode) SetLockHeld(held bool) { n.lockHeld = held }
 
 // InternalPath returns the internal path of the Node
 func (n *BaseNode) InternalPath() string {
@@ -372,7 +383,11 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 		return n, nil, errtypes.NotFound(filepath.Join(n.ParentID, n.Name))
 	}
 
-	return n, unlock, nil
+	n.SetLockHeld(true)
+	return n, func() error {
+		n.SetLockHeld(false)
+		return unlock()
+	}, nil
 }
 
 // ReadNode creates a new instance from an id and checks if it exists
@@ -392,9 +407,10 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		// read space root
 		spaceRoot = &Node{
 			BaseNode: BaseNode{
-				SpaceID: spaceID,
-				lu:      lu,
-				ID:      spaceID,
+				SpaceID:  spaceID,
+				lu:       lu,
+				ID:       spaceID,
+				lockHeld: alreadyLocked && nodeID == spaceID,
 			},
 		}
 		spaceRoot.SpaceRoot = spaceRoot
@@ -403,7 +419,7 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		// through the no-lock path so the owner/name/disabled reads below do not try
 		// to re-acquire the already-held lock and self-deadlock.
 		if alreadyLocked && nodeID == spaceID {
-			_, err = spaceRoot.XattrsWhileLocked(ctx)
+			_, err = spaceRoot.Xattrs(ctx)
 			switch {
 			case metadata.IsNotExist(err):
 				return spaceRoot, nil // swallow not found, the node defaults to exists = false
@@ -458,9 +474,10 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 	// read node
 	n := &Node{
 		BaseNode: BaseNode{
-			SpaceID: spaceID,
-			lu:      lu,
-			ID:      nodeID,
+			SpaceID:  spaceID,
+			lu:       lu,
+			ID:       nodeID,
+			lockHeld: alreadyLocked,
 		},
 		SpaceRoot: spaceRoot,
 	}
@@ -477,11 +494,7 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 	}()
 
 	var attrs Attributes
-	if alreadyLocked {
-		attrs, err = n.XattrsWhileLocked(ctx)
-	} else {
-		attrs, err = n.Xattrs(ctx)
-	}
+	attrs, err = n.Xattrs(ctx)
 	switch {
 	case metadata.IsNotExist(err):
 		return n, nil // swallow not found, the node defaults to exists = false
@@ -738,7 +751,7 @@ func (n *Node) SetMtimeString(ctx context.Context, mtime string) error {
 // SetMTime writes the UTC mtime to the extended attributes or removes the attribute if nil is passed
 func (n *Node) SetMtime(ctx context.Context, t *time.Time) (err error) {
 	if t == nil {
-		return n.RemoveXattr(ctx, prefixes.MTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.MTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.MTimeAttr, t.UTC().Format(time.RFC3339Nano))
 }
@@ -778,7 +791,7 @@ func (n *Node) SetFavorite(ctx context.Context, uid *userpb.UserId) error {
 func (n *Node) UnsetFavorite(ctx context.Context, uid *userpb.UserId) error {
 	// the favorite flag is specific to the user, so we need to incorporate the userid
 	fa := prefixes.FavoriteKey(uid)
-	return n.RemoveXattr(ctx, fa, true)
+	return n.RemoveXattr(ctx, fa)
 }
 
 // IsDir returns true if the node is a directory
@@ -1115,7 +1128,7 @@ func (n *Node) SetChecksum(ctx context.Context, csType string, h hash.Hash) (err
 
 // UnsetTempEtag removes the temporary etag attribute
 func (n *Node) UnsetTempEtag(ctx context.Context) (err error) {
-	return n.RemoveXattr(ctx, prefixes.TmpEtagAttr, true)
+	return n.RemoveXattr(ctx, prefixes.TmpEtagAttr)
 }
 
 func isGrantExpired(g *provider.Grant) bool {
@@ -1276,7 +1289,7 @@ func (n *Node) ReadGrant(ctx context.Context, grantee string) (g *provider.Grant
 }
 
 // ReadGrant reads a CS3 grant
-func (n *Node) DeleteGrant(ctx context.Context, g *provider.Grant, acquireLock bool) (err error) {
+func (n *Node) DeleteGrant(ctx context.Context, g *provider.Grant) (err error) {
 
 	var attr string
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_GROUP {
@@ -1285,7 +1298,7 @@ func (n *Node) DeleteGrant(ctx context.Context, g *provider.Grant, acquireLock b
 		attr = prefixes.GrantUserAcePrefix + g.Grantee.GetUserId().OpaqueId
 	}
 
-	if err = n.RemoveXattr(ctx, attr, acquireLock); err != nil {
+	if err = n.RemoveXattr(ctx, attr); err != nil {
 		return err
 	}
 
@@ -1377,7 +1390,7 @@ func (n *Node) UnmarkProcessing(ctx context.Context, uploadID string) error {
 		// file started another postprocessing later - do not remove
 		return nil
 	}
-	return n.RemoveXattr(ctx, prefixes.StatusPrefix, true)
+	return n.RemoveXattr(ctx, prefixes.StatusPrefix)
 }
 
 // IsProcessing returns true if the node is currently being processed
@@ -1402,7 +1415,7 @@ func (n *Node) SetScanData(ctx context.Context, info string, date time.Time) err
 	attribs := Attributes{}
 	attribs.SetString(prefixes.ScanStatusPrefix, info)
 	attribs.SetString(prefixes.ScanDatePrefix, date.Format(time.RFC3339Nano))
-	return n.SetXattrsWithContext(ctx, attribs, true)
+	return n.SetXattrsWithContext(ctx, attribs)
 }
 
 // ScanData returns scanning information of the node

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -44,6 +44,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/mime"
 	"github.com/opencloud-eu/reva/v2/pkg/rhttp/datatx/metrics"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/internal/goroutinelock"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/metadata/prefixes"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/ace"
@@ -179,9 +180,11 @@ type BaseNode struct {
 	SpaceID string
 	ID      string
 
-	// lockHeld records that the caller already holds this node's metadata lock, so
-	// the metadata backend must not (re-)acquire it when reading attributes.
-	lockHeld bool
+	// lock records which goroutine (if any) holds this node's metadata lock, so the
+	// metadata backend must not (re-)acquire it when reading attributes. Ownership is
+	// scoped to the acquiring goroutine: a node leaked into another goroutine reports
+	// LockHeld() == false there and takes its own lock rather than riding a stale flag.
+	lock goroutinelock.Lock
 
 	lu             PathLookup
 	internalPathID string
@@ -199,13 +202,18 @@ func NewBaseNode(spaceID, nodeID string, lu PathLookup) *BaseNode {
 func (n *BaseNode) GetSpaceID() string { return n.SpaceID }
 func (n *BaseNode) GetID() string      { return n.ID }
 
-// LockHeld reports whether the caller already holds this node's metadata lock.
-func (n *BaseNode) LockHeld() bool { return n.lockHeld }
+// LockHeld reports whether the calling goroutine holds this node's metadata lock.
+func (n *BaseNode) LockHeld() bool { return n.lock.Held() }
 
-// SetLockHeld records whether the caller holds this node's metadata lock. The
-// metadata backend uses LockHeld to decide whether to (re-)acquire the lock when
-// reading attributes.
-func (n *BaseNode) SetLockHeld(held bool) { n.lockHeld = held }
+// SetLockHeld records whether the calling goroutine holds this node's metadata
+// lock
+func (n *BaseNode) SetLockHeld(held bool) {
+	if held {
+		n.lock.Hold()
+		return
+	}
+	n.lock.Release()
+}
 
 // InternalPath returns the internal path of the Node
 func (n *BaseNode) InternalPath() string {
@@ -407,13 +415,15 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		// read space root
 		spaceRoot = &Node{
 			BaseNode: BaseNode{
-				SpaceID:  spaceID,
-				lu:       lu,
-				ID:       spaceID,
-				lockHeld: alreadyLocked && nodeID == spaceID,
+				SpaceID: spaceID,
+				lu:      lu,
+				ID:      spaceID,
 			},
 		}
 		spaceRoot.SpaceRoot = spaceRoot
+		if alreadyLocked && nodeID == spaceID {
+			spaceRoot.SetLockHeld(true)
+		}
 
 		// If we hold the lock on the space root itself, prime its attribute cache
 		// through the no-lock path so the owner/name/disabled reads below do not try
@@ -474,12 +484,14 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 	// read node
 	n := &Node{
 		BaseNode: BaseNode{
-			SpaceID:  spaceID,
-			lu:       lu,
-			ID:       nodeID,
-			lockHeld: alreadyLocked,
+			SpaceID: spaceID,
+			lu:      lu,
+			ID:      nodeID,
 		},
 		SpaceRoot: spaceRoot,
+	}
+	if alreadyLocked {
+		n.SetLockHeld(true)
 	}
 	if internalPath != "" {
 		n.internalPath = internalPath

--- a/pkg/storage/pkg/decomposedfs/node/node.go
+++ b/pkg/storage/pkg/decomposedfs/node/node.go
@@ -50,7 +50,6 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/utils/grants"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -139,7 +138,7 @@ type Tree interface {
 	BuildSpaceIDIndexEntry(spaceID string) string
 	ResolveSpaceIDIndexEntry(spaceID string) (string, error)
 
-	CreateRevision(ctx context.Context, n *Node, version string, f *lockedfile.File) (string, error)
+	CreateRevision(ctx context.Context, n *Node, version string) (string, error)
 	ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error)
 	DownloadRevision(ctx context.Context, ref *provider.Reference, revisionKey string, openReaderFunc func(md *provider.ResourceInfo) bool) (*provider.ResourceInfo, io.ReadCloser, error)
 
@@ -166,7 +165,7 @@ type PathLookup interface {
 	MetadataBackend() metadata.Backend
 	TimeManager() TimeManager
 	ReadBlobIDAndSizeAttr(ctx context.Context, n metadata.MetadataNode, attrs Attributes) (string, int64, error)
-	CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), lockedSource *lockedfile.File, acquireTargetLock bool) (err error)
+	CopyMetadataWithSourceLock(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error)
 	CopyMetadata(ctx context.Context, sourceNode, targetNode metadata.MetadataNode, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error)
 
 	PurgeNode(n *Node) error
@@ -355,15 +354,15 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 	ctx, span := tracer.Start(ctx, "LockAndReadNode")
 	defer span.End()
 
-	_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
+	_, subspan := tracer.Start(ctx, "MetadataBackend.Lock")
 	bn := NewBaseNode(spaceID, nodeID, lu)
-	unlock, r, err := lu.MetadataBackend().LockAndRead(bn)
+	unlock, err := lu.MetadataBackend().Lock(bn)
 	subspan.End()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	n, err := readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, r)
+	n, err := readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, true)
 	if err != nil {
 		_ = unlock()
 		return nil, nil, err
@@ -378,12 +377,13 @@ func LockAndReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, intern
 
 // ReadNode creates a new instance from an id and checks if it exists
 func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, error) {
-	return readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, nil)
+	return readNode(ctx, lu, spaceID, nodeID, internalPath, canListDisabledSpace, spaceRoot, skipParentCheck, false)
 }
 
-// readNode reads a node by its id. If a reader is provided, it will be passed to the metadata backend to read the metadata.
-// This is useful when the caller already holds a lock to prevent deadlocks when reading the metadata.
-func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool, r io.Reader) (*Node, error) {
+// readNode reads a node by its id. When alreadyLocked is true the caller already
+// holds the node's metadata lock, so the attributes are read without re-acquiring it
+// (which would dead-lock e.g. the hybrid backend).
+func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool, alreadyLocked bool) (*Node, error) {
 	ctx, span := tracer.Start(ctx, "ReadNode")
 	defer span.End()
 	var err error
@@ -402,8 +402,8 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 		// If we hold the lock on the space root itself, prime its attribute cache
 		// through the no-lock path so the owner/name/disabled reads below do not try
 		// to re-acquire the already-held lock and self-deadlock.
-		if r != nil && nodeID == spaceID {
-			_, err = spaceRoot.XattrsWithReader(ctx, r)
+		if alreadyLocked && nodeID == spaceID {
+			_, err = spaceRoot.XattrsWhileLocked(ctx)
 			switch {
 			case metadata.IsNotExist(err):
 				return spaceRoot, nil // swallow not found, the node defaults to exists = false
@@ -477,7 +477,11 @@ func readNode(ctx context.Context, lu PathLookup, spaceID, nodeID, internalPath 
 	}()
 
 	var attrs Attributes
-	attrs, err = n.XattrsWithReader(ctx, r)
+	if alreadyLocked {
+		attrs, err = n.XattrsWhileLocked(ctx)
+	} else {
+		attrs, err = n.Xattrs(ctx)
+	}
 	switch {
 	case metadata.IsNotExist(err):
 		return n, nil // swallow not found, the node defaults to exists = false
@@ -570,9 +574,9 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 	return readNode, nil
 }
 
-// ParentWithReader returns the parent node
-func (n *Node) ParentWithReader(ctx context.Context, r io.Reader) (*Node, error) {
-	_, span := tracer.Start(ctx, "ParentWithReader")
+// Parent returns the parent node
+func (n *Node) Parent(ctx context.Context) (*Node, error) {
+	_, span := tracer.Start(ctx, "Parent")
 	defer span.End()
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
@@ -586,8 +590,7 @@ func (n *Node) ParentWithReader(ctx context.Context, r io.Reader) (*Node, error)
 		SpaceRoot: n.SpaceRoot,
 	}
 
-	// fill metadata cache using the reader
-	attrs, err := p.XattrsWithReader(ctx, r)
+	attrs, err := p.Xattrs(ctx)
 	switch {
 	case metadata.IsNotExist(err):
 		return p, nil // swallow not found, the node defaults to exists = false
@@ -600,11 +603,6 @@ func (n *Node) ParentWithReader(ctx context.Context, r io.Reader) (*Node, error)
 	p.ParentID = attrs.String(prefixes.ParentidAttr)
 
 	return p, err
-}
-
-// Parent returns the parent node
-func (n *Node) Parent(ctx context.Context) (p *Node, err error) {
-	return n.ParentWithReader(ctx, nil)
 }
 
 // Owner returns the space owner

--- a/pkg/storage/pkg/decomposedfs/node/node_test.go
+++ b/pkg/storage/pkg/decomposedfs/node/node_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Node", func() {
 			n.BlobID = "TestBlobID"
 			n.Blobsize = blobsize
 
-			err = n.SetXattrs(n.NodeMetadata(env.Ctx), true)
+			err = n.SetXattrs(n.NodeMetadata(env.Ctx))
 			Expect(err).ToNot(HaveOccurred())
 			n2, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/pkg/decomposedfs/node/xattrs.go
+++ b/pkg/storage/pkg/decomposedfs/node/xattrs.go
@@ -71,7 +71,7 @@ func (md Attributes) SetTime(key string, t time.Time) {
 }
 
 // SetXattrs sets multiple extended attributes on the write-through cache/node
-func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]byte, acquireLock bool) (err error) {
+func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]byte) (err error) {
 	_, span := tracer.Start(ctx, "SetXattrsWithContext")
 	defer span.End()
 	if n.xattrsCache != nil {
@@ -80,12 +80,12 @@ func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]by
 		}
 	}
 
-	return n.lu.MetadataBackend().SetMultiple(ctx, n, attribs, acquireLock)
+	return n.lu.MetadataBackend().SetMultiple(ctx, n, attribs)
 }
 
 // SetXattrs sets multiple extended attributes on the write-through cache/node
-func (n *Node) SetXattrs(attribs map[string][]byte, acquireLock bool) (err error) {
-	return n.SetXattrsWithContext(context.Background(), attribs, acquireLock)
+func (n *Node) SetXattrs(attribs map[string][]byte) (err error) {
+	return n.SetXattrsWithContext(context.Background(), attribs)
 }
 
 // SetXattr sets an extended attribute on the write-through cache/node
@@ -107,11 +107,11 @@ func (n *Node) SetXattrString(ctx context.Context, key, val string) (err error) 
 }
 
 // RemoveXattr removes an extended attribute from the write-through cache/node
-func (n *Node) RemoveXattr(ctx context.Context, key string, acquireLock bool) error {
+func (n *Node) RemoveXattr(ctx context.Context, key string) error {
 	if n.xattrsCache != nil {
 		delete(n.xattrsCache, key)
 	}
-	return n.lu.MetadataBackend().Remove(ctx, n, key, acquireLock)
+	return n.lu.MetadataBackend().Remove(ctx, n, key)
 }
 
 // loadXattrs reads and caches the node's extended attributes using the given load
@@ -137,17 +137,6 @@ func (n *Node) loadXattrs(load func() (Attributes, error)) (Attributes, error) {
 	return n.xattrsCache, nil
 }
 
-// XattrsWhileLocked returns the extended attributes of the node assuming the caller
-// already holds the node's metadata lock (e.g. acquired via MetadataBackend().Lock).
-//
-// It does not re-acquire the metadata lock, so it is safe to call while holding it:
-// re-locking might dead-lock backends that lock unconditionally.
-func (n *Node) XattrsWhileLocked(ctx context.Context) (Attributes, error) {
-	return n.loadXattrs(func() (Attributes, error) {
-		return n.lu.MetadataBackend().AllWhileLocked(ctx, n)
-	})
-}
-
 // Xattrs returns the extended attributes of the node, acquiring the metadata lock as
 // needed. If the attributes have already been cached they are not read from disk
 // again.
@@ -161,27 +150,19 @@ func (n *Node) Xattrs(ctx context.Context) (Attributes, error) {
 // been cached it is not read from disk again.
 func (n *Node) Xattr(ctx context.Context, key string) ([]byte, error) {
 	path := n.InternalPath()
-
 	if path == "" {
-		// Do not try to read the attribute of an non-existing node
+		// Do not try to read the attribute of a non-existing node
 		return []byte{}, fs.ErrNotExist
 	}
 
-	if n.ID == "" {
-		// Do not try to read the attribute of an empty node. The InternalPath points to the
-		// base nodes directory in this case.
-		return []byte{}, &xattr.Error{Op: "node.Xattr", Path: path, Name: key, Err: xattr.ENOATTR}
+	attrs, err := n.loadXattrs(func() (Attributes, error) {
+		return n.lu.MetadataBackend().All(ctx, n)
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	if n.xattrsCache == nil {
-		attrs, err := n.lu.MetadataBackend().All(ctx, n)
-		if err != nil {
-			return []byte{}, err
-		}
-		n.xattrsCache = attrs
-	}
-
-	if val, ok := n.xattrsCache[key]; ok {
+	if val, ok := attrs[key]; ok {
 		return val, nil
 	}
 	// wrap the error as xattr does

--- a/pkg/storage/pkg/decomposedfs/node/xattrs.go
+++ b/pkg/storage/pkg/decomposedfs/node/xattrs.go
@@ -20,7 +20,6 @@ package node
 
 import (
 	"context"
-	"io"
 	"io/fs"
 	"strconv"
 	"time"
@@ -115,26 +114,21 @@ func (n *Node) RemoveXattr(ctx context.Context, key string, acquireLock bool) er
 	return n.lu.MetadataBackend().Remove(ctx, n, key, acquireLock)
 }
 
-// XattrsWithReader returns the extended attributes of the node. If the attributes have already
-// been cached they are not read from disk again.
-func (n *Node) XattrsWithReader(ctx context.Context, r io.Reader) (Attributes, error) {
+// loadXattrs reads and caches the node's extended attributes using the given load
+// function. It centralizes the empty-node guard and the write-through caching that
+// is shared by all the Xattrs accessors below.
+func (n *Node) loadXattrs(load func() (Attributes, error)) (Attributes, error) {
 	if n.ID == "" {
 		// Do not try to read the attribute of an empty node. The InternalPath points to the
 		// base nodes directory in this case.
-		return Attributes{}, &xattr.Error{Op: "node.XattrsWithReader", Path: n.InternalPath(), Err: xattr.ENOATTR}
+		return Attributes{}, &xattr.Error{Op: "node.Xattrs", Path: n.InternalPath(), Err: xattr.ENOATTR}
 	}
 
 	if n.xattrsCache != nil {
 		return n.xattrsCache, nil
 	}
 
-	var attrs Attributes
-	var err error
-	if r != nil {
-		attrs, err = n.lu.MetadataBackend().AllWithLockedSource(ctx, n, r)
-	} else {
-		attrs, err = n.lu.MetadataBackend().All(ctx, n)
-	}
+	attrs, err := load()
 	if err != nil {
 		return nil, err
 	}
@@ -143,10 +137,24 @@ func (n *Node) XattrsWithReader(ctx context.Context, r io.Reader) (Attributes, e
 	return n.xattrsCache, nil
 }
 
-// Xattrs returns the extended attributes of the node. If the attributes have already
-// been cached they are not read from disk again.
+// XattrsWhileLocked returns the extended attributes of the node assuming the caller
+// already holds the node's metadata lock (e.g. acquired via MetadataBackend().Lock).
+//
+// It does not re-acquire the metadata lock, so it is safe to call while holding it:
+// re-locking might dead-lock backends that lock unconditionally.
+func (n *Node) XattrsWhileLocked(ctx context.Context) (Attributes, error) {
+	return n.loadXattrs(func() (Attributes, error) {
+		return n.lu.MetadataBackend().AllWhileLocked(ctx, n)
+	})
+}
+
+// Xattrs returns the extended attributes of the node, acquiring the metadata lock as
+// needed. If the attributes have already been cached they are not read from disk
+// again.
 func (n *Node) Xattrs(ctx context.Context) (Attributes, error) {
-	return n.XattrsWithReader(ctx, nil)
+	return n.loadXattrs(func() (Attributes, error) {
+		return n.lu.MetadataBackend().All(ctx, n)
+	})
 }
 
 // Xattr returns an extended attribute of the node. If the attributes have already

--- a/pkg/storage/pkg/decomposedfs/options/options.go
+++ b/pkg/storage/pkg/decomposedfs/options/options.go
@@ -127,7 +127,7 @@ func New(m map[string]interface{}) (*Options, error) {
 	o.GatewayAddr = sharedconf.GetGatewaySVC(o.GatewayAddr)
 
 	if o.MetadataBackend == "" {
-		o.MetadataBackend = "xattrs"
+		o.MetadataBackend = "messagepack"
 	}
 
 	// ensure user layout has no starting or trailing /

--- a/pkg/storage/pkg/decomposedfs/revisions.go
+++ b/pkg/storage/pkg/decomposedfs/revisions.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	"github.com/rogpeppe/go-internal/lockedfile"
 
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
@@ -99,12 +98,12 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	}
 
 	// write lock node before copying metadata
-	f, err := lockedfile.OpenFile(fs.lu.MetadataBackend().LockfilePath(n), os.O_RDWR|os.O_CREATE, 0600)
+	unlock, err := fs.lu.MetadataBackend().Lock(n)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = f.Close()
+		_ = unlock()
 		_ = os.Remove(fs.lu.MetadataBackend().LockfilePath(n))
 	}()
 
@@ -116,7 +115,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	}
 
 	// create a revision of the current node
-	if _, err := fs.tp.CreateRevision(ctx, n, mtime.UTC().Format(time.RFC3339Nano), f); err != nil {
+	if _, err := fs.tp.CreateRevision(ctx, n, mtime.UTC().Format(time.RFC3339Nano)); err != nil {
 		return err
 	}
 

--- a/pkg/storage/pkg/decomposedfs/spaces.go
+++ b/pkg/storage/pkg/decomposedfs/spaces.go
@@ -196,7 +196,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		metadata.SetString(prefixes.SpaceAliasAttr, alias)
 	}
 
-	if err := root.SetXattrsWithContext(ctx, metadata, true); err != nil {
+	if err := root.SetXattrsWithContext(ctx, metadata); err != nil {
 		return nil, err
 	}
 
@@ -697,7 +697,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 	metadata[prefixes.TreeMTimeAttr] = []byte(time.Now().UTC().Format(time.RFC3339Nano))
 
-	err = spaceNode.SetXattrsWithContext(ctx, metadata, true)
+	err = spaceNode.SetXattrsWithContext(ctx, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -967,7 +967,7 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 			// This way we don't have to have a cron job checking the grants in regular intervals.
 			// The tradeof obviously is that this code is here.
 			if isGrantExpired(g) {
-				if err := n.DeleteGrant(ctx, g, true); err != nil {
+				if err := n.DeleteGrant(ctx, g); err != nil {
 					sublog.Error().Err(err).Str("grantee", id).
 						Msg("failed to delete expired space grant")
 				}

--- a/pkg/storage/pkg/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/pkg/decomposedfs/testhelpers/helpers.go
@@ -308,7 +308,7 @@ func (t *DecomposedTestEnv) CreateTestFile(name, blobID, parentID, spaceID strin
 	if err != nil {
 		return nil, err
 	}
-	err = n.SetXattrs(n.NodeMetadata(t.Ctx), true)
+	err = n.SetXattrs(n.NodeMetadata(t.Ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/pkg/decomposedfs/timemanager/timemanager.go
+++ b/pkg/storage/pkg/decomposedfs/timemanager/timemanager.go
@@ -54,7 +54,7 @@ func (dtm *Manager) MTime(ctx context.Context, n *node.Node) (time.Time, error) 
 // If the time is nil, the attribute is removed.
 func (dtm *Manager) SetMTime(ctx context.Context, n *node.Node, mtime *time.Time) error {
 	if mtime == nil {
-		return n.RemoveXattr(ctx, prefixes.MTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.MTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.MTimeAttr, mtime.UTC().Format(time.RFC3339Nano))
 }
@@ -75,7 +75,7 @@ func (dtm *Manager) TMTime(ctx context.Context, n *node.Node) (time.Time, error)
 // If the time is nil, the attribute is removed.
 func (dtm *Manager) SetTMTime(ctx context.Context, n *node.Node, tmtime *time.Time) error {
 	if tmtime == nil {
-		return n.RemoveXattr(ctx, prefixes.TreeMTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.TreeMTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.TreeMTimeAttr, tmtime.UTC().Format(time.RFC3339Nano))
 }
@@ -121,7 +121,7 @@ func (dtm *Manager) DTime(ctx context.Context, n *node.Node) (tmTime time.Time, 
 // If the time is nil, the attribute is removed.
 func (dtm *Manager) SetDTime(ctx context.Context, n *node.Node, t *time.Time) (err error) {
 	if t == nil {
-		return n.RemoveXattr(ctx, prefixes.DTimeAttr, true)
+		return n.RemoveXattr(ctx, prefixes.DTimeAttr)
 	}
 	return n.SetXattrString(ctx, prefixes.DTimeAttr, t.UTC().Format(time.RFC3339Nano))
 }

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
@@ -385,7 +385,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, reca
 		log.Debug().Uint64("newSize", newSize).Msg("updated treesize of node")
 	}
 
-	if err = n.SetXattrsWithContext(ctx, attrs, false); err != nil {
+	if err = n.SetXattrsWithContext(ctx, attrs); err != nil {
 		log.Error().Err(err).Msg("Failed to update extend attributes of node")
 		cleanup()
 		return

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
@@ -43,12 +43,6 @@ const (
 
 var _propagationGracePeriod = 3 * time.Minute
 
-type PropagationNode interface {
-	GetSpaceID() string
-	GetID() string
-	InternalPath() string
-}
-
 // AsyncPropagator implements asynchronous treetime & treesize propagation
 type AsyncPropagator struct {
 	treeSizeAccounting bool
@@ -130,8 +124,8 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, o options.A
 					now := time.Now()
 					_ = os.Chtimes(changesDirPath, now, now)
 
-					n := node.NewBaseNode(parts[0], strings.TrimSuffix(parts[1], ".processing"), lookup)
-					p.propagate(context.Background(), n, true, *log)
+					nodeID := strings.TrimSuffix(parts[1], ".processing")
+					p.propagate(context.Background(), parts[0], nodeID, true, *log)
 				}()
 			}
 		}
@@ -164,14 +158,17 @@ func (p AsyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff i
 		SyncTime: time.Now().UTC(),
 		SizeDiff: sizeDiff,
 	}
-	go p.queuePropagation(ctx, n, c, log)
+
+	// Hand only the node's logical identity to the goroutine, never the live
+	// *node.Node: sharing the instance would leak and race its metadata-lock state.
+	go p.queuePropagation(ctx, n.SpaceID, n.ID, c, log)
 
 	return nil
 }
 
-func (p AsyncPropagator) queuePropagation(ctx context.Context, n *node.Node, change Change, log zerolog.Logger) {
+func (p AsyncPropagator) queuePropagation(ctx context.Context, spaceID, nodeID string, change Change, log zerolog.Logger) {
 	// add a change to the parent node
-	changePath := p.changesPath(n.SpaceID, n.ID, uuid.New().String()+".mpk")
+	changePath := p.changesPath(spaceID, nodeID, uuid.New().String()+".mpk")
 
 	data, err := msgpack.Marshal(change)
 	if err != nil {
@@ -212,7 +209,7 @@ func (p AsyncPropagator) queuePropagation(ctx context.Context, n *node.Node, cha
 
 	log.Debug().Msg("propagating")
 	// add a change to the parent node
-	changeDirPath := p.changesPath(n.SpaceID, n.ID, "")
+	changeDirPath := p.changesPath(spaceID, nodeID, "")
 
 	// first rename the existing node dir
 	err = os.Rename(changeDirPath, changeDirPath+".processing")
@@ -224,11 +221,11 @@ func (p AsyncPropagator) queuePropagation(ctx context.Context, n *node.Node, cha
 		//    -> ignore, the previous propagation will pick the new changes up
 		return
 	}
-	p.propagate(ctx, n, false, log)
+	p.propagate(ctx, spaceID, nodeID, false, log)
 }
 
-func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, recalculateTreeSize bool, log zerolog.Logger) {
-	changeDirPath := p.changesPath(pn.GetSpaceID(), pn.GetID(), "")
+func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, recalculateTreeSize bool, log zerolog.Logger) {
+	changeDirPath := p.changesPath(spaceID, nodeID, "")
 	processingPath := changeDirPath + ".processing"
 
 	cleanup := func() {
@@ -286,7 +283,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, reca
 	attrs := node.Attributes{}
 
 	_, subspan = tracer.Start(ctx, "node.LockAndReadNode")
-	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, pn.GetSpaceID(), pn.GetID(), "", false, nil, false)
+	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, spaceID, nodeID, "", false, nil, false)
 	subspan.End()
 	if err != nil {
 		if n != nil && !n.Exists {
@@ -400,7 +397,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, reca
 	cleanup()
 
 	if !n.IsSpaceRoot(ctx) {
-		p.queuePropagation(ctx, n, pc, log)
+		p.queuePropagation(ctx, n.SpaceID, n.ID, pc, log)
 	}
 
 	// Check for a changes dir that might have been added meanwhile and pick it up
@@ -416,7 +413,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, pn PropagationNode, reca
 			//    -> ignore, the previous propagation will pick the new changes up
 			return
 		}
-		p.propagate(ctx, n, false, log)
+		p.propagate(ctx, spaceID, nodeID, false, log)
 	}
 }
 

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -190,7 +190,7 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 		log.Debug().Uint64("newSize", newSize).Msg("updated treesize of parent node")
 	}
 
-	if err = n.SetXattrsWithContext(ctx, attrs, false); err != nil {
+	if err = n.SetXattrsWithContext(ctx, attrs); err != nil {
 		log.Error().Err(err).Msg("Failed to update extend attributes of parent node")
 		return n, true, err
 	}

--- a/pkg/storage/pkg/decomposedfs/tree/revisions.go
+++ b/pkg/storage/pkg/decomposedfs/tree/revisions.go
@@ -30,7 +30,6 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 
 	"github.com/opencloud-eu/reva/v2/pkg/appctx"
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
@@ -49,8 +48,10 @@ import (
 // We can add a background process to move old revisions to a slower storage
 // and replace the revision file with a symbolic link in the future, if necessary.
 
-// CreateVersion creates a new version of the node
-func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string, f *lockedfile.File) (string, error) {
+// CreateRevision creates a new version of the node. The caller MUST already hold the
+// metadata lock of n, as the node's metadata is read (without re-locking) to copy the
+// blob metadata onto the new revision.
+func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string) (string, error) {
 	versionNode := node.NewBaseNode(n.SpaceID, n.ID+node.RevisionIDDelimiter+version, tp.lookup)
 	versionPath := versionNode.InternalPath()
 
@@ -122,7 +123,7 @@ func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr ||
 			attributeName == prefixes.MTimeAttr
-	}, f, true); err != nil {
+	}, true); err != nil {
 		return "", err
 	}
 

--- a/pkg/storage/pkg/decomposedfs/tree/revisions.go
+++ b/pkg/storage/pkg/decomposedfs/tree/revisions.go
@@ -117,13 +117,13 @@ func (tp *Tree) CreateRevision(ctx context.Context, n *node.Node, version string
 	defer vf.Close()
 
 	// copy blob metadata to version node
-	if err := tp.lookup.CopyMetadataWithSourceLock(ctx, n, versionNode, func(attributeName string, value []byte) (newValue []byte, copy bool) {
+	if err := tp.lookup.CopyMetadata(ctx, n, versionNode, func(attributeName string, value []byte) (newValue []byte, copy bool) {
 		return value, strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr ||
 			attributeName == prefixes.MTimeAttr
-	}, true); err != nil {
+	}); err != nil {
 		return "", err
 	}
 
@@ -337,7 +337,7 @@ func (tp *Tree) RestoreRevision(ctx context.Context, sourceNode, targetNode meta
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr
-	}, false)
+	})
 	if err != nil {
 		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 	}
@@ -348,8 +348,7 @@ func (tp *Tree) RestoreRevision(ctx context.Context, sourceNode, targetNode meta
 	err = tp.lookup.MetadataBackend().SetMultiple(ctx, targetNode,
 		map[string][]byte{
 			prefixes.MTimeAttr: []byte(mtime.UTC().Format(time.RFC3339Nano)),
-		},
-		false)
+		})
 	if err != nil {
 		return errtypes.InternalError("failed to set mtime attribute on node: " + err.Error())
 	}

--- a/pkg/storage/pkg/decomposedfs/tree/tree.go
+++ b/pkg/storage/pkg/decomposedfs/tree/tree.go
@@ -156,7 +156,7 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node, markprocessing bool,
 			return errors.Wrap(err, "Decomposedfs: could not set mtime")
 		}
 	}
-	err = n.SetXattrsWithContext(ctx, attributes, true)
+	err = n.SetXattrsWithContext(ctx, attributes)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 	attribs := node.Attributes{}
 	attribs.SetString(prefixes.ParentidAttr, newNode.ParentID)
 	attribs.SetString(prefixes.NameAttr, newNode.Name)
-	if err := oldNode.SetXattrsWithContext(ctx, attribs, true); err != nil {
+	if err := oldNode.SetXattrsWithContext(ctx, attribs); err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not update old node attributes")
 	}
 
@@ -458,7 +458,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	trashLink := filepath.Join(t.options.Root, "spaces", lookup.Pathify(n.SpaceRoot.ID, 1, 2), "trash", lookup.Pathify(n.ID, 4, 2))
 	if err := os.MkdirAll(filepath.Dir(trashLink), 0700); err != nil {
 		// Roll back changes
-		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
+		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr)
 		return err
 	}
 
@@ -471,7 +471,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	err = os.Symlink("../../../../../nodes/"+lookup.Pathify(n.ID, 4, 2)+node.TrashIDDelimiter+deletionTime, trashLink)
 	if err != nil {
 		// Roll back changes
-		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
+		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr)
 		return
 	}
 
@@ -485,12 +485,12 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 		// To roll back changes
 		// TODO remove symlink
 		// Roll back changes
-		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
+		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr)
 		return
 	}
 	err = t.lookup.MetadataBackend().Rename(n, trashNode)
 	if err != nil {
-		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
+		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr)
 		_ = os.Rename(trashPath, nodePath)
 		return
 	}
@@ -507,7 +507,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 		// TODO revert the rename
 		// TODO remove symlink
 		// Roll back changes
-		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr, true)
+		_ = n.RemoveXattr(ctx, prefixes.TrashOriginAttr)
 		return
 	}
 
@@ -580,7 +580,7 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		// set ParentidAttr to restorePath's node parent id
 		attrs.SetString(prefixes.ParentidAttr, targetNode.ParentID)
 
-		if err = t.lookup.MetadataBackend().SetMultiple(ctx, restoreNode, map[string][]byte(attrs), true); err != nil {
+		if err = t.lookup.MetadataBackend().SetMultiple(ctx, restoreNode, map[string][]byte(attrs)); err != nil {
 			return nil, errors.Wrap(err, "Decomposedfs: could not update recycle node")
 		}
 
@@ -850,7 +850,7 @@ func (t *Tree) createDirNode(ctx context.Context, n *node.Node) (err error) {
 	if t.options.TreeTimeAccounting || t.options.TreeSizeAccounting {
 		attributes[prefixes.PropagationAttr] = []byte("1") // mark the node for propagation
 	}
-	return n.SetXattrsWithContext(ctx, attributes, true)
+	return n.SetXattrsWithContext(ctx, attributes)
 }
 
 var nodeIDRegep = regexp.MustCompile(`.*/nodes/([^.]*).*`)

--- a/pkg/storage/pkg/decomposedfs/upload/store.go
+++ b/pkg/storage/pkg/decomposedfs/upload/store.go
@@ -285,7 +285,7 @@ func (store DecomposedFsStore) CreateNodeForUpload(ctx context.Context, session 
 	}
 
 	// update node metadata with new blobid etc
-	err = n.SetXattrsWithContext(ctx, initAttrs, false)
+	err = n.SetXattrsWithContext(ctx, initAttrs)
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: could not write metadata")
 	}

--- a/pkg/storage/pkg/decomposedfs/upload/store.go
+++ b/pkg/storage/pkg/decomposedfs/upload/store.go
@@ -44,7 +44,6 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/options"
 	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/usermapper"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	"github.com/rs/zerolog"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 )
@@ -306,14 +305,9 @@ func (store DecomposedFsStore) updateExistingNode(ctx context.Context, session *
 	defer span.End()
 
 	// write lock existing node before reading any metadata
-	f, err := lockedfile.OpenFile(store.lu.MetadataBackend().LockfilePath(n), os.O_RDWR|os.O_CREATE, 0600)
+	unlock, err := store.lu.MetadataBackend().Lock(n)
 	if err != nil {
 		return nil, err
-	}
-
-	unlock := func() error {
-		// NOTE: to prevent stale NFS file handles do not remove lock file!
-		return f.Close()
 	}
 
 	old, _ := node.ReadNode(ctx, store.lu, spaceID, n.ID, "", false, nil, false)
@@ -366,7 +360,7 @@ func (store DecomposedFsStore) updateExistingNode(ctx context.Context, session *
 		span.AddEvent("CreateVersion")
 		timestamp := oldNodeMtime.UTC().Format(time.RFC3339Nano)
 		versionID := n.ID + node.RevisionIDDelimiter + timestamp
-		versionPath, err := session.store.tp.CreateRevision(ctx, n, timestamp, f)
+		versionPath, err := session.store.tp.CreateRevision(ctx, n, timestamp)
 		if err != nil {
 			if !errors.Is(err, os.ErrExist) {
 				return unlock, err
@@ -389,7 +383,7 @@ func (store DecomposedFsStore) updateExistingNode(ctx context.Context, session *
 			}
 
 			// clean revision file
-			if versionPath, err = session.store.tp.CreateRevision(ctx, n, timestamp, f); err != nil {
+			if versionPath, err = session.store.tp.CreateRevision(ctx, n, timestamp); err != nil {
 				return unlock, err
 			}
 		}

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -295,7 +295,7 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	ctx, span := tracer.Start(session.Context(ctx), "Finalize")
 	defer span.End()
 
-	revisionNode := node.New(session.SpaceID(), session.NodeID(), "", "", session.Size(), session.ID(),
+	n := node.New(session.SpaceID(), session.NodeID(), "", "", session.Size(), session.ID(),
 		provider.ResourceType_RESOURCE_TYPE_FILE, session.SpaceOwner(), session.store.lu)
 
 	var (
@@ -309,11 +309,11 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	case spaceRoot.InternalPath() == "":
 		return fmt.Errorf("space root for space id %s has no valid internal path", session.SpaceID())
 	default:
-		revisionNode.SpaceRoot = spaceRoot
+		n.SpaceRoot = spaceRoot
 	}
 
 	// lock the node before reading its metadata and writing the blob
-	unlock, err := session.store.lu.MetadataBackend().Lock(revisionNode)
+	unlock, err := session.store.lu.MetadataBackend().Lock(n)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	}()
 
 	// Read the node attributes while holding the lock acquired above.
-	attribs, err := revisionNode.Xattrs(ctx)
+	attribs, err := n.Xattrs(ctx)
 	if err != nil {
 		return err
 	}
@@ -332,32 +332,27 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 
 	// another upload on this node is in progress or has finished since we started
 	if !isProcessing || processingID != session.ID() {
-		versionID := revisionNode.ID + node.RevisionIDDelimiter + session.MTime().UTC().Format(time.RFC3339Nano)
+		versionID := n.ID + node.RevisionIDDelimiter + session.MTime().UTC().Format(time.RFC3339Nano)
 		// There should be a revision node (created by the other upload that finished before us), read it and upload our blob there.
-		existingRevisionNode, err := node.ReadNode(ctx, session.store.lu, session.SpaceID(), versionID, "", false, spaceRoot, false)
+		existingRevisionNode, revisionNodeUnlock, err := node.LockAndReadNode(ctx, session.store.lu, session.SpaceID(), versionID, "", false, spaceRoot, false)
 		if err != nil || !existingRevisionNode.Exists {
 			// The revision node has not been created. Likely because the file on disk was modified externally and re-assilimated (watchfs == true)
 			// Let's create the revision node now and upload the blob to it.
-			revisionNode, err = session.createRevisionNodeForUpload(ctx, revisionNode, session.MTime().UTC().Format(time.RFC3339Nano))
+			n, revisionNodeUnlock, err = session.createRevisionNodeForUpload(ctx, n, session.MTime().UTC().Format(time.RFC3339Nano))
 			if err != nil {
 				appctx.GetLogger(ctx).Debug().Err(err).Str("versionID", session.MTime().UTC().Format(time.RFC3339Nano)).Msg("failed to create revision node for upload finalization")
 				return err
 			}
 		} else {
-			revisionNode = existingRevisionNode
+			n = existingRevisionNode
 		}
-		// lock this node as well, before writing the blob
-		revisionNodeUnlock, err := session.store.lu.MetadataBackend().Lock(revisionNode)
-		if err != nil {
-			return err
-		}
-		appctx.GetLogger(ctx).Debug().Str("new nodepath", revisionNode.InternalPath()).Msg("uploading to revision node, that was created for us by another upload")
+		appctx.GetLogger(ctx).Debug().Str("new nodepath", n.InternalPath()).Msg("uploading to revision node, that was created for us by another upload")
 		defer func() { _ = revisionNodeUnlock() }()
 	}
 
 	// upload the data to the blobstore
 	_, subspan := tracer.Start(ctx, "WriteBlob")
-	err = session.store.tp.WriteBlob(revisionNode, session.binPath())
+	err = session.store.tp.WriteBlob(n, session.binPath())
 	subspan.End()
 	if err != nil {
 		return errors.Wrap(err, "failed to upload file to blobstore")
@@ -366,19 +361,19 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	return nil
 }
 
-func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Context, baseNode *node.Node, rev string) (*node.Node, error) {
+func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Context, baseNode *node.Node, rev string) (*node.Node, func() error, error) {
 	versionID := baseNode.ID + node.RevisionIDDelimiter + rev
 	log := appctx.GetLogger(ctx)
 	_, err := session.store.tp.CreateRevision(ctx, baseNode, rev)
 	if err != nil {
 		log.Error().Err(err).Str("versionID", versionID).Msg("failed to create revision node for upload")
-		return nil, err
+		return nil, nil, err
 	}
 
 	// FIXME: We already calculated the checksums in FinishUpload, we should maybe pass them via the session instead of recalculating them here
 	sha1h, md5h, adler32h, err := node.CalculateChecksums(ctx, session.binPath())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// update checksums
@@ -387,7 +382,7 @@ func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Cont
 		prefixes.ChecksumPrefix + "md5":     md5h.Sum(nil),
 		prefixes.ChecksumPrefix + "adler32": adler32h.Sum(nil),
 	}
-	revisionNode, err := node.ReadNode(ctx, session.store.lu, session.SpaceID(), versionID, "", false, baseNode.SpaceRoot, false)
+	revisionNode, unlock, err := node.LockAndReadNode(ctx, session.store.lu, session.SpaceID(), versionID, "", false, baseNode.SpaceRoot, false)
 	if err == nil {
 		mtime := session.MTime()
 		attrs.SetString(prefixes.BlobIDAttr, session.ID())
@@ -397,17 +392,14 @@ func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Cont
 
 		err = session.store.lu.TimeManager().OverrideMtime(ctx, revisionNode, &attrs, mtime)
 		if err != nil {
-			return nil, errors.Wrap(err, "Decomposedfs: failed to set the mtime")
+			return nil, nil, errors.Wrap(err, "Decomposedfs: failed to set the mtime")
 		}
-		// The revision node was just created and is not shared yet, so no metadata lock
-		// needs to be acquired for the write below.
-		revisionNode.SetLockHeld(true)
 		err = revisionNode.SetXattrsWithContext(ctx, attrs)
 		if err != nil {
-			return nil, errors.Wrap(err, "Decomposedfs: failed to set node attributes")
+			return nil, nil, errors.Wrap(err, "Decomposedfs: failed to set node attributes")
 		}
 	}
-	return revisionNode, err
+	return revisionNode, unlock, err
 }
 
 func checkHash(expected string, h hash.Hash) error {

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -322,7 +322,7 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	}()
 
 	// Read the node attributes while holding the lock acquired above.
-	attribs, err := revisionNode.XattrsWhileLocked(ctx)
+	attribs, err := revisionNode.Xattrs(ctx)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,10 @@ func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Cont
 		if err != nil {
 			return nil, errors.Wrap(err, "Decomposedfs: failed to set the mtime")
 		}
-		err = revisionNode.SetXattrsWithContext(ctx, attrs, false)
+		// The revision node was just created and is not shared yet, so no metadata lock
+		// needs to be acquired for the write below.
+		revisionNode.SetLockHeld(true)
+		err = revisionNode.SetXattrsWithContext(ctx, attrs)
 		if err != nil {
 			return nil, errors.Wrap(err, "Decomposedfs: failed to set node attributes")
 		}

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -392,10 +392,12 @@ func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Cont
 
 		err = session.store.lu.TimeManager().OverrideMtime(ctx, revisionNode, &attrs, mtime)
 		if err != nil {
+			_ = unlock()
 			return nil, nil, errors.Wrap(err, "Decomposedfs: failed to set the mtime")
 		}
 		err = revisionNode.SetXattrsWithContext(ctx, attrs)
 		if err != nil {
+			_ = unlock()
 			return nil, nil, errors.Wrap(err, "Decomposedfs: failed to set node attributes")
 		}
 	}

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -35,7 +35,6 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pkg/errors"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -313,16 +312,17 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 		revisionNode.SpaceRoot = spaceRoot
 	}
 
-	// lock the node before writing the blob
-	lockedNode, err := lockedfile.OpenFile(session.store.lu.MetadataBackend().LockfilePath(revisionNode), os.O_RDWR|os.O_CREATE, 0600)
+	// lock the node before reading its metadata and writing the blob
+	unlock, err := session.store.lu.MetadataBackend().Lock(revisionNode)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		_ = lockedNode.Close()
+		_ = unlock()
 	}()
 
-	attribs, err := revisionNode.XattrsWithReader(ctx, lockedNode)
+	// Read the node attributes while holding the lock acquired above.
+	attribs, err := revisionNode.XattrsWhileLocked(ctx)
 	if err != nil {
 		return err
 	}
@@ -338,7 +338,7 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 		if err != nil || !existingRevisionNode.Exists {
 			// The revision node has not been created. Likely because the file on disk was modified externally and re-assilimated (watchfs == true)
 			// Let's create the revision node now and upload the blob to it.
-			revisionNode, err = session.createRevisionNodeForUpload(ctx, revisionNode, session.MTime().UTC().Format(time.RFC3339Nano), lockedNode)
+			revisionNode, err = session.createRevisionNodeForUpload(ctx, revisionNode, session.MTime().UTC().Format(time.RFC3339Nano))
 			if err != nil {
 				appctx.GetLogger(ctx).Debug().Err(err).Str("versionID", session.MTime().UTC().Format(time.RFC3339Nano)).Msg("failed to create revision node for upload finalization")
 				return err
@@ -366,10 +366,10 @@ func (session *DecomposedFsSession) Finalize(ctx context.Context) (err error) {
 	return nil
 }
 
-func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Context, baseNode *node.Node, rev string, lockedNode *lockedfile.File) (*node.Node, error) {
+func (session *DecomposedFsSession) createRevisionNodeForUpload(ctx context.Context, baseNode *node.Node, rev string) (*node.Node, error) {
 	versionID := baseNode.ID + node.RevisionIDDelimiter + rev
 	log := appctx.GetLogger(ctx)
-	_, err := session.store.tp.CreateRevision(ctx, baseNode, rev, lockedNode)
+	_, err := session.store.tp.CreateRevision(ctx, baseNode, rev)
 	if err != nil {
 		log.Error().Err(err).Str("versionID", versionID).Msg("failed to create revision node for upload")
 		return nil, err

--- a/pkg/storage/pkg/decomposedfs/upload_async_test.go
+++ b/pkg/storage/pkg/decomposedfs/upload_async_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 
-		lu = lookup.New(metadata.NewXattrsBackend(o.FileMetadataCache), o, &timemanager.Manager{})
+		lu = lookup.New(metadata.NewMessagePackBackend(o.FileMetadataCache), o, &timemanager.Manager{})
 		pmock = &mocks.PermissionsChecker{}
 
 		cs3permissionsclient = &mocks.CS3PermissionsClient{}

--- a/pkg/storage/pkg/decomposedfs/upload_test.go
+++ b/pkg/storage/pkg/decomposedfs/upload_test.go
@@ -108,7 +108,7 @@ var _ = Describe("File uploads", func() {
 			},
 		})
 		Expect(err).ToNot(HaveOccurred())
-		lu = lookup.New(metadata.NewXattrsBackend(o.FileMetadataCache), o, &timemanager.Manager{})
+		lu = lookup.New(metadata.NewMessagePackBackend(o.FileMetadataCache), o, &timemanager.Manager{})
 		pmock = &mocks.PermissionsChecker{}
 		cs3permissionsclient = &mocks.CS3PermissionsClient{}
 		pool.RemoveSelector("PermissionsSelector" + "any")

--- a/tests/oc-integration-tests/ci/storage-users-decomposeds3.toml
+++ b/tests/oc-integration-tests/ci/storage-users-decomposeds3.toml
@@ -31,7 +31,7 @@ permissionssvc = "localhost:10000"
 "s3.bucket" = "test"
 "s3.access_key" = "test"
 "s3.secret_key" = "test"
-"metadata_backend" = "xattrs"
+"metadata_backend" = "messagepack"
 
 # we have a locally running dataprovider
 [http]
@@ -51,4 +51,4 @@ permissionssvc = "localhost:10000"
 "s3.bucket" = "test"
 "s3.access_key" = "test"
 "s3.secret_key" = "test"
-"metadata_backend" = "xattrs"
+"metadata_backend" = "messagepack"

--- a/tests/oc-integration-tests/local/storage-users-decomposeds3.toml
+++ b/tests/oc-integration-tests/local/storage-users-decomposeds3.toml
@@ -38,7 +38,7 @@ permissionssvc = "localhost:10000"
 "s3.bucket" = "test"
 "s3.access_key" = "testadmin"
 "s3.secret_key" = "testadmin"
-"metadata_backend" = "xattrs"
+"metadata_backend" = "messagepack"
 
 # we have a locally running dataprovider
 [http]
@@ -58,4 +58,4 @@ permissionssvc = "localhost:10000"
 "s3.bucket" = "test"
 "s3.access_key" = "testadmin"
 "s3.secret_key" = "testadmin"
-"metadata_backend" = "xattrs"
+"metadata_backend" = "messagepack"


### PR DESCRIPTION
This reworks the metadata interfaces to prevent misuse of the `LockAndRead` and `AllWithLockedSource` methods.

The `LockAndRead` method is removed completely. It returned an io.Reader object that seemed to be useful for reading the Nodes  Attributes from it. That was however misleading. For most of the current backed the
Reader is pointing to the metadata lockfile instead of the metadata source itself.

The `AllWithLockedSource` is replaced with the new method `AllWhileLocked` it does require the reader parameter. But requires the caller to take care that the Metadata was locked with `Lock()` before calling.

All of the callers where adjusted to no longer pass the reader around. And the unused ParentWithReader method.

This switches the default metadata backend for decomposedfs to "messagepack" to align with the hardcoded default in OpenCloud, which is force to "messagepack" for all decomposedfs setups.