### PR TITLE
fix(decomposedfs): merge service account permissions with node grants

### DIFF
--- a/pkg/storage/pkg/decomposedfs/node/node_test.go
+++ b/pkg/storage/pkg/decomposedfs/node/node_test.go
@@ -290,6 +290,32 @@ var _ = Describe("Node", func() {
 			expected := ocsconv.NewManagerRole().CS3ResourcePermissions()
 			Expect(grants.PermissionsEqual(perms, expected)).To(BeTrue())
 		})
+		It("Merges grants with the service account permissions for service accounts", func() {
+			pSpace, err := env.CreateTestStorageSpace("project", &provider.Quota{QuotaMaxBytes: 2000})
+			Expect(err).ToNot(HaveOccurred())
+			sa := &userpb.User{Id: &userpb.UserId{OpaqueId: "service-account", Type: userpb.UserType_USER_TYPE_SERVICE}}
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
+				AddGrant: true,
+				Stat:     true,
+			}, nil).Times(1)
+			err = env.Fs.AddGrant(env.Ctx, &provider.Reference{
+				ResourceId: &provider.ResourceId{SpaceId: pSpace.SpaceId, OpaqueId: pSpace.OpaqueId},
+			}, &provider.Grant{
+				Grantee:     &provider.Grantee{Type: provider.GranteeType_GRANTEE_TYPE_USER, Id: &provider.Grantee_UserId{UserId: sa.Id}},
+				Permissions: ocsconv.NewEditorRole().CS3ResourcePermissions(),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			// resolve as the service account: grant must be honored (not shadowed by an
+			// early return) and merged with, not replaced by, the service account defaults.
+			spaceRoot, err := env.Lookup.NodeFromSpaceID(env.Ctx, pSpace.SpaceId)
+			Expect(err).ToNot(HaveOccurred())
+			saCtx := ctxpkg.ContextSetUser(env.Ctx, sa)
+			perms, err := node.NewPermissions(env.Lookup).AssemblePermissions(saCtx, spaceRoot)
+			Expect(err).ToNot(HaveOccurred())
+			expected := ocsconv.NewEditorRole().CS3ResourcePermissions()
+			node.AddPermissions(expected, node.ServiceAccountPermissions())
+			Expect(grants.PermissionsEqual(perms, expected)).To(BeTrue())
+		})
 		It("Checks the Editor permissions on a project space and a denial", func() {
 			storageSpace, err := env.CreateTestStorageSpace("project", &provider.Quota{QuotaMaxBytes: 2000})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/pkg/decomposedfs/node/permissions.go
+++ b/pkg/storage/pkg/decomposedfs/node/permissions.go
@@ -134,10 +134,6 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 		return NoPermissions(), nil
 	}
 
-	if u.GetId().GetType() == userpb.UserType_USER_TYPE_SERVICE {
-		return ServiceAccountPermissions(), nil
-	}
-
 	// are we reading a revision?
 	if strings.Contains(n.ID, RevisionIDDelimiter) {
 		// verify revision key format
@@ -202,6 +198,11 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 	// check if the current user is the owner
 	if utils.UserIDEqual(u.Id, n.Owner()) {
 		return OwnerPermissions(), nil
+	}
+
+	// merge in the general service account permissions; grants can only add to them
+	if u.GetId().GetType() == userpb.UserType_USER_TYPE_SERVICE {
+		AddPermissions(ap, ServiceAccountPermissions())
 	}
 
 	appctx.GetLogger(ctx).Debug().Interface("permissions", ap).Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Interface("user", u).Msg("returning agregated permissions")


### PR DESCRIPTION
## Problem

`assemblePermissions` returned `ServiceAccountPermissions()` early for service accounts, before reading the grants stored on the node. On project space creation the creator gets a `SpaceManager` grant (`spaces.go`), but the follow-up creator share checks `SufficientCS3Permissions` against those service account defaults, which lack the manager permissions. The share was denied and the space rolled back with `CODE_INTERNAL`. #593 turned the previously tolerated creator-share failure into this hard rollback.

## Fix

Drop the early return: read the node grants, then union `ServiceAccountPermissions()` into the result. A service account keeps its baseline permissions and additionally gets whatever a grant adds. Grants can only add, never remove.

Applied to both decomposedfs copies (`pkg/...` and `utils/...`), each with a regression test (grant an Editor role to a service account, assert the assembled set is the union of grant and defaults).

Trade-off: service accounts now read node grants on every Stat instead of short-circuiting. Slightly more work per call for correct permissions.

## Reproducer

Standalone repro (service account `CreateStorageSpace` returns `CODE_INTERNAL` unpatched, `CODE_OK` patched): https://github.com/dschmidt/reva-serviceaccount-space-repro

## Credit

Fix suggested by @rhafer.
