### PR TITLE
test(decomposedfs): assert a space manager may disable a project space

### DIFF
--- a/pkg/storage/pkg/decomposedfs/spaces_test.go
+++ b/pkg/storage/pkg/decomposedfs/spaces_test.go
@@ -203,6 +203,17 @@ var _ = Describe("Spaces", func() {
 				err := env.Fs.DeleteStorageSpace(ctx, delReq)
 				Expect(err).To(HaveOccurred())
 			})
+			It("succeeds at disabling as a space manager", func() {
+				// The positive counterpart to the purge denial above: since #672
+				// a space manager may still disable (but not purge) a project
+				// space. delReq's space is pre-disabled in BeforeEach, so use a
+				// fresh one.
+				resp, err := env.Fs.CreateStorageSpace(env.Ctx, &provider.CreateStorageSpaceRequest{Name: "Manager Disables", Type: "project"})
+				Expect(err).ToNot(HaveOccurred())
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.SpaceManager)
+				err = env.Fs.DeleteStorageSpace(ctx, &provider.DeleteStorageSpaceRequest{Id: resp.StorageSpace.GetId()})
+				Expect(err).To(Not(HaveOccurred()))
+			})
 			// Reproducer for opencloud-eu/opencloud#2985: purging a space must
 			// invalidate ALL of its msgpack indexes, not only the by-type index.
 			// The by-user-id index keeps a stale entry pointing at the purged


### PR DESCRIPTION
## Description

Adds one test to the `can delete (purge) project spaces` context in `pkg/storage/pkg/decomposedfs/spaces_test.go`: `succeeds at disabling as a space manager`. It creates a fresh project space and disables it as `env.SpaceManager`, expecting success. This exercises the `!purge && IsManager(rp)` branch of `canDeleteSpace`. A fresh space is used because `BeforeEach` pre-disables the shared one.

## Related Issue

None. Covers the disable-allowed half of the manager permission split from #672.

## Motivation and Context

Since #672 a space manager may disable but not purge a project space. The context asserts only the denial side (`fails as a space manager`); the disable case was untested, so a regression breaking manager disable would pass unnoticed. #716 realigned the purge tests here but did not add this assertion. Supersedes the disable half of #709 (now closed).

## How Has This Been Tested?

- `golang:1.25` container, source on an ext4 volume for `user.*` xattr support (native macOS is unreliable for these tests)
- `go test ./pkg/storage/pkg/decomposedfs/`: both space-manager specs pass (`fails as a space manager` and the new one)
- `gofmt`, `go vet`, `golangci-lint v2.10.1`: clean on the package

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added (n/a: reva builds the changelog from the PR title and `Type:*` label via ready-release-go, so no fragment is needed)

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
