### PR TITLE
fix(metadata/hybrid): Avoid resurrecting space root directory

### DIFF
--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend.go
@@ -500,9 +500,21 @@ func (b HybridBackend) Lock(n MetadataNode) (UnlockFunc, error) {
 	mlock, err := lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// create the parent directory
-			err = os.MkdirAll(filepath.Dir(metaLockPath), 0700)
-			if err != nil {
+			// The lock file's parent directories don't exist yet (or anymore).
+			// We may only create the space's metadata directories, never the
+			// space's base directory itself: locking a node (i.e. the space
+			// root) whose space has been removed (or has not been created yet)
+			// must not resurrect the spaca.
+			base := b.metadataPathFunc(n)
+			if base == "" {
+				return nil, err
+			}
+			// base is the space's metadata directory (e.g. <spaceRoot>/.oc-nodes),
+			// so its parent is the space's base directory.
+			if _, statErr := os.Stat(filepath.Dir(base)); statErr != nil {
+				return nil, statErr
+			}
+			if err = os.MkdirAll(filepath.Dir(metaLockPath), 0700); err != nil {
 				return nil, err
 			}
 			mlock, err = lockedfile.OpenFile(metaLockPath, os.O_RDWR|os.O_CREATE, 0600)

--- a/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
+++ b/pkg/storage/pkg/decomposedfs/metadata/hybrid_backend_test.go
@@ -347,5 +347,39 @@ var _ = Describe("HybridBackend", func() {
 			err = unlock2()
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("does not create the space base directory when the space does not exist", func() {
+			missingSpaceRoot := path.Join(tmpdir, "missing-space")
+			missing := &testNode{
+				spaceID: "123",
+				id:      "456",
+				path:    path.Join(missingSpaceRoot, "file"),
+			}
+
+			_, err := backend.Lock(missing)
+			Expect(err).To(HaveOccurred())
+			Expect(metadata.IsNotExist(err)).To(BeTrue())
+
+			By("not resurrecting the space base directory")
+			_, err = os.Stat(missingSpaceRoot)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("creates the metadata directories when the space exists", func() {
+			existingSpaceRoot := path.Join(tmpdir, "existing-space")
+			Expect(os.MkdirAll(existingSpaceRoot, 0700)).To(Succeed())
+			existing := &testNode{
+				spaceID: "123",
+				id:      "456",
+				path:    path.Join(existingSpaceRoot, "file"),
+			}
+
+			unlock, err := backend.Lock(existing)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unlock()).To(Succeed())
+
+			_, err = os.Stat(backend.LockfilePath(existing))
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
Trying to read the Attributes of an already delete Space caused the 'Lock' function to re-create the spaceroot directory. This left empty spaceroot directories behind that confuse listing of spaces.

Fixes: https://github.com/opencloud-eu/opencloud/issues/1878