### PR TITLE
Do not disregard disabled spaces when propagating changes

### DIFF
--- a/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/async.go
@@ -282,8 +282,10 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 
 	attrs := node.Attributes{}
 
+	// lock parent before reading treesize or tree time
+	// we deliberately allow reading disabled spaces so that the metadata is always consistent (see https://github.com/opencloud-eu/reva/issues/747)
 	_, subspan = tracer.Start(ctx, "node.LockAndReadNode")
-	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, spaceID, nodeID, "", false, nil, false)
+	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, spaceID, nodeID, "", true, nil, false)
 	subspan.End()
 	if err != nil {
 		if n != nil && !n.Exists {

--- a/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/pkg/decomposedfs/tree/propagator/sync.go
@@ -92,7 +92,8 @@ func (p SyncPropagator) propagateItem(ctx context.Context, n *node.Node, sTime t
 	attrs := node.Attributes{}
 
 	// lock parent before reading treesize or tree time
-	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, n.SpaceID, n.ParentID, "", false, n.SpaceRoot, false)
+	// we deliberately allow reading disabled spaces so that the metadata is always consistent (see https://github.com/opencloud-eu/reva/issues/747)
+	n, unlock, err := node.LockAndReadNode(ctx, p.lookup, n.SpaceID, n.ParentID, "", true, n.SpaceRoot, false)
 	if err != nil {
 		return nil, true, err
 	}


### PR DESCRIPTION
This prevented files and directories in disabled spaces from being assimilated during a "posixfs scan".

Fixes https://github.com/opencloud-eu/reva/issues/747