### PR TITLE
fix key propagation in for shared resources when restoring version

### DIFF
--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -955,6 +955,7 @@ func (s *service) RestoreFileVersion(ctx context.Context, req *provider.RestoreF
 	return gatewayClient.RestoreFileVersion(ctx, &provider.RestoreFileVersionRequest{
 		Opaque: req.Opaque,
 		Ref:    buildReferenceInShare(req.Ref, receivedShare),
+		Key:    req.Key,
 	})
 }
 

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
@@ -883,7 +883,12 @@ var _ = Describe("Sharesstorageprovider", func() {
 
 		Describe("RestoreFileVersion", func() {
 			BeforeEach(func() {
-				gatewayClient.On("RestoreFileVersion", mock.Anything, mock.Anything).Return(
+				// might be redundant but it's better to ensure that we always propagate the key
+				gatewayClient.On("RestoreFileVersion", mock.Anything,
+					mock.MatchedBy(func(req *sprovider.RestoreFileVersionRequest) bool {
+						return req.GetKey() == "1"
+					}),
+				).Return(
 					&sprovider.RestoreFileVersionResponse{
 						Status: status.NewOK(ctx),
 					}, nil)


### PR DESCRIPTION
on restoring the shared resource the key propagation was missing because of that the RestoreFileVersion call cannot understand what version to restore