### PR TITLE
Extend upload sessions to hold more explicit state information

### DIFF
--- a/pkg/storage/pkg/decomposedfs/decomposedfs.go
+++ b/pkg/storage/pkg/decomposedfs/decomposedfs.go
@@ -82,6 +82,7 @@ var (
 		events.PostprocessingFinished{},
 		events.PostprocessingStepFinished{},
 		events.RestartPostprocessing{},
+		events.StartPostprocessingStep{},
 	}
 )
 
@@ -440,6 +441,22 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				Filesize:      uint64(session.Size()),
 			}); err != nil {
 				sublog.Error().Err(err).Msg("Failed to publish BytesReceived event")
+			}
+		case events.StartPostprocessingStep:
+			sublog := log.With().Str("event", "StartPostprocessingStep").Str("uploadid", ev.UploadID).Logger()
+			if ev.UploadID == "" {
+				sublog.Error().Msg("UploadID is empty, cannot start postprocessing step")
+				continue
+			}
+			session, err := fs.sessionStore.Get(ctx, ev.UploadID)
+			if err != nil {
+				sublog.Error().Err(err).Msg("Failed to get upload")
+				continue
+			}
+			session.SetStatus(upload.SessionStatusProcessing, "started postprocessing step: "+string(ev.StepToStart))
+			err = session.Persist(ctx)
+			if err != nil {
+				sublog.Error().Err(err).Msg("Failed to persist upload session after starting postprocessing step")
 			}
 		case events.PostprocessingStepFinished:
 			sublog := log.With().Str("event", "PostprocessingStepFinished").Str("uploadid", ev.UploadID).Logger()

--- a/pkg/storage/pkg/decomposedfs/upload/session.go
+++ b/pkg/storage/pkg/decomposedfs/upload/session.go
@@ -46,6 +46,12 @@ type DecomposedFsSession struct {
 	info tusd.FileInfo
 }
 
+const (
+	SessionStatusUploading  = "uploading"
+	SessionStatusProcessing = "processing"
+	SessionStatusFailed     = "failed"
+)
+
 // Context returns a context with the user, logger and lockid used when initiating the upload session
 func (session *DecomposedFsSession) Context(ctx context.Context) context.Context { // restore logger from file info
 	sub := session.store.log.With().Int("pid", os.Getpid()).Logger()
@@ -307,10 +313,9 @@ func (session *DecomposedFsSession) MTime() time.Time {
 	return t
 }
 
-// IsProcessing returns true if all bytes have been received. The session then has entered postprocessing state.
+// IsProcessing returns true if the upload is in the processing state, meaning that the upload has finished and postprocessing is still running.
 func (session *DecomposedFsSession) IsProcessing() bool {
-	// We might need a more sophisticated way to determine processing status soon
-	return session.info.Size == session.info.Offset && session.info.MetaData["scanResult"] == ""
+	return session.info.MetaData["status"] == SessionStatusProcessing
 }
 
 // binPath returns the path to the file storing the binary data.
@@ -337,6 +342,22 @@ func (session *DecomposedFsSession) ScanData() (string, time.Time) {
 	}
 	d, _ := time.Parse(time.RFC3339, date)
 	return session.info.MetaData["scanResult"], d
+}
+
+// SetStatus sets the status of the upload session
+func (session *DecomposedFsSession) SetStatus(status, msg string) {
+	session.info.MetaData["status"] = status
+	session.info.MetaData["statusMessage"] = msg
+}
+
+// Status returns the status of the upload session
+func (session *DecomposedFsSession) Status() string {
+	return session.info.MetaData["status"]
+}
+
+// StatusMessage returns the status message of the upload session
+func (session *DecomposedFsSession) StatusMessage() string {
+	return session.info.MetaData["statusMessage"]
 }
 
 // sessionPath returns the path to the .info file storing the file's info.

--- a/pkg/storage/pkg/decomposedfs/upload/session_status_test.go
+++ b/pkg/storage/pkg/decomposedfs/upload/session_status_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 OpenCloud GmbH <mail@opencloud.eu>
+// SPDX-License-Identifier: Apache-2.0
+
+package upload_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/aspects"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/options"
+	"github.com/opencloud-eu/reva/v2/pkg/storage/pkg/decomposedfs/upload"
+)
+
+var _ = Describe("Session", func() {
+	var session *upload.DecomposedFsSession
+
+	BeforeEach(func() {
+		log := &zerolog.Logger{}
+		root := GinkgoT().TempDir()
+		store := upload.NewSessionStore(nil, aspects.Aspects{}, root, false, options.TokenOptions{}, log)
+		session = store.New(context.Background())
+	})
+
+	Describe("a newly created session", func() {
+		It("starts in the uploading status", func() {
+			Expect(session.Status()).To(Equal(upload.SessionStatusUploading))
+			Expect(session.StatusMessage()).To(BeEmpty())
+			Expect(session.IsProcessing()).To(BeFalse())
+		})
+	})
+
+	Describe("SetStatus", func() {
+		It("stores the status and message", func() {
+			session.SetStatus(upload.SessionStatusFailed, "something went wrong")
+
+			Expect(session.Status()).To(Equal(upload.SessionStatusFailed))
+			Expect(session.StatusMessage()).To(Equal("something went wrong"))
+		})
+
+		It("overwrites the previous message", func() {
+			session.SetStatus(upload.SessionStatusFailed, "first error")
+			session.SetStatus(upload.SessionStatusProcessing, "")
+
+			Expect(session.Status()).To(Equal(upload.SessionStatusProcessing))
+			Expect(session.StatusMessage()).To(BeEmpty())
+		})
+	})
+
+	Describe("IsProcessing", func() {
+		DescribeTable("reports the processing state based on the status",
+			func(status string, wantProcessing bool) {
+				session.SetStatus(status, "")
+
+				Expect(session.IsProcessing()).To(Equal(wantProcessing))
+			},
+			Entry("uploading is not processing", upload.SessionStatusUploading, false),
+			Entry("processing is processing", upload.SessionStatusProcessing, true),
+			Entry("failed is not processing", upload.SessionStatusFailed, false),
+		)
+	})
+})

--- a/pkg/storage/pkg/decomposedfs/upload/store.go
+++ b/pkg/storage/pkg/decomposedfs/upload/store.go
@@ -94,7 +94,9 @@ func (store DecomposedFsStore) New(ctx context.Context) *DecomposedFsSession {
 			Storage: map[string]string{
 				"Type": "DecomposedFsStore",
 			},
-			MetaData: tusd.MetaData{},
+			MetaData: tusd.MetaData{
+				"status": string(SessionStatusUploading),
+			},
 		},
 	}
 }

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -195,7 +195,9 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 	n, err := session.store.CreateNodeForUpload(ctx, session, attrs)
 	if err != nil {
 		session.SetStatus(SessionStatusFailed, err.Error())
-		session.Persist(ctx)
+		if perr := session.Persist(ctx); perr != nil {
+			log.Error().Err(perr).Msg("failed to persist upload session after setting status to failed")
+		}
 		return err
 	}
 	// increase the processing counter for every started processing
@@ -246,7 +248,9 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 	}
 
 	session.SetStatus(SessionStatusProcessing, "")
-	session.Persist(ctx)
+	if err = session.Persist(ctx); err != nil {
+		log.Error().Err(err).Msg("failed to persist upload session after setting status to processing")
+	}
 	return session.store.tp.Propagate(ctx, n, session.SizeDiff())
 }
 

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -200,6 +200,12 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 		}
 		return err
 	}
+
+	session.SetStatus(SessionStatusProcessing, "")
+	if err = session.Persist(ctx); err != nil {
+		log.Error().Err(err).Msg("failed to persist upload session after setting status to processing")
+	}
+
 	// increase the processing counter for every started processing
 	// will be decreased in Cleanup()
 	metrics.UploadProcessing.Inc()
@@ -247,10 +253,6 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 		metrics.UploadSessionsFinalized.Inc()
 	}
 
-	session.SetStatus(SessionStatusProcessing, "")
-	if err = session.Persist(ctx); err != nil {
-		log.Error().Err(err).Msg("failed to persist upload session after setting status to processing")
-	}
 	return session.store.tp.Propagate(ctx, n, session.SizeDiff())
 }
 

--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -194,6 +194,8 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 
 	n, err := session.store.CreateNodeForUpload(ctx, session, attrs)
 	if err != nil {
+		session.SetStatus(SessionStatusFailed, err.Error())
+		session.Persist(ctx)
 		return err
 	}
 	// increase the processing counter for every started processing
@@ -243,6 +245,8 @@ func (session *DecomposedFsSession) FinishUploadDecomposed(ctx context.Context) 
 		metrics.UploadSessionsFinalized.Inc()
 	}
 
+	session.SetStatus(SessionStatusProcessing, "")
+	session.Persist(ctx)
 	return session.store.tp.Propagate(ctx, n, session.SizeDiff())
 }
 

--- a/pkg/storage/pkg/decomposedfs/upload/upload_suite_test.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package upload_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUpload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Upload Suite")
+}

--- a/pkg/storage/uploads.go
+++ b/pkg/storage/uploads.go
@@ -94,6 +94,11 @@ type UploadSession interface {
 
 	// ScanData returns the scan data for the UploadSession
 	ScanData() (string, time.Time)
+
+	// Status returns the status for the UploadSession
+	Status() string
+	// StatusMessage returns the status message for the UploadSession
+	StatusMessage() string
 }
 
 // UploadSessionFilter can be used to filter upload sessions

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -339,7 +339,7 @@ func (s *OcisSession) ScanData() (string, time.Time) {
 }
 
 func (s *OcisSession) SetStatus(status string) {
-	s.info.MetaData["status"] = string(status)
+	s.info.MetaData["status"] = status
 }
 
 func (s *OcisSession) Status() string {

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -338,6 +338,22 @@ func (s *OcisSession) ScanData() (string, time.Time) {
 	return s.info.MetaData["scanResult"], d
 }
 
+func (s *OcisSession) SetStatus(status string) {
+	s.info.MetaData["status"] = string(status)
+}
+
+func (s *OcisSession) Status() string {
+	return s.info.MetaData["status"]
+}
+
+func (s *OcisSession) SetStatusMessage(message string) {
+	s.info.MetaData["status_message"] = message
+}
+
+func (s *OcisSession) StatusMessage() string {
+	return s.info.MetaData["status_message"]
+}
+
 // sessionPath returns the path to the .info file storing the file's info.
 func sessionPath(root, id string) string {
 	return filepath.Join(root, "uploads", id+".info")


### PR DESCRIPTION
Upload sesssions now hold an explicit state for the uploading->postprocessing->finished/failed lifecycle as well as an status message which gives information about the current step or failure.