### PR TITLE
Return a webdav error body when listing a space container fails

### DIFF
--- a/internal/http/services/owncloud/ocdav/errors/error.go
+++ b/internal/http/services/owncloud/ocdav/errors/error.go
@@ -167,21 +167,53 @@ var (
 	ErrTokenStatInfoMissing = errors.New("webdav: token stat info missing")
 )
 
-// HandleErrorStatus checks the status code, logs a Debug or Error level message
-// and writes an appropriate http status
-func HandleErrorStatus(log *zerolog.Logger, w http.ResponseWriter, s *rpc.Status) {
-	hsc := status.HTTPStatusFromCode(s.Code)
-	if s.Code == rpc.Code_CODE_ABORTED {
+// httpStatusFromStatus maps a CS3 status to the http status code webdav uses for it.
+func httpStatusFromStatus(s *rpc.Status) int {
+	hsc := status.HTTPStatusFromCode(s.GetCode())
+	if s.GetCode() == rpc.Code_CODE_ABORTED {
 		// aborted is used for etag an lock mismatches, which translates to 412
 		// in case a real Conflict response is needed, the calling code needs to send the header
 		hsc = http.StatusPreconditionFailed
 	}
+	return hsc
+}
+
+// logStatus logs a status at Error level when it turns into a server error and at
+// Debug level otherwise, so that a 500 is always visible in the logs of an operator
+// who is not running the service at debug level.
+func logStatus(log *zerolog.Logger, s *rpc.Status, hsc int) {
 	if hsc == http.StatusInternalServerError {
 		log.Error().Interface("status", s).Int("code", hsc).Msg(http.StatusText(hsc))
 	} else {
 		log.Debug().Interface("status", s).Int("code", hsc).Msg(http.StatusText(hsc))
 	}
+}
+
+// HandleErrorStatus checks the status code, logs a Debug or Error level message
+// and writes an appropriate http status
+func HandleErrorStatus(log *zerolog.Logger, w http.ResponseWriter, s *rpc.Status) {
+	hsc := httpStatusFromStatus(s)
+	logStatus(log, s, hsc)
 	w.WriteHeader(hsc)
+}
+
+// HandleWebdavErrorStatus does what HandleErrorStatus does and additionally writes a
+// webdav error body. Prefer it over HandleErrorStatus wherever a webdav client is
+// waiting for the response: a bare status code with an empty body cannot be parsed by
+// a webdav client, so it can only report a generic "not XML" error, which hides both
+// the status and the message the server had available.
+func HandleWebdavErrorStatus(log *zerolog.Logger, w http.ResponseWriter, s *rpc.Status) {
+	hsc := httpStatusFromStatus(s)
+	logStatus(log, s, hsc)
+
+	m := s.GetMessage()
+	if hsc == http.StatusNotFound {
+		m = "Resource not found" // mimic the oc10 error message
+	}
+
+	w.WriteHeader(hsc)
+	b, err := Marshal(hsc, m, "", "")
+	HandleWebdavError(log, w, b, err)
 }
 
 // HandleWebdavError checks the status code, logs an error and creates a webdav response body

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -761,6 +761,14 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 	return resourceInfos, sendTusHeaders, true
 }
 
+// writeWebdavError writes the http status code together with a webdav error body.
+// The caller is expected to have logged the underlying error already.
+func writeWebdavError(log *zerolog.Logger, w http.ResponseWriter, code int, message string) {
+	w.WriteHeader(code)
+	b, err := errors.Marshal(code, message, "", "")
+	errors.HandleWebdavError(log, w, b, err)
+}
+
 func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWriter, r *http.Request, pf XML, ref *provider.Reference, requestPath string, depth net.Depth, log zerolog.Logger) ([]*provider.ResourceInfo, bool) {
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "get_space_resource_infos")
 	span.SetAttributes(attribute.KeyValue{Key: "requestPath", Value: attribute.StringValue(requestPath)})
@@ -770,7 +778,7 @@ func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWrit
 	client, err := p.selector.Next()
 	if err != nil {
 		log.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
+		writeWebdavError(&log, w, http.StatusInternalServerError, "error getting grpc client")
 		return nil, false
 	}
 
@@ -786,13 +794,18 @@ func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWrit
 	res, err := client.ListContainer(ctx, req)
 	if err != nil {
 		log.Error().Err(err).Msg("error sending list container grpc request")
-		w.WriteHeader(http.StatusInternalServerError)
+		writeWebdavError(&log, w, http.StatusInternalServerError, "error listing container")
 		return nil, false
 	}
 
 	if res.Status.Code != rpc.Code_CODE_OK {
-		log.Debug().Interface("status", res.Status).Msg("List Container not ok, skipping")
-		w.WriteHeader(http.StatusInternalServerError)
+		// this aborts the propfind, the status has to be turned into a proper webdav
+		// error response. A NOT_FOUND for example is a 404 the client can act on, not
+		// a 500. Do not turn this into a `continue` like the sub-container listings
+		// below: this is the listing of the requested resource itself, skipping it
+		// would answer with a multistatus that silently omits all children.
+		lcLog := log.With().Str("rpc", "ListContainer").Logger()
+		errors.HandleWebdavErrorStatus(&lcLog, w, res.Status)
 		return nil, false
 	}
 	for _, info := range res.Infos {
@@ -820,7 +833,7 @@ func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWrit
 			res, err := client.ListContainer(ctx, req) // FIXME public link depth infinity -> "gateway: could not find provider: gateway: error calling ListStorageProviders: rpc error: code = PermissionDenied desc = auth: core access token is invalid"
 			if err != nil {
 				log.Error().Err(err).Interface("info", info).Msg("error sending list container grpc request")
-				w.WriteHeader(http.StatusInternalServerError)
+				writeWebdavError(&log, w, http.StatusInternalServerError, "error listing container")
 				return nil, false
 			}
 			if res.Status.Code != rpc.Code_CODE_OK {

--- a/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
@@ -21,12 +21,14 @@ package propfind_test
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	sprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -1692,5 +1694,124 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).To(HaveOccurred())
 
 		})
+	})
+})
+
+// davError is the webdav error document as a namespace aware client parses it,
+// see http://www.webdav.org/specs/rfc4918.html#ELEMENT_error
+type davError struct {
+	XMLName   xml.Name `xml:"DAV error"`
+	Exception string   `xml:"http://sabredav.org/ns exception"`
+	Message   string   `xml:"http://sabredav.org/ns message"`
+}
+
+var _ = Describe("PropfindWithFailingListContainer", func() {
+	var (
+		handler *propfind.Handler
+		client  *mocks.GatewayAPIClient
+		ctx     context.Context
+		spaceID string
+
+		// readDavError asserts that the body is a parsable webdav error document and
+		// returns it. This is what the reported bug was about: the handler used to
+		// answer with an empty body, which a webdav client can only report as a
+		// generic "response is not XML" error.
+		readDavError = func(r io.Reader) davError {
+			body, err := io.ReadAll(r)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).ToNot(BeEmpty())
+
+			e := davError{}
+			Expect(xml.Unmarshal(body, &e)).To(Succeed())
+			return e
+		}
+
+		// listContainerFails makes the ListContainer call for the space root answer
+		// with the given non OK status.
+		listContainerFails = func(s *rpc.Status) {
+			client.On("ListContainer", mock.Anything, mock.Anything).Return(&sprovider.ListContainerResponse{
+				Status: s,
+			}, nil)
+		}
+
+		// propfindSpaceRoot issues a depth 1 propfind on the space root, which is the
+		// request the desktop client sends while syncing a folder.
+		propfindSpaceRoot = func() *httptest.ResponseRecorder {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("PROPFIND", "/", strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			req = req.WithContext(ctx)
+
+			handler.HandleSpacesPropfind(rr, req, spaceID)
+			return rr
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = context.WithValue(context.Background(), net.CtxKeyBaseURI, "http://127.0.0.1:3000")
+		client = &mocks.GatewayAPIClient{}
+
+		cfg := &config.Config{
+			FilesNamespace:  "/users/{{.Username}}",
+			WebdavNamespace: "/users/{{.Username}}",
+			NameValidation: config.NameValidation{
+				MaxLength:    255,
+				InvalidChars: []string{"\f", "\r", "\n", "\\"},
+			},
+		}
+		handler = propfind.NewHandler("127.0.0.1:3000", selector{client: client}, nil, cfg)
+
+		spaceID = storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+
+		// the space root itself stats fine, only listing its children fails
+		client.On("Stat", mock.Anything, mock.Anything).Return(&sprovider.StatResponse{
+			Status: status.NewOK(ctx),
+			Info: &sprovider.ResourceInfo{
+				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"},
+				Type: sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Path: ".",
+				Size: uint64(131),
+			},
+		}, nil)
+	})
+
+	It("maps a not found status to 404 and returns a webdav error body", func() {
+		listContainerFails(status.NewNotFound(ctx, "gone while syncing"))
+
+		rr := propfindSpaceRoot()
+		Expect(rr.Code).To(Equal(http.StatusNotFound))
+
+		e := readDavError(rr.Result().Body)
+		Expect(e.Exception).To(Equal("Sabre\\DAV\\Exception\\NotFound"))
+		Expect(e.Message).To(Equal("Resource not found"))
+	})
+
+	It("maps a permission denied status to 403 and returns a webdav error body", func() {
+		listContainerFails(status.NewPermissionDenied(ctx, nil, "no access"))
+
+		rr := propfindSpaceRoot()
+		Expect(rr.Code).To(Equal(http.StatusForbidden))
+
+		e := readDavError(rr.Result().Body)
+		Expect(e.Exception).To(Equal("Sabre\\DAV\\Exception\\Forbidden"))
+		Expect(e.Message).To(Equal("no access"))
+	})
+
+	It("still answers 500 for an internal status, but with a parsable body", func() {
+		listContainerFails(status.NewInternal(ctx, "storage exploded"))
+
+		rr := propfindSpaceRoot()
+		Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+
+		Expect(readDavError(rr.Result().Body).Message).To(Equal("storage exploded"))
+	})
+
+	It("returns a webdav error body when the list container request itself fails", func() {
+		client.On("ListContainer", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("transport is closing"))
+
+		rr := propfindSpaceRoot()
+		Expect(rr.Code).To(Equal(http.StatusInternalServerError))
+
+		Expect(readDavError(rr.Result().Body).Message).To(Equal("error listing container"))
 	})
 })


### PR DESCRIPTION
Fixes #767

## The bug

`getSpaceResourceInfos` listed the requested resource and then did this with a non OK CS3 status:

```go
if res.Status.Code != rpc.Code_CODE_OK {
    log.Debug().Interface("status", res.Status).Msg("List Container not ok, skipping")
    w.WriteHeader(http.StatusInternalServerError)
    return nil, false
}
```

Three things go wrong in those four lines:

1. **The status is thrown away.** Every non OK status became a 500. A `NOT_FOUND`, which is routine when a folder is deleted or moved while a client is syncing, arrived at the client as a hard 500 instead of the 404 it knows how to handle.
2. **No body.** A bare `WriteHeader` sends no webdav error document, so a webdav client has nothing to parse and can only report a generic "response is not XML". The `Stat` error handling ~400 lines earlier in the same file already does this correctly, this path just never got the same treatment.
3. **Logged at Debug.** Of the call sites in this file that write a 500, this was the only one below Error level, so the failure left no trace for an operator not running at debug level. The message "List Container not ok, skipping" was copied from the three sub-container listings that really do `continue`. This one does not skip, it ends the request.

Together that produces a 500 with a zero length body and no matching error log line, which is close to undiagnosable from either side.

## The fix

`errors.HandleWebdavErrorStatus` is added next to the existing `errors.HandleErrorStatus`. It does exactly what `HandleErrorStatus` does and additionally writes the webdav error body, so the log level keeps following the resulting http status: Error when it really is a 500, Debug for an expected 404. Both now share one mapping helper, so `HandleErrorStatus` behaviour is unchanged.

The branch in `getSpaceResourceInfos` uses it, and the failing rpc is named in the log entry so the operator still learns which call failed. A `NOT_FOUND` now becomes a 404 with a `Sabre\DAV\Exception\NotFound` body, a `PERMISSION_DENIED` a 403, and a genuine `INTERNAL` stays a 500 but with a parsable body and an Error level log line.

I deliberately did not turn this into a `continue` like the sibling listings below it. Those iterate sub-containers during a Depth:Infinity walk, where skipping one is right. This one is the listing of the requested resource itself, so skipping it would answer 207 with a multistatus that silently omits every child.

The remaining error exits of the same function wrote the same bodyless 500, they now write a webdav error body too.

## Tests

Four specs in a new `PropfindWithFailingListContainer` block, each parsing the response the way a namespace aware webdav client does. Against the unpatched handler they fail with exactly the reported symptoms:

| Case | before | after |
| --- | --- | --- |
| `NOT_FOUND` | 500, empty body | 404, `Sabre\DAV\Exception\NotFound` |
| `PERMISSION_DENIED` | 500, empty body | 403, `Sabre\DAV\Exception\Forbidden` |
| `INTERNAL` | 500, empty body | 500, message preserved in the body |
| transport error | 500, empty body | 500, error body |

`go test ./internal/http/services/owncloud/ocdav/...` and `golangci-lint run` on both changed packages are clean. The wider `ocdav` suite is unchanged at 147 passed / 2 failed, the two failures being pre-existing on `main` in my environment.

## Out of scope

Two things the issue mentions that I left alone on purpose, happy to follow up in a separate PR if you want them:

- `propfindResponse` swallowing a failed `ListPublicShares` (logged only, `linkshares` stays nil), so a 207 can come back missing `oc:share-type` and `oc:permissions` with no operator visible cause.
- `context.Canceled` from a client disconnect is still not distinguished from a genuine server error anywhere in this file. Worth doing, but it touches more call sites than this fix should.
