### PR TITLE
mime: map the Nikon NRW raw extension

### DIFF
--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -602,6 +602,7 @@ var mimeTypes = map[string]string{
 	"nc":                       "application/x-netcdf",
 	"ncx":                      "application/x-dtbncx+xml",
 	"nef":                      "image/x-nikon-nef",
+	"nrw":                      "image/x-nikon-nrw",
 	"nfo":                      "text/x-nfo",
 	"ngdat":                    "application/vnd.nokia.n-gage.data",
 	"nitf":                     "application/vnd.nitf",


### PR DESCRIPTION
Maps one more TIFF-based camera raw extension so downstream consumers can detect and handle it:

- `nrw` -> `image/x-nikon-nrw`

`nrw` is a TIFF-based Nikon raw format (the Coolpix counterpart to `nef`) and sits alongside the already-mapped `nef`/`pef`/`arw`/`sr2`/`srf`. This lets a consumer (e.g. the OpenCloud thumbnails service, which extracts embedded JPEG previews from TIFF-based raws) recognise Nikon NRW the same way it already recognises its siblings.

Detection here is extension-only, so I deliberately left out `.ptx` (nominally Pentax raw): that extension is overloaded with far more common non-raw formats (Ptex textures, Paratext files) and Pentax raw is `.pef`/DNG in practice, so mapping it would mis-type those.

Pure mimetype-map addition, no behaviour change.
