### PR TITLE
fix(ocm): normalize accepted-user ids on invite handshake

### DIFF
--- a/changelog/unreleased/ocm-normalize-invite-user-id.md
+++ b/changelog/unreleased/ocm-normalize-invite-user-id.md
@@ -1,0 +1,11 @@
+Bugfix: Normalize OCM accepted-user ids on write
+
+Accepted remote users are now stored with a bare OCM identifier in `opaque_id`
+and a scheme-free provider in `idp`, matching the OCM specification. Legacy
+entries (`uuid@https://host` opaque ids) remain readable via fallback matching.
+`GetAcceptedUser` now returns `CODE_NOT_FOUND` instead of `CODE_INTERNAL` when
+the remote user is unknown.
+
+After OpenCloud bumps Reva, Graph invite `objectId` values from
+`find-accepted-users` should use the single-`@` form `uuid@host:port` instead
+of the previous double-`@` workaround.

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -174,11 +174,9 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 	remoteUser, err := s.ocmClient.InviteAccepted(ctx, ocmEndpoint, &client.InviteAcceptedRequest{
 		Token:             req.InviteToken.GetToken(),
 		RecipientProvider: s.conf.ProviderDomain,
-		// The UserID is only a string here. To not lose the IDP information we use the LocalUserFederatedID encoding
-		// i.e. UserID@IDP
-		UserID: ocmuser.FormatOCMUser(user.GetId()),
-		Email:  user.GetMail(),
-		Name:   user.GetDisplayName(),
+		UserID:            user.GetId().GetOpaqueId(),
+		Email:             user.GetMail(),
+		Name:              user.GetDisplayName(),
 	})
 	if err != nil {
 		switch {
@@ -211,14 +209,12 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 
 	// remoteUser.UserID is the federated ID (just a string), to get a unique CS3 userid
 	// we're using the provider domain as the IDP part of the ID
+	providerDomain := req.GetOriginSystemProvider().Domain
 	remoteUserID := &userpb.UserId{
 		Type:     userpb.UserType_USER_TYPE_FEDERATED,
-		Idp:      req.GetOriginSystemProvider().Domain,
-		OpaqueId: remoteUser.UserID,
+		Idp:      ocmuser.TrimOCMScheme(providerDomain),
+		OpaqueId: ocmuser.NormalizeRemoteUserID(remoteUser.UserID, providerDomain),
 	}
-
-	// we need to use a unique identifier for federated users
-	remoteUserID = ocmuser.LocalUserFederatedID(remoteUserID, "")
 
 	if err := s.repo.AddRemoteUser(ctx, user.Id, &userpb.User{
 		Id:          remoteUserID,
@@ -279,8 +275,7 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 	}
 
 	remoteUser := req.GetRemoteUser()
-	// we need to use a unique identifier for federated users
-	remoteUser.Id = ocmuser.LocalUserFederatedID(remoteUser.Id, "")
+	ocmuser.CanonicalizeRemoteUserID(remoteUser.Id)
 
 	if err := s.repo.AddRemoteUser(ctx, token.GetUserId(), remoteUser); err != nil {
 		if !errors.Is(err, invite.ErrUserAlreadyAccepted) {
@@ -331,7 +326,7 @@ func (s *service) GetAcceptedUser(ctx context.Context, req *invitepb.GetAccepted
 	remoteUser, err := s.repo.GetRemoteUser(ctx, user.GetId(), req.GetRemoteUserId())
 	if err != nil {
 		return &invitepb.GetAcceptedUserResponse{
-			Status: status.NewInternal(ctx, "error fetching remote user details"),
+			Status: status.NewStatusFromErrType(ctx, "error fetching remote user details", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager_test.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager_test.go
@@ -1,0 +1,91 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocminvitemanager
+
+import (
+	"context"
+	"testing"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	ctxpkg "github.com/opencloud-eu/reva/v2/pkg/ctx"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubInviteRepo struct {
+	getRemoteUserFn func(ctx context.Context, initiator *userpb.UserId, remoteUserID *userpb.UserId) (*userpb.User, error)
+}
+
+func (s *stubInviteRepo) AddToken(context.Context, *invitepb.InviteToken) error {
+	panic("not implemented")
+}
+
+func (s *stubInviteRepo) GetToken(context.Context, string) (*invitepb.InviteToken, error) {
+	panic("not implemented")
+}
+
+func (s *stubInviteRepo) ListTokens(context.Context, *userpb.UserId) ([]*invitepb.InviteToken, error) {
+	panic("not implemented")
+}
+
+func (s *stubInviteRepo) AddRemoteUser(context.Context, *userpb.UserId, *userpb.User) error {
+	panic("not implemented")
+}
+
+func (s *stubInviteRepo) GetRemoteUser(ctx context.Context, initiator *userpb.UserId, remoteUserID *userpb.UserId) (*userpb.User, error) {
+	return s.getRemoteUserFn(ctx, initiator, remoteUserID)
+}
+
+func (s *stubInviteRepo) FindRemoteUsers(context.Context, *userpb.UserId, string) ([]*userpb.User, error) {
+	panic("not implemented")
+}
+
+func (s *stubInviteRepo) DeleteRemoteUser(context.Context, *userpb.UserId, *userpb.UserId) error {
+	panic("not implemented")
+}
+
+func TestGetAcceptedUser_NotFound(t *testing.T) {
+	const remoteID = "056fc874-dd7f-11ef-ba84-af6fca4b7289"
+
+	svc := &service{
+		repo: &stubInviteRepo{
+			getRemoteUserFn: func(_ context.Context, _ *userpb.UserId, remoteUserID *userpb.UserId) (*userpb.User, error) {
+				return nil, errtypes.NotFound(remoteUserID.GetOpaqueId())
+			},
+		},
+	}
+
+	ctx := ctxpkg.ContextSetUser(context.Background(), &userpb.User{
+		Id: &userpb.UserId{OpaqueId: "alan"},
+	})
+
+	resp, err := svc.GetAcceptedUser(ctx, &invitepb.GetAcceptedUserRequest{
+		RemoteUserId: &userpb.UserId{
+			OpaqueId: remoteID,
+			Idp:      "cloud2.opencloud.test:10200",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, rpc.Code_CODE_NOT_FOUND, resp.GetStatus().GetCode())
+	assert.Nil(t, resp.GetRemoteUser())
+}

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -110,8 +110,8 @@ func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 
 	userObj := &userpb.User{
 		Id: &userpb.UserId{
-			OpaqueId: req.UserID,
-			Idp:      req.RecipientProvider,
+			OpaqueId: ocmuser.NormalizeRemoteUserID(req.UserID, req.RecipientProvider),
+			Idp:      ocmuser.TrimOCMScheme(req.RecipientProvider),
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
 		},
 		Mail:        req.Email,

--- a/pkg/ocm/invite/repository/json/json.go
+++ b/pkg/ocm/invite/repository/json/json.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/ocm/invite"
 	"github.com/opencloud-eu/reva/v2/pkg/ocm/invite/repository/registry"
+	ocmuser "github.com/opencloud-eu/reva/v2/pkg/ocm/user"
 	"github.com/opencloud-eu/reva/v2/pkg/utils"
 	"github.com/opencloud-eu/reva/v2/pkg/utils/cfg"
 	"github.com/opencloud-eu/reva/v2/pkg/utils/list"
@@ -182,7 +182,7 @@ func (m *manager) AddRemoteUser(ctx context.Context, initiator *userpb.UserId, r
 	defer m.Unlock()
 
 	for _, acceptedUser := range m.model.AcceptedUsers[initiator.GetOpaqueId()] {
-		if acceptedUser.Id.GetOpaqueId() == remoteUser.Id.OpaqueId && idpsEqual(acceptedUser.Id.GetIdp(), remoteUser.Id.Idp) {
+		if ocmuser.RemoteUserIDsMatch(acceptedUser.Id, remoteUser.Id) {
 			return invite.ErrUserAlreadyAccepted
 		}
 	}
@@ -192,31 +192,6 @@ func (m *manager) AddRemoteUser(ctx context.Context, initiator *userpb.UserId, r
 		return errors.Wrap(err, "json: error saving model")
 	}
 	return nil
-}
-
-func idpsEqual(idp1, idp2 string) bool {
-	normalizeIDP := func(s string) (string, error) {
-		u, err := url.Parse(s)
-		if err != nil {
-			return "", errors.New("could not parse url")
-		}
-
-		if u.Scheme == "" {
-			return strings.ToLower(u.Path), nil // the string is just a hostname
-		}
-		return strings.ToLower(u.Hostname()), nil
-	}
-
-	domain1, err := normalizeIDP(idp1)
-	if err != nil {
-		return false
-	}
-	domain2, err := normalizeIDP(idp2)
-	if err != nil {
-		return false
-	}
-
-	return domain1 == domain2
 }
 
 func (m *manager) GetRemoteUser(ctx context.Context, initiator *userpb.UserId, remoteUserID *userpb.UserId) (*userpb.User, error) {
@@ -231,7 +206,7 @@ func (m *manager) GetRemoteUser(ctx context.Context, initiator *userpb.UserId, r
 			acceptedUser.Id.GetOpaqueId(),
 			acceptedUser.Id.GetIdp(),
 		)
-		if (acceptedUser.Id.GetOpaqueId() == remoteUserID.OpaqueId) && (remoteUserID.Idp == "" || idpsEqual(acceptedUser.Id.GetIdp(), remoteUserID.Idp)) {
+		if ocmuser.RemoteUserIDsMatch(acceptedUser.Id, remoteUserID) {
 			return acceptedUser, nil
 		}
 	}
@@ -267,7 +242,7 @@ func (m *manager) DeleteRemoteUser(ctx context.Context, initiator *userpb.UserId
 	}
 
 	for i, user := range acceptedUsers {
-		if (user.Id.GetOpaqueId() == remoteUser.OpaqueId) && (remoteUser.Idp == "" || user.Id.GetIdp() == remoteUser.Idp) {
+		if ocmuser.RemoteUserIDsMatch(user.Id, remoteUser) {
 			acceptedUsers = list.Remove(acceptedUsers, i)
 			m.model.AcceptedUsers[initiator.GetOpaqueId()] = acceptedUsers
 			_ = m.model.save()

--- a/pkg/ocm/invite/repository/json/json_test.go
+++ b/pkg/ocm/invite/repository/json/json_test.go
@@ -28,6 +28,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/errtypes"
 	"github.com/opencloud-eu/reva/v2/pkg/ocm/invite"
 	"github.com/stretchr/testify/assert"
 )
@@ -147,6 +148,105 @@ func TestGetRemoteUser_NotFound(t *testing.T) {
 	// Try to get a non-existent remote user
 	_, err := mgr.GetRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: "non-existent"})
 	assert.Error(t, err)
+	var notFound errtypes.NotFound
+	assert.ErrorAs(t, err, &notFound)
+}
+
+func TestGetRemoteUser_LegacyAndCanonicalLookup(t *testing.T) {
+	const (
+		uuid = "056fc874-dd7f-11ef-ba84-af6fca4b7289"
+		idp  = "cloud2.opencloud.test:10200"
+	)
+	legacyOpaque := uuid + "@https://" + idp
+	ctx := context.Background()
+	initiator := &userpb.UserId{OpaqueId: "alan"}
+
+	t.Run("legacy stored found by canonical query", func(t *testing.T) {
+		mgr := setupTestManager(t)
+		mgr.model.AcceptedUsers[initiator.OpaqueId] = []*userpb.User{{
+			Id:          &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			DisplayName: "Mary",
+		}}
+		user, err := mgr.GetRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: uuid, Idp: idp})
+		assert.NoError(t, err)
+		assert.Equal(t, legacyOpaque, user.Id.OpaqueId)
+	})
+
+	t.Run("legacy stored found by legacy graph query opaque", func(t *testing.T) {
+		mgr := setupTestManager(t)
+		mgr.model.AcceptedUsers[initiator.OpaqueId] = []*userpb.User{{
+			Id:          &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			DisplayName: "Mary",
+		}}
+		user, err := mgr.GetRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp})
+		assert.NoError(t, err)
+		assert.Equal(t, legacyOpaque, user.Id.OpaqueId)
+	})
+
+	t.Run("canonical stored found by qualified query", func(t *testing.T) {
+		mgr := setupTestManager(t)
+		mgr.model.AcceptedUsers[initiator.OpaqueId] = []*userpb.User{{
+			Id:          &userpb.UserId{OpaqueId: uuid, Idp: idp},
+			DisplayName: "Mary",
+		}}
+		user, err := mgr.GetRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: uuid + "@" + idp, Idp: idp})
+		assert.NoError(t, err)
+		assert.Equal(t, uuid, user.Id.OpaqueId)
+	})
+}
+
+func TestAddRemoteUser_LegacyDedup(t *testing.T) {
+	const (
+		uuid = "056fc874-dd7f-11ef-ba84-af6fca4b7289"
+		idp  = "cloud2.opencloud.test:10200"
+	)
+	legacyOpaque := uuid + "@https://" + idp
+	ctx := context.Background()
+	initiator := &userpb.UserId{OpaqueId: "alan"}
+
+	mgr := setupTestManager(t)
+	mgr.model.AcceptedUsers[initiator.OpaqueId] = []*userpb.User{{
+		Id:          &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+		DisplayName: "Mary",
+	}}
+
+	canonicalUser := &userpb.User{
+		Id: &userpb.UserId{
+			OpaqueId: uuid,
+			Idp:      idp,
+		},
+		DisplayName: "Mary",
+	}
+
+	err := mgr.AddRemoteUser(ctx, initiator, canonicalUser)
+	assert.ErrorIs(t, err, invite.ErrUserAlreadyAccepted)
+	assert.Len(t, mgr.model.AcceptedUsers[initiator.OpaqueId], 1)
+	assert.Equal(t, legacyOpaque, mgr.model.AcceptedUsers[initiator.OpaqueId][0].Id.OpaqueId)
+}
+
+func TestDeleteRemoteUser_LegacyFallback(t *testing.T) {
+	const (
+		uuid = "056fc874-dd7f-11ef-ba84-af6fca4b7289"
+		idp  = "cloud2.opencloud.test:10200"
+	)
+	legacyOpaque := uuid + "@https://" + idp
+	ctx := context.Background()
+	initiator := &userpb.UserId{OpaqueId: "alan"}
+
+	mgr := setupTestManager(t)
+	mgr.model.AcceptedUsers[initiator.OpaqueId] = []*userpb.User{{
+		Id:          &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+		DisplayName: "Mary",
+	}}
+
+	err := mgr.DeleteRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: uuid, Idp: idp})
+	assert.NoError(t, err)
+	assert.Empty(t, mgr.model.AcceptedUsers[initiator.OpaqueId])
+
+	_, err = mgr.GetRemoteUser(ctx, initiator, &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp})
+	assert.Error(t, err)
+	var notFound errtypes.NotFound
+	assert.ErrorAs(t, err, &notFound)
 }
 
 func TestDeleteRemoteUser(t *testing.T) {

--- a/pkg/ocm/user/user.go
+++ b/pkg/ocm/user/user.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -49,10 +50,133 @@ func DecodeRemoteUserFederatedID(id *userpb.UserId) *userpb.UserId {
 	return remoteId
 }
 
-// FormatOCMUser formats a user id in the form of <opaque-id>@<idp> used by the OCM API in shareWith, owner and creator fields
-func FormatOCMUser(u *userpb.UserId) string {
-	if u.Idp == "" {
-		return u.OpaqueId
+// ParseOCMAddress parses an OCM address in the form <id>@<provider> according to
+// the OCM specification. The provider must not include a URI scheme.
+func ParseOCMAddress(user string) (*userpb.UserId, error) {
+	last := strings.LastIndex(user, "@")
+	if last == -1 {
+		return nil, errors.New("not in the form <id>@<provider>")
 	}
-	return fmt.Sprintf("%s@%s", u.OpaqueId, u.Idp)
+
+	id, idp := user[:last], user[last+1:]
+	if id == "" {
+		return nil, errors.New("id cannot be empty")
+	}
+	if idp == "" {
+		return nil, errors.New("provider cannot be empty")
+	}
+	idp = TrimOCMScheme(idp)
+
+	return &userpb.UserId{
+		OpaqueId: id,
+		Idp:      idp,
+		Type:     userpb.UserType_USER_TYPE_FEDERATED,
+	}, nil
+}
+
+// TrimOCMScheme removes a leading http(s):// scheme from an OCM host string.
+// OCM Addresses are not URIs and MUST NOT carry a scheme, but some servers
+// (Nextcloud, oCIS, OpenCloud) include one; we strip it defensively.
+func TrimOCMScheme(host string) string {
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	return host
+}
+
+// NormalizeRemoteUserID returns the bare OCM identifier for a remote user.
+//
+// Per the OCM spec the invite userID MUST be the bare identifier of the user
+// at their OCM Server, and the host travels separately in recipientProvider.
+// Some non-conformant servers append the host to userID anyway (oCIS sends
+// "id@host", OpenCloud sends "id@https://host"). If stored verbatim, the
+// qualified string is kept as OpaqueId and later re-appended when building
+// shareWith, producing "id@host@host" (or with a scheme).
+//
+// We strip a trailing "@<provider>" suffix ONLY when it matches the already-known
+// provider domain, repeating to collapse accidental double-qualification.
+func NormalizeRemoteUserID(userID, providerDomain string) string {
+	host := TrimOCMScheme(providerDomain)
+	if host == "" {
+		return userID
+	}
+	for {
+		uid, err := ParseOCMAddress(userID)
+		if err != nil || !strings.EqualFold(TrimOCMScheme(uid.Idp), host) {
+			return userID
+		}
+		userID = uid.OpaqueId
+	}
+}
+
+// CanonicalizeRemoteUserID normalizes a federated remote user id in place.
+func CanonicalizeRemoteUserID(id *userpb.UserId) {
+	if id == nil {
+		return
+	}
+	id.Idp = TrimOCMScheme(id.Idp)
+	id.OpaqueId = NormalizeRemoteUserID(id.OpaqueId, id.Idp)
+}
+
+// IdpsEqual reports whether two OCM provider strings refer to the same host,
+// ignoring URI schemes and case.
+func IdpsEqual(idp1, idp2 string) bool {
+	normalizeIDP := func(s string) (string, error) {
+		u, err := url.Parse(s)
+		if err != nil {
+			return "", errors.New("could not parse url")
+		}
+
+		if u.Scheme == "" {
+			return strings.ToLower(u.Path), nil
+		}
+		return strings.ToLower(u.Hostname()), nil
+	}
+
+	domain1, err := normalizeIDP(idp1)
+	if err != nil {
+		return false
+	}
+	domain2, err := normalizeIDP(idp2)
+	if err != nil {
+		return false
+	}
+
+	return domain1 == domain2
+}
+
+// RemoteUserIDsMatch reports whether two federated user ids refer to the same
+// remote user, including legacy encodings stored before normalization on write.
+func RemoteUserIDsMatch(stored, query *userpb.UserId) bool {
+	if stored == nil || query == nil {
+		return false
+	}
+
+	if stored.GetOpaqueId() == query.GetOpaqueId() {
+		if query.GetIdp() == "" || IdpsEqual(stored.GetIdp(), query.GetIdp()) {
+			return true
+		}
+	}
+
+	if query.GetIdp() != "" && !IdpsEqual(stored.GetIdp(), query.GetIdp()) {
+		return false
+	}
+
+	storedHost := TrimOCMScheme(stored.GetIdp())
+	queryHost := TrimOCMScheme(query.GetIdp())
+	storedBare := NormalizeRemoteUserID(stored.GetOpaqueId(), storedHost)
+	queryBare := NormalizeRemoteUserID(query.GetOpaqueId(), queryHost)
+
+	return storedBare == queryBare
+}
+
+// FormatOCMUser renders a CS3 user id as an OCM Address "<opaque-id>@<host>".
+// It strips any scheme from the host and collapses a redundant, self-referential
+// provider suffix already present in the opaque id.
+func FormatOCMUser(u *userpb.UserId) string {
+	if u.GetIdp() == "" {
+		return u.GetOpaqueId()
+	}
+	host := TrimOCMScheme(u.Idp)
+	opaque := NormalizeRemoteUserID(u.OpaqueId, host)
+	return fmt.Sprintf("%s@%s", opaque, host)
 }

--- a/pkg/ocm/user/user_test.go
+++ b/pkg/ocm/user/user_test.go
@@ -1,0 +1,203 @@
+package user_test
+
+import (
+	"testing"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	"github.com/opencloud-eu/reva/v2/pkg/ocm/user"
+)
+
+func TestTrimOCMScheme(t *testing.T) {
+	cases := map[string]string{
+		"host.docker":         "host.docker",
+		"https://host.docker": "host.docker",
+		"http://host.docker":  "host.docker",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := user.TrimOCMScheme(in); got != want {
+			t.Errorf("TrimOCMScheme(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeRemoteUserID(t *testing.T) {
+	tests := []struct {
+		name     string
+		userID   string
+		provider string
+		want     string
+	}{
+		{
+			name:     "bare id is left untouched (spec-conformant)",
+			userID:   "f7fbf8c8-1234",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "id qualified with matching host is stripped (oCIS)",
+			userID:   "f7fbf8c8-1234@ocis2.docker",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "id qualified with scheme+host is stripped (OpenCloud)",
+			userID:   "60708dda-5678@https://opencloud2.docker",
+			provider: "opencloud2.docker",
+			want:     "60708dda-5678",
+		},
+		{
+			name:     "scheme in provider domain is tolerated",
+			userID:   "60708dda-5678@opencloud2.docker",
+			provider: "https://opencloud2.docker",
+			want:     "60708dda-5678",
+		},
+		{
+			name:     "double-qualified id collapses fully",
+			userID:   "f7fbf8c8-1234@ocis2.docker@ocis2.docker",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "trailing suffix from a different host is preserved",
+			userID:   "user@other.docker",
+			provider: "ocis2.docker",
+			want:     "user@other.docker",
+		},
+		{
+			name:     "empty provider returns userID unchanged",
+			userID:   "user@ocis2.docker",
+			provider: "",
+			want:     "user@ocis2.docker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := user.NormalizeRemoteUserID(tt.userID, tt.provider); got != tt.want {
+				t.Errorf("NormalizeRemoteUserID(%q, %q) = %q, want %q", tt.userID, tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOCMAddress(t *testing.T) {
+	uid, err := user.ParseOCMAddress("id@http://host.docker")
+	if err != nil {
+		t.Fatalf("ParseOCMAddress returned error: %v", err)
+	}
+	if uid.Idp != "host.docker" {
+		t.Errorf("Idp = %q, want %q", uid.Idp, "host.docker")
+	}
+	if uid.OpaqueId != "id" {
+		t.Errorf("OpaqueId = %q, want %q", uid.OpaqueId, "id")
+	}
+}
+
+func TestCanonicalizeRemoteUserID(t *testing.T) {
+	t.Run("nil input does not panic", func(t *testing.T) {
+		user.CanonicalizeRemoteUserID(nil)
+	})
+
+	t.Run("strips scheme from Idp and matching qualified opaque id", func(t *testing.T) {
+		id := &userpb.UserId{
+			OpaqueId: "id@host.docker",
+			Idp:      "https://host.docker",
+		}
+		user.CanonicalizeRemoteUserID(id)
+		if id.Idp != "host.docker" {
+			t.Errorf("Idp = %q, want %q", id.Idp, "host.docker")
+		}
+		if id.OpaqueId != "id" {
+			t.Errorf("OpaqueId = %q, want %q", id.OpaqueId, "id")
+		}
+	})
+}
+
+func TestFormatOCMUser(t *testing.T) {
+	tests := []struct {
+		name string
+		user *userpb.UserId
+		want string
+	}{
+		{
+			name: "bare opaque id and clean host",
+			user: &userpb.UserId{OpaqueId: "f7fbf8c8-1234", Idp: "cernbox2.docker"},
+			want: "f7fbf8c8-1234@cernbox2.docker",
+		},
+		{
+			name: "opaque id already qualified with matching host does not double up",
+			user: &userpb.UserId{OpaqueId: "f7fbf8c8-1234@ocis2.docker", Idp: "ocis2.docker"},
+			want: "f7fbf8c8-1234@ocis2.docker",
+		},
+		{
+			name: "scheme in host is stripped",
+			user: &userpb.UserId{OpaqueId: "60708dda-5678", Idp: "https://opencloud2.docker"},
+			want: "60708dda-5678@opencloud2.docker",
+		},
+		{
+			name: "scheme-qualified opaque id collapses to single host",
+			user: &userpb.UserId{OpaqueId: "60708dda-5678@https://opencloud2.docker", Idp: "opencloud2.docker"},
+			want: "60708dda-5678@opencloud2.docker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := user.FormatOCMUser(tt.user); got != tt.want {
+				t.Errorf("FormatOCMUser(%+v) = %q, want %q", tt.user, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteUserIDsMatch(t *testing.T) {
+	const (
+		uuid = "056fc874-dd7f-11ef-ba84-af6fca4b7289"
+		idp  = "cloud2.opencloud.test:10200"
+	)
+	legacyOpaque := uuid + "@https://" + idp
+
+	tests := []struct {
+		name   string
+		stored *userpb.UserId
+		query  *userpb.UserId
+		want   bool
+	}{
+		{
+			name:   "canonical exact match",
+			stored: &userpb.UserId{OpaqueId: uuid, Idp: idp},
+			query:  &userpb.UserId{OpaqueId: uuid, Idp: idp},
+			want:   true,
+		},
+		{
+			name:   "legacy stored found by canonical query",
+			stored: &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			query:  &userpb.UserId{OpaqueId: uuid, Idp: idp},
+			want:   true,
+		},
+		{
+			name:   "legacy stored found by legacy graph query opaque",
+			stored: &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			query:  &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			want:   true,
+		},
+		{
+			name:   "different users",
+			stored: &userpb.UserId{OpaqueId: legacyOpaque, Idp: idp},
+			query:  &userpb.UserId{OpaqueId: "other-uuid", Idp: idp},
+			want:   false,
+		},
+		{
+			name:   "different idp",
+			stored: &userpb.UserId{OpaqueId: uuid, Idp: idp},
+			query:  &userpb.UserId{OpaqueId: uuid, Idp: "other.example.com"},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := user.RemoteUserIDsMatch(tt.stored, tt.query); got != tt.want {
+				t.Errorf("RemoteUserIDsMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/grpc/ocm_invitation_test.go
+++ b/tests/integration/grpc/ocm_invitation_test.go
@@ -118,7 +118,7 @@ var _ = Describe("ocm invitation workflow", func() {
 			Id: &userpb.UserId{
 				Type:     userpb.UserType_USER_TYPE_FEDERATED,
 				Idp:      "cernbox.cern.ch",
-				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51@https://cernbox.cern.ch",
+				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51",
 			},
 			Username:    "einstein",
 			Mail:        "einstein@cern.ch",
@@ -138,7 +138,7 @@ var _ = Describe("ocm invitation workflow", func() {
 			Id: &userpb.UserId{
 				Type:     userpb.UserType_USER_TYPE_FEDERATED,
 				Idp:      "cesnet.cz",
-				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@https://cesnet.cz",
+				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 			},
 			Username:    "marie",
 			Mail:        "marie@cesnet.cz",

--- a/tests/integration/grpc/ocm_share_test.go
+++ b/tests/integration/grpc/ocm_share_test.go
@@ -125,8 +125,8 @@ var _ = Describe("ocm share", func() {
 		}
 		federatedEinsteinID = &userpb.UserId{
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
-			Idp:      "cernbox.cern.ch",                                              // the provider is stored in the idp property
-			OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51@https://cernbox.cern.ch", // the original idp becomes part of the opaqueid
+			Idp:      "cernbox.cern.ch",                      // scheme-free OCM provider
+			OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51", // bare OCM user id, not id@host
 		}
 		marie = &userpb.User{
 			Id: &userpb.UserId{
@@ -140,8 +140,8 @@ var _ = Describe("ocm share", func() {
 		}
 		federatedMarieID = &userpb.UserId{
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
-			Idp:      "cesnet.cz",                                              // the provider is stored in the idp property
-			OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c@https://cesnet.cz", // the original idp becomes part of the opaqueid
+			Idp:      "cesnet.cz",                            // scheme-free OCM provider
+			OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c", // bare OCM user id, not id@host
 		}
 	)
 
@@ -209,12 +209,11 @@ var _ = Describe("ocm share", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(invRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
-			// Make sure the user is a federated user
 			// The user type must be a federated user
 			Expect(invRes.UserId.Type).To(Equal(userpb.UserType_USER_TYPE_FEDERATED))
-			// Federated users use the OCM provider id which MUST NOT contain the protocol
+			// Idp is the OCM provider domain without a URI scheme.
 			Expect(invRes.UserId.Idp).To(Equal("cernbox.cern.ch"))
-			// The OpaqueId follows the pattern{user opaque id}@{user ipd}@{provider id} to prevent collisions with other users on the graph API
+			// OpaqueId is the bare remote identifier; Graph builds "{opaque}@{idp}".
 			Expect(invRes.UserId.OpaqueId).To(Equal(federatedEinsteinID.OpaqueId))
 		})
 


### PR DESCRIPTION
Ref https://github.com/opencloud-eu/opencloud/issues/3262#issuecomment-5325066489

- Store bare opaque_id and scheme-free idp per OCM spec on write.
- Send bare userID on ForwardInvite, and match legacy encodings on read so existing ocminvites.json keeps working. 
- Map GetAcceptedUser repo NotFound to CODE_NOT_FOUND instead of CODE_INTERNAL.


Per OCM spec `opaque_id` and `ipd` are separate fields and `idp` has no URL scheme part

With the current implementation we get the following after the invitation is accepted:
```
{
  "File": "/var/lib/opencloud/storage/ocm/ocminvites.json",
  "invites": {},
  "accepted_users": {
    "056fc874-dd7f-11ef-ba84-af6fca4b7289": [
      {
        "id": {
          "idp": "cloud1.opencloud.test:9200",
          "opaque_id": "b1f74ec4-dd7e-11ef-a543-03775734d0f7@https://cloud1.opencloud.test:9200",
          "type": 6
        },
        "mail": "alan@example.org",
        "display_name": "Alan Turing"
      }
    ]
  }
}
```

Afterwards to share anything as this user it should be represented in the awkward notation 
`b1f74ec4-dd7e-11ef-a543-03775734d0f7@https://cloud1.opencloud.test:9200@cloud1.opencloud.test:9200"`

This PR strips `@https://cloud1.opencloud.test:9200` from the `opaque_id` before storing it into the `ocminvites.json`
so the backward compatible behavior is preserved.

## Backward compatibility was tested manually:
1. alan@opencloud1 invites mary@opencloud2 
2. both alan and mary  share share file and folder with each other
3. opencloud1 is updated to to have this change
4. Alan is still able to reach Mary's items. Mary is still able to reach Alan's items. 
5. Newly created shares  between normalized/non-normalized instances work too 