### PR TITLE
make datagateway optional in events

### DIFF
--- a/pkg/storage/pkg/decomposedfs/upload/upload.go
+++ b/pkg/storage/pkg/decomposedfs/upload/upload.go
@@ -503,12 +503,18 @@ func (session *DecomposedFsSession) Cleanup(revertNodeMetadata, cleanBin, cleanI
 
 // URL returns a url to download an upload
 func (session *DecomposedFsSession) URL(_ context.Context) (string, error) {
+
+	u := joinurl(session.store.tknopts.DownloadEndpoint, "tus/", session.ID())
+	if session.store.tknopts.DataGatewayEndpoint == "" {
+		return u, nil
+	}
+
+	// we need to create a token
 	type transferClaims struct {
 		jwt.RegisteredClaims
 		Target string `json:"target"`
 	}
 
-	u := joinurl(session.store.tknopts.DownloadEndpoint, "tus/", session.ID())
 	ttl := time.Duration(session.store.tknopts.TransferExpires) * time.Second
 	claims := transferClaims{
 		RegisteredClaims: jwt.RegisteredClaims{

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -371,12 +371,17 @@ func (session *OcisSession) Cleanup(revertNodeMetadata, cleanBin, cleanInfo bool
 
 // URL returns a url to download an upload
 func (session *OcisSession) URL(_ context.Context) (string, error) {
+	u := joinurl(session.store.tknopts.DownloadEndpoint, "tus/", session.ID())
+	if session.store.tknopts.DataGatewayEndpoint == "" {
+		return u, nil
+	}
+
+	// we need to create a token
 	type transferClaims struct {
 		jwt.RegisteredClaims
 		Target string `json:"target"`
 	}
 
-	u := joinurl(session.store.tknopts.DownloadEndpoint, "tus/", session.ID())
 	ttl := time.Duration(session.store.tknopts.TransferExpires) * time.Second
 	claims := transferClaims{
 		RegisteredClaims: jwt.RegisteredClaims{


### PR DESCRIPTION
Part of https://github.com/opencloud-eu/opencloud/pull/3289

Our current code actually only works with a datagateway. When a BytesReceived event is published the storage driver always wraps the DataProvider URL in a JWT and prepends the datagateway URL. This PR makes the datagateway optional. 

Once this is merged I will rebase the opencloud PR and remove any config options for this. 

We could delete the datagateway and token related code from the storage drivers later if we can assume that only internal services will consume events. Or replace the config option with an events "middleware"? nah ... just get rid of it.

🤔 *wait ... In kubernetes the antivirus service lives in another pod. references to localhost won't work. Why do we even go through another HTTP download to read the bytes? Well because not all upload implementations might store the upload on disk. Ok, so reading via HTTP makes sense.*

*I still don't like that the storagedriver has to know its url, only so it can create a download url when emitting events. The dataprovider currently handles the datagateway wrapping if it is configured to not expose the data provider. But it currently cannot do that.* 

If we really need to wrap urls in events in the future we should use a custom events.Stream implementation to wrap the underlying stream. The storageproider can then inject this wrapper into the storage drivers:
```go
	Stream interface {
		Publish(string, interface{}, ...events.PublishOption) error
		Consume(string, ...events.ConsumeOption) (<-chan events.Event, error)
	}
```
We could even always wrap the stream and let the storageprovider write the URL. The storage driver only sets the upload ID. Then it would not need to know the host and port of the storage provider. 🤩 