### PR TITLE
feat: add mimetypes for avif images

### DIFF
--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -76,6 +76,7 @@ var mimeTypes = map[string]string{
 	"atx":                      "application/vnd.antix.game-component",
 	"au":                       "audio/basic",
 	"avi":                      "video/x-msvideo",
+	"avif":                     "image/avif",
 	"aw":                       "application/applixware",
 	"azf":                      "application/vnd.airzip.filesecure.azf",
 	"azs":                      "application/vnd.airzip.filesecure.azs",


### PR DESCRIPTION
Add missing mimetypes for images with AVIF extension. Preparation to eventually add AVIF thumbnail support to OpenCloud (which I am working on).

Very similar PR to https://github.com/opencloud-eu/reva/pull/773