### PR TITLE
enhancement(shares/jsoncs3): Shortcut migration on fresh system

### DIFF
--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -289,6 +289,34 @@ func (m *Manager) initialize(ctx context.Context) error {
 		return err
 	}
 
+	err = m.storage.MakeDirIfNotExist(ctx, "migrations")
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	// A missing "storages" directory means nobody has ever used this metadata
+	// tree, so there is nothing to migrate. Record all migrations as applied
+	// before creating "storages": any instance that observes "storages" is then
+	// guaranteed to also observe the state file, which keeps instances starting
+	// in parallel from disagreeing about whether migrations have to run.
+	_, err = m.storage.Stat(ctx, "storages")
+	switch err.(type) {
+	case nil:
+		// existing deployment, leave the migration state untouched
+	case errtypes.IsNotFound:
+		if err = migration.MarkAllApplied(ctx, m.storage); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	default:
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
 	err = m.storage.MakeDirIfNotExist(ctx, "storages")
 	if err != nil {
 		span.RecordError(err)
@@ -302,12 +330,6 @@ func (m *Manager) initialize(ctx context.Context) error {
 		return err
 	}
 	err = m.storage.MakeDirIfNotExist(ctx, "groups")
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return err
-	}
-	err = m.storage.MakeDirIfNotExist(ctx, "migrations")
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/pkg/share/manager/jsoncs3/migrations/migration.go
+++ b/pkg/share/manager/jsoncs3/migrations/migration.go
@@ -139,6 +139,40 @@ func New(logger zerolog.Logger,
 	}
 }
 
+// LatestVersion returns the version of the most recent registered migration.
+func LatestVersion() int {
+	version := 0
+	for _, mig := range migrations {
+		if mig.Version() > version {
+			version = mig.Version()
+		}
+	}
+	return version
+}
+
+// MarkAllApplied records every registered migration as applied without running
+// any of them. It is meant for fresh deployments, where there is no data to
+// migrate and running the migrations would needlessly block write operations
+// while depending on services that may not be up yet.
+//
+// The state file is created atomically and an existing state file is never
+// overwritten, so instances starting in parallel converge on the same state.
+func MarkAllApplied(ctx context.Context, storage metadata.Storage) error {
+	data, err := json.Marshal(persistedState{Version: LatestVersion()})
+	if err != nil {
+		return err
+	}
+	_, err = storage.Upload(ctx, metadata.UploadRequest{
+		Path:        stateFile,
+		Content:     data,
+		IfNoneMatch: []string{"*"},
+	})
+	if err != nil && !isConflict(err) {
+		return err
+	}
+	return nil
+}
+
 // acquireLock tries to atomically create the lock file, blocking until the lock
 // is obtained. It returns the etag of the lock file on success. It retries
 // indefinitely until ctx is cancelled. A lock whose timestamp is older than

--- a/pkg/share/manager/jsoncs3/migrations/migration_state_test.go
+++ b/pkg/share/manager/jsoncs3/migrations/migration_state_test.go
@@ -152,6 +152,54 @@ var _ = Describe("RunMigrations / loadState / saveState", func() {
 
 	// ── RunMigrations ──────────────────────────────────────────────────────────
 
+	Describe("MarkAllApplied", func() {
+		BeforeEach(func() {
+			migrations = []migration{
+				&fakeMigration{name: "first", version: 1},
+				&fakeMigration{name: "second", version: 2},
+			}
+		})
+
+		It("records the highest registered version so no migration runs", func() {
+			Expect(MarkAllApplied(context.Background(), stor)).To(Succeed())
+
+			Expect(m.loadState(context.Background())).To(Succeed())
+			Expect(m.state.version).To(Equal(2))
+
+			m.RunMigrations()
+			for _, mig := range migrations {
+				Expect(mig.(*fakeMigration).called).To(BeFalse())
+			}
+		})
+
+		It("never overwrites an already persisted state", func() {
+			m.state.version = 1
+			Expect(m.saveState(context.Background())).To(Succeed())
+
+			Expect(MarkAllApplied(context.Background(), stor)).To(Succeed())
+
+			m.state.version = 0
+			Expect(m.loadState(context.Background())).To(Succeed())
+			Expect(m.state.version).To(Equal(1))
+		})
+
+		It("is safe to call concurrently from several instances", func() {
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Add(1)
+				go func() {
+					defer GinkgoRecover()
+					defer wg.Done()
+					Expect(MarkAllApplied(context.Background(), stor)).To(Succeed())
+				}()
+			}
+			wg.Wait()
+
+			Expect(m.loadState(context.Background())).To(Succeed())
+			Expect(m.state.version).To(Equal(2))
+		})
+	})
+
 	Describe("RunMigrations", func() {
 		Context("when there are no registered migrations", func() {
 			It("completes without error and leaves version at 0", func() {


### PR DESCRIPTION
Avoid waiting in migrations on fresh systems. Some migrations are blocking the correct startup of the service until dependent services are up and running, we don't need this on a fresh system.

Fixes: https://github.com/opencloud-eu/opencloud/pull/3392