### PR TITLE
fix(decomposedfs): write arbitrary metadata in one go

### DIFF
--- a/pkg/storage/pkg/decomposedfs/metadata.go
+++ b/pkg/storage/pkg/decomposedfs/metadata.go
@@ -85,10 +85,15 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 			}
 		}
 	}
-	for k, v := range md.Metadata {
-		attrName := prefixes.MetadataPrefix + k
-		if err = n.SetXattrString(ctx, attrName, v); err != nil {
-			errs = append(errs, errors.Wrap(err, "Decomposedfs: could not set metadata attribute "+attrName+" to "+k))
+	// one write for the whole set: a per key write publishes every intermediate
+	// state to the unlocked, cache first readers
+	if len(md.Metadata) > 0 {
+		attribs := make(map[string][]byte, len(md.Metadata))
+		for k, v := range md.Metadata {
+			attribs[prefixes.MetadataPrefix+k] = []byte(v)
+		}
+		if err = n.SetXattrsWithContext(ctx, attribs); err != nil {
+			errs = append(errs, errors.Wrap(err, "Decomposedfs: could not set metadata attributes"))
 		}
 	}
 


### PR DESCRIPTION
`SetArbitraryMetadata` looped over the metadata map and wrote one attribute per call. Each of those is a separate read-merge-write on the node's metadata plus its own `PushToCache`, so a set of N keys becomes N observable states. Readers (`loadAttributes`) take no lock and hit the cache first, so a concurrent stat can see a subset that was never written as a set.

Every single write succeeds, nothing is lost. What the loop costs is atomicity: the iteration order is Go map order, so the subset a reader can observe differs on every run.

Now built as one map and written with `SetXattrsWithContext`, a single `SetMultiple`. Also drops N-1 read-merge-write cycles per call.

No test: asserting this needs either a racing reader, which only hunts for the window, or a metadata backend injected into `testhelpers.NewTestEnv`, which is a bigger change than the fix.
