### PR TITLE
fix(jsoncs3): wait for init before asserting the migration timeout

### DIFF
--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -340,6 +340,12 @@ func (m *Manager) initialize(ctx context.Context) error {
 	return nil
 }
 
+// Ready returns a channel that is closed once the background initialization
+// goroutine has successfully connected to the metadata storage.
+func (m *Manager) Ready() <-chan struct{} {
+	return m.ready
+}
+
 // waitForInit blocks until the background initialization goroutine has
 // successfully completed, or until ctx is cancelled.
 func (m *Manager) waitForInit(ctx context.Context) error {

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -1163,7 +1163,13 @@ var _ = Describe("CleanupStaleShares", func() {
 		m, err := jsoncs3.New(storage, nil, nil, 0, nil, 0)
 		Expect(err).ToNot(HaveOccurred())
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		// New initializes the metadata storage in the background. Wait for that
+		// to finish, otherwise the context below can expire while the manager is
+		// still initializing and CleanupStaleShares reports that instead of the
+		// migration timeout.
+		Eventually(m.Ready(), 10*time.Second).Should(BeClosed())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
 		err = m.CleanupStaleShares(ctx)


### PR DESCRIPTION
`New()` initializes the metadata storage in a background goroutine. The `CleanupStaleShares` spec started its 1ms context right after `New()`, so `CleanupStaleShares` raced:

```go
if err := m.waitForInit(ctx); err != nil { return err }   // "share manager not yet initialized"
if err := m.waitForMigrations(ctx); err != nil { ... }    // "share manager migrations did not complete"
```

On a loaded machine the context expires before `Init` + `MakeDirIfNotExist` + `MarkAllApplied` are done, so the first wait returns and the spec fails:

```
[FAILED] Expected
    : share manager not yet initialized: context deadline exceeded
to contain substring
    : share manager migrations did not complete
```

Reproduced with 8 busy loops on 4 cores: 21 of 40 runs failed.

This exposes `Ready()` and waits for it before starting the timeout context. The timeout then only applies to the migration wait, which is what the spec asserts. Same load, 0 of 40 runs failed; package is green under `-race`.

Seen on https://ci.opencloud.rocks/repos/4/pipeline/586/19, unrelated to the PR it failed on (#790).